### PR TITLE
Add administrative properties to AdminPolicy

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -22,8 +22,45 @@ module Cocina
 
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
-        def self.from_dynamic(_dyn)
-          params = {}
+        # This was copied from the ActiveFedora defaults: Dor::AdminPolicyObject.new.defaultObjectRights.content
+        DEFAULT_OBJECT_RIGHTS = <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+
+          <rightsMetadata>
+             <access type="discover">
+                <machine>
+                   <world/>
+                </machine>
+             </access>
+             <access type="read">
+                <machine>
+                   <world/>
+                </machine>
+             </access>
+             <use>
+                <human type="useAndReproduction"/>
+                <human type="creativeCommons"/>
+                <machine type="creativeCommons" uri=""/>
+                <human type="openDataCommons"/>
+                <machine type="openDataCommons" uri=""/>
+             </use>
+             <copyright>
+                <human/>
+             </copyright>
+          </rightsMetadata>
+        XML
+
+        # An XML blob that is to be used temporarily until we model rights
+        attribute :default_object_rights, Types::Strict::String.optional.default(DEFAULT_OBJECT_RIGHTS)
+
+        # which workflow to start when registering (used by Web Archive apos to start wasCrawlPreassemblyWF)
+        attribute :registration_workflow, Types::String.optional.default(nil)
+
+        def self.from_dynamic(dyn)
+          params = {
+            default_object_rights: dyn['default_object_rights'],
+            registration_workflow: dyn['registration_workflow']
+          }
           Administrative.new(params)
         end
       end
@@ -52,8 +89,7 @@ module Cocina
         }
 
         # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
-        # params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
-
+        params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
         AdminPolicy.new(params)
       end
 

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
           access: {
           },
           administrative: {
+            default_object_rights: '<rightsMetadata></rightsMetadata>',
+            registration_workflow: 'wasCrawlPreassemblyWF'
           }
         }
       end
@@ -67,6 +69,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
         expect(admin_policy.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(admin_policy.type).to eq type
         expect(admin_policy.label).to eq 'My admin_policy'
+        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
+        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
       end
     end
   end
@@ -82,7 +86,10 @@ RSpec.describe Cocina::Models::AdminPolicy do
           'label' => 'Examination of the memorial of the owners and underwriters ...',
           'version' => 1,
           'access' => {},
-          'administrative' => {},
+          'administrative' => {
+            'default_object_rights' => '<rightsMetadata></rightsMetadata>',
+            'registration_workflow' => 'wasCrawlPreassemblyWF'
+          },
           'identification' => {},
           'structural' => {}
         }
@@ -90,6 +97,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
 
       it 'has properties' do
         expect(admin_policy.externalIdentifier).to eq 'druid:kv840rx2720'
+        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
+        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
       end
     end
   end
@@ -131,6 +140,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
             "access": {
             },
             "administrative": {
+              "default_object_rights":"<rightsMetadata></rightsMetadata>",
+              "registration_workflow":"wasCrawlPreassemblyWF"
             }
           }
         JSON
@@ -140,6 +151,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
         expect(admin_policy.attributes).to include(externalIdentifier: 'druid:12343234',
                                                    label: 'my admin_policy',
                                                    type: type)
+
+        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To support default_object_rights and registration workflow via cocina, so we can retire some Fedora calls from common-accessioning.

## Was the documentation (README, wiki) updated?
n/a