### PR TITLE
Add apo to collections

### DIFF
--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -27,10 +27,14 @@ module Cocina
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
         attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
+        # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
+        # but I think it's actually required for every DRO
+        attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)
 
         def self.from_dynamic(dyn)
           params = {}
           params[:releaseTags] = dyn['releaseTags'].map { |rt| ReleaseTag.from_dynamic(rt) } if dyn['releaseTags']
+          params[:hasAdminPolicy] = dyn['hasAdminPolicy']
           Administrative.new(params)
         end
       end

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Cocina::Models::Collection do
           access: {
           },
           administrative: {
+            hasAdminPolicy: 'druid:mx123cd4567',
             releaseTags: [
               {
                 who: 'Justin',
@@ -84,6 +85,7 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.type).to eq collection_type
         expect(collection.label).to eq 'My collection'
 
+        expect(collection.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(collection.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
         tag = collection.administrative.releaseTags.first
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
@@ -153,6 +155,7 @@ RSpec.describe Cocina::Models::Collection do
             "access": {
             },
             "administrative": {
+              "hasAdminPolicy":"druid:mx123cd4567",
               "releaseTags": [
                 {
                   "who":"Justin",
@@ -178,6 +181,9 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.attributes).to include(externalIdentifier: 'druid:12343234',
                                                  label: 'my collection',
                                                  type: collection_type)
+
+        expect(collection.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+
         tags = collection.administrative.releaseTags
         expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
       end


### PR DESCRIPTION
## Why was this change made?

So that consumers are able to get the collection's apo.  


## Was the documentation (README, wiki) updated?
n/a