### PR TITLE
Point at TravisCI.com for badge and service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ after_script:
 
 notifications:
   email: false
+
+env:
+  global:
+    - CC_TEST_REPORTER_ID=882e943342bed5285a6078be9a41b7738ae7ebd17458c08414581cbece99b8e6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/sul-dlss/cocina-models.svg?branch=master)](https://travis-ci.org/sul-dlss/cocina-models)
+[![Build Status](https://travis-ci.com/sul-dlss/cocina-models.svg?branch=master)](https://travis-ci.com/sul-dlss/cocina-models)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/472273351516ac01dce1/test_coverage)](https://codeclimate.com/github/sul-dlss/cocina-models/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/472273351516ac01dce1/maintainability)](https://codeclimate.com/github/sul-dlss/cocina-models/maintainability)
 [![Gem Version](https://badge.fury.io/rb/cocina-models.svg)](https://badge.fury.io/rb/cocina-models)


### PR DESCRIPTION
## Why was this change made?

To have a single build instead of multiple builds. I also removed the travis-ci.org webhook and installed the codeclimate coverage webhook.

## Was the documentation (README, wiki) updated?

yes, the badge