### PR TITLE
Ensure we aren't using any shared defaults

### DIFF
--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -26,7 +26,7 @@ module Cocina
 
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
-        attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
+        attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
         # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
         # but I think it's actually required for every DRO
         attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -39,7 +39,7 @@ module Cocina
 
       # Subschema for administrative concerns
       class Administrative < Dry::Struct
-        attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
+        attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true).default([].freeze)
         # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
         # but I think it's actually required for every DRO
         attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -54,8 +54,8 @@ module Cocina
       attribute :filename, Types::String.optional.default(nil)
       attribute :use, Types::String.enum('original', 'preservation', 'access').optional.default(nil)
       attribute :size, Types::Coercible::Integer.optional.default(nil)
-      attribute :hasMessageDigests, Types::Strict::Array.of(Fixity).default([])
-      attribute :presentation, Presentation.optional.default(Presentation.new)
+      attribute :hasMessageDigests, Types::Strict::Array.of(Fixity).default([].freeze)
+      attribute(:presentation, Presentation.optional.default { Presentation.new })
       attribute :version, Types::Coercible::Integer
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Cocina::Models::Collection do
     it { is_expected.not_to be_file_set }
   end
 
+  describe Cocina::Models::Collection::Administrative do
+    let(:instance) { described_class.new }
+
+    describe '#releaseTags' do
+      subject { instance.releaseTags }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe 'initialization' do
     context 'with a minimal set, defined above' do
       it 'has properties' do

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe Cocina::Models::DRO do
     it { is_expected.not_to be_file_set }
   end
 
+  describe Cocina::Models::DRO::Administrative do
+    let(:instance) { described_class.new }
+
+    describe '#releaseTags' do
+      subject { instance.releaseTags }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe 'initialization' do
     context 'with a minimal set, as defined above' do
       it 'has properties' do


### PR DESCRIPTION
Ensure releaseTags is always an array

## Why was this change made?
This removes a bunch of warnings about using shared defaults.


## Was the documentation (README, wiki) updated?
n/a