### PR TITLE
Add a property for a DROs AdminPolicy

### DIFF
--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -58,10 +58,14 @@ module Cocina
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
         attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
+        # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
+        # but I think it's actually required for every DRO
+        attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)
 
         def self.from_dynamic(dyn)
           params = {}
           params[:releaseTags] = dyn['releaseTags'].map { |rt| ReleaseTag.from_dynamic(rt) } if dyn['releaseTags']
+          params[:hasAdminPolicy] = dyn['hasAdminPolicy']
           Administrative.new(params)
         end
       end

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Cocina::Models::DRO do
             embargoReleaseDate: '2009-12-14T07:00:00Z'
           },
           administrative: {
+            hasAdminPolicy: 'druid:mx123cd4567',
             releaseTags: [
               {
                 who: 'Justin',
@@ -93,6 +94,7 @@ RSpec.describe Cocina::Models::DRO do
 
         expect(item.access.embargoReleaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
 
+        expect(item.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(item.administrative.releaseTags).to all(be_kind_of(Cocina::Models::DRO::ReleaseTag))
         tag = item.administrative.releaseTags.first
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
@@ -165,6 +167,7 @@ RSpec.describe Cocina::Models::DRO do
               "embargoReleaseDate":"2009-12-14T07:00:00Z"
             },
             "administrative": {
+              "hasAdminPolicy":"druid:mx123cd4567",
               "releaseTags": [
                 {
                   "who":"Justin",
@@ -198,6 +201,8 @@ RSpec.describe Cocina::Models::DRO do
                                           type: item_type)
         access_attributes = dro.access.attributes
         expect(access_attributes).to eq(embargoReleaseDate: DateTime.parse('2009-12-14T07:00:00Z'))
+
+        expect(dro.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
 
         tags = dro.administrative.releaseTags
         expect(tags).to all(be_instance_of Cocina::Models::DRO::ReleaseTag)


### PR DESCRIPTION
## Why was this change made?

Required for removing calls to Fedora from common-accessioning.

## Was the documentation (README, wiki) updated?
n/a