### PR TITLE
Allow interrogation of model types

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -6,6 +6,8 @@ module Cocina
   module Models
     # An admin policy object.
     class AdminPolicy < Dry::Struct
+      include Checkable
+
       TYPES = [
         Vocab.admin_policy
       ].freeze

--- a/lib/cocina/models/checkable.rb
+++ b/lib/cocina/models/checkable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # A common interface for interrogating a model instance's type
+    module Checkable
+      def admin_policy?
+        (self.class::TYPES & AdminPolicy::TYPES).any?
+      end
+
+      def collection?
+        (self.class::TYPES & Collection::TYPES).any?
+      end
+
+      def dro?
+        (self.class::TYPES & DRO::TYPES).any?
+      end
+
+      def file?
+        (self.class::TYPES & File::TYPES).any?
+      end
+
+      def file_set?
+        (self.class::TYPES & FileSet::TYPES).any?
+      end
+    end
+  end
+end

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -6,6 +6,8 @@ module Cocina
   module Models
     # A digital repository collection.  See http://sul-dlss.github.io/cocina-models/maps/Collection.json
     class Collection < Dry::Struct
+      include Checkable
+
       TYPES = [
         Vocab.collection,
         Vocab.curated_collection,

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -6,6 +6,8 @@ module Cocina
   module Models
     # A digital repository object.  See http://sul-dlss.github.io/cocina-models/maps/DRO.json
     class DRO < Dry::Struct
+      include Checkable
+
       TYPES = [
         Vocab.object,
         Vocab.three_dimensional,

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -6,6 +6,8 @@ module Cocina
   module Models
     # Metadata for a file.  See http://sul-dlss.github.io/cocina-models/maps/File.json
     class File < Dry::Struct
+      include Checkable
+
       TYPES = [
         Vocab.file
       ].freeze

--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -6,6 +6,8 @@ module Cocina
   module Models
     # Metadata for a File Set.  See http://sul-dlss.github.io/cocina-models/maps/Fileset.json
     class FileSet < Dry::Struct
+      include Checkable
+
       TYPES = [
         Vocab.fileset
       ].freeze

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -3,21 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::AdminPolicy do
+  subject(:admin_policy) { described_class.new(properties) }
+
+  let(:properties) do
+    {
+      externalIdentifier: 'druid:ab123cd4567',
+      type: type,
+      label: 'My admin_policy',
+      version: 3
+    }
+  end
   let(:type) { 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld' }
 
+  describe 'model check methods' do
+    it { is_expected.to be_admin_policy }
+    it { is_expected.not_to be_collection }
+    it { is_expected.not_to be_dro }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+  end
+
   describe 'initialization' do
-    subject(:admin_policy) { described_class.new(properties) }
-
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: type,
-          label: 'My admin_policy',
-          version: 3
-        }
-      end
-
+    context 'with a minimal set, defined above' do
       it 'has properties' do
         expect(admin_policy.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(admin_policy.type).to eq type

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -3,21 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Collection do
+  subject(:collection) { described_class.new(properties) }
+
   let(:collection_type) { 'http://cocina.sul.stanford.edu/models/collection.jsonld' }
+  let(:properties) do
+    {
+      externalIdentifier: 'druid:ab123cd4567',
+      type: collection_type,
+      label: 'My collection',
+      version: 3
+    }
+  end
+
+  describe 'model check methods' do
+    it { is_expected.not_to be_admin_policy }
+    it { is_expected.to be_collection }
+    it { is_expected.not_to be_dro }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+  end
 
   describe 'initialization' do
-    subject(:collection) { described_class.new(properties) }
-
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: collection_type,
-          label: 'My collection',
-          version: 3
-        }
-      end
-
+    context 'with a minimal set, defined above' do
       it 'has properties' do
         expect(collection.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(collection.type).to eq collection_type

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -3,21 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::DRO do
+  subject(:item) { described_class.new(properties) }
+
   let(:item_type) { 'http://cocina.sul.stanford.edu/models/object.jsonld' }
+  let(:properties) do
+    {
+      externalIdentifier: 'druid:ab123cd4567',
+      type: item_type,
+      label: 'My object',
+      version: 3
+    }
+  end
+
+  describe 'model check methods' do
+    it { is_expected.not_to be_admin_policy }
+    it { is_expected.not_to be_collection }
+    it { is_expected.to be_dro }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+  end
 
   describe 'initialization' do
-    subject(:item) { described_class.new(properties) }
-
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: item_type,
-          label: 'My object',
-          version: 3
-        }
-      end
-
+    context 'with a minimal set, as defined above' do
       it 'has properties' do
         expect(item.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(item.type).to eq item_type

--- a/spec/cocina/models/file_set_spec.rb
+++ b/spec/cocina/models/file_set_spec.rb
@@ -3,21 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::FileSet do
+  subject(:item) { described_class.new(properties) }
+
   let(:file_set_type) { 'http://cocina.sul.stanford.edu/models/fileset.jsonld' }
+  let(:properties) do
+    {
+      externalIdentifier: 'druid:ab123cd4567',
+      type: file_set_type,
+      label: 'My file',
+      version: 3
+    }
+  end
+
+  describe 'model check methods' do
+    it { is_expected.not_to be_admin_policy }
+    it { is_expected.not_to be_collection }
+    it { is_expected.not_to be_dro }
+    it { is_expected.not_to be_file }
+    it { is_expected.to be_file_set }
+  end
 
   describe 'initialization' do
-    subject(:item) { described_class.new(properties) }
-
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: file_set_type,
-          label: 'My file',
-          version: 3
-        }
-      end
-
+    context 'with a minimal set, as defined above' do
       it 'has properties' do
         expect(item.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(item.type).to eq file_set_type

--- a/spec/cocina/models/file_spec.rb
+++ b/spec/cocina/models/file_spec.rb
@@ -3,21 +3,28 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::File do
+  subject(:item) { described_class.new(properties) }
+
   let(:file_type) { 'http://cocina.sul.stanford.edu/models/file.jsonld' }
+  let(:properties) do
+    {
+      externalIdentifier: 'druid:ab123cd4567',
+      type: file_type,
+      label: 'My file',
+      version: 3
+    }
+  end
+
+  describe 'model check methods' do
+    it { is_expected.not_to be_admin_policy }
+    it { is_expected.not_to be_collection }
+    it { is_expected.not_to be_dro }
+    it { is_expected.to be_file }
+    it { is_expected.not_to be_file_set }
+  end
 
   describe 'initialization' do
-    subject(:item) { described_class.new(properties) }
-
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: file_type,
-          label: 'My file',
-          version: 3
-        }
-      end
-
+    context 'with a minimal set, as defined above' do
       it 'has properties' do
         expect(item.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(item.type).to eq file_type


### PR DESCRIPTION
## Why was this change made?

Instead of requiring upstream code to have to care about the internal structure of the cocina-models gem, introduce a new common interface that all cocina models implement that allows them to be asked about what they are.

This allows code like this:

```ruby
obj = object_client.find
return unless obj.is_a?(Cocina::Models::DRO)
```

to change to:

```ruby
obj = object_client.find
return unless obj.dro? # or .collection? .admin_policy? .file? .file_set? etc.
```

## Was the documentation (README, wiki) updated?

no.