### PR TITLE
Collections should have release tags

### DIFF
--- a/docs/maps/Collection.json
+++ b/docs/maps/Collection.json
@@ -125,6 +125,13 @@
           "description": "Administrative or Internal project this resource is a part of.",
           "type": "string"
         },
+        "releaseTags": {
+          "description": "Tags for release",
+          "type": "array",
+          "items": {
+            "$ref": "ReleaseTag.json"
+          }
+        },
         "sdrPreserve": {
           "description": "If this resource should be sent to Preservation.",
           "type": "boolean"

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -26,8 +26,11 @@ module Cocina
 
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
-        def self.from_dynamic(_dyn)
+        attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
+
+        def self.from_dynamic(dyn)
           params = {}
+          params[:releaseTags] = dyn['releaseTags'].map { |rt| ReleaseTag.from_dynamic(rt) } if dyn['releaseTags']
           Administrative.new(params)
         end
       end
@@ -56,7 +59,7 @@ module Cocina
         }
 
         # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
-        # params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
+        params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
 
         Collection.new(params)
       end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -26,24 +26,6 @@ module Cocina
         Vocab.webarchive_seed
       ].freeze
 
-      # Subschema for release tags
-      class ReleaseTag < Dry::Struct
-        attribute :to, Types::Strict::String
-        attribute :what, Types::Strict::String.enum('self', 'collection')
-        # we use 'when' other places, but that's reserved word, so 'date' it is!
-        attribute :date, Types::Params::DateTime
-        attribute :who, Types::Strict::String
-        attribute :release, Types::Params::Bool
-
-        def self.from_dynamic(dyn)
-          ReleaseTag.new(to: dyn['to'],
-                         what: dyn['what'],
-                         date: dyn['date'],
-                         who: dyn['who'],
-                         release: dyn['release'])
-        end
-      end
-
       # Subschema for access concerns
       class Access < Dry::Struct
         attribute :embargoReleaseDate, Types::Params::DateTime.meta(omittable: true)

--- a/lib/cocina/models/release_tag.rb
+++ b/lib/cocina/models/release_tag.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # Subschema for release tags
+    class ReleaseTag < Dry::Struct
+      attribute :to, Types::Strict::String.enum('Searchworks', 'Earthworks')
+      attribute :what, Types::Strict::String.enum('self', 'collection')
+      # we use 'when' other places, but that's reserved word, so 'date' it is!
+      attribute :date, Types::Params::DateTime
+      attribute :who, Types::Strict::String
+      attribute :release, Types::Params::Bool
+
+      def self.from_dynamic(dyn)
+        ReleaseTag.new(to: dyn['to'],
+                       what: dyn['what'],
+                       date: dyn['date'],
+                       who: dyn['who'],
+                       release: dyn['release'])
+      end
+    end
+  end
+end

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe Cocina::Models::Collection do
           access: {
           },
           administrative: {
+            releaseTags: [
+              {
+                who: 'Justin',
+                what: 'collection',
+                date: '2018-11-23T00:44:52Z',
+                to: 'Searchworks',
+                release: 'true'
+              },
+              {
+                who: 'Other Justin',
+                what: 'self',
+                date: '2017-10-20T15:42:15Z',
+                to: 'Earthworks',
+                release: 'false'
+              }
+            ]
           }
         }
       end
@@ -67,6 +83,12 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(collection.type).to eq collection_type
         expect(collection.label).to eq 'My collection'
+
+        expect(collection.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
+        tag = collection.administrative.releaseTags.first
+        expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
+        expect(tag.to).to eq 'Searchworks'
+        expect(tag.release).to be true
       end
     end
   end
@@ -131,6 +153,22 @@ RSpec.describe Cocina::Models::Collection do
             "access": {
             },
             "administrative": {
+              "releaseTags": [
+                {
+                  "who":"Justin",
+                  "what":"collection",
+                  "date":"2018-11-23T00:44:52Z",
+                  "to":"Searchworks",
+                  "release":true
+                },
+                {
+                  "who":"Other Justin",
+                  "what":"self",
+                  "date":"2017-10-20T15:42:15Z",
+                  "to":"Searchworks",
+                  "release":false
+                }
+              ]
             }
           }
         JSON
@@ -140,6 +178,8 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.attributes).to include(externalIdentifier: 'druid:12343234',
                                                  label: 'my collection',
                                                  type: collection_type)
+        tags = collection.administrative.releaseTags
+        expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
       end
     end
   end

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Cocina::Models::DRO do
         expect(item.access.embargoReleaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
 
         expect(item.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(item.administrative.releaseTags).to all(be_kind_of(Cocina::Models::DRO::ReleaseTag))
+        expect(item.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
         tag = item.administrative.releaseTags.first
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
         expect(tag.to).to eq 'Searchworks'
@@ -180,14 +180,14 @@ RSpec.describe Cocina::Models::DRO do
                   "what":"collection",
                   "date":"2018-11-23T00:44:52Z",
                   "to":"Searchworks",
-                  "release":"true"
+                  "release":true
                 },
                 {
                   "who":"Other Justin",
                   "what":"self",
                   "date":"2017-10-20T15:42:15Z",
                   "to":"Searchworks",
-                  "release":"false"
+                  "release":false
                 }
               ]
             },
@@ -219,7 +219,7 @@ RSpec.describe Cocina::Models::DRO do
         expect(dro.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
 
         tags = dro.administrative.releaseTags
-        expect(tags).to all(be_instance_of Cocina::Models::DRO::ReleaseTag)
+        expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
         expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
       end
     end


### PR DESCRIPTION
## Why was this change made?

So that we can communicate about release tags on collections. This will allow us to remove Fedora calls in the release workflow.


## Was the documentation (README, wiki) updated?

n/a
