### PR TITLE
DRO should display a collection it is a member of

### DIFF
--- a/docs/maps/DRO.json
+++ b/docs/maps/DRO.json
@@ -254,6 +254,10 @@
             "type": "string"
           }]
         },
+        "isMemberOf": {
+          "description": "Collection that this DRO is a member of",
+          "type": "string"
+        },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the DRO.",
           "type": ["string", "null"]

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -58,9 +58,11 @@ module Cocina
       # Structural sub-schema for the DRO
       class Structural < Dry::Struct
         attribute :contains, Types::Strict::Array.of(FileSet).meta(omittable: true)
+        attribute :isMemberOf, Types::Strict::String.meta(omittable: true)
 
         def self.from_dynamic(dyn)
           params = {}
+          params[:isMemberOf] = dyn['isMemberOf'] if dyn['isMemberOf']
           params[:contains] = dyn['contains'].map { |fs| FileSet.from_dynamic(fs) } if dyn['contains']
           Structural.new(params)
         end

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Cocina::Models::DRO do
             ]
           },
           structural: {
+            isMemberOf: 'druid:bc777df7777',
             contains: [
               Cocina::Models::FileSet.new(type: fileset_type,
                                           version: 3,
@@ -108,6 +109,7 @@ RSpec.describe Cocina::Models::DRO do
         expect(tag.release).to be true
 
         expect(item.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(item.structural.isMemberOf).to eq 'druid:bc777df7777'
       end
     end
   end
@@ -203,7 +205,8 @@ RSpec.describe Cocina::Models::DRO do
                   "version":3,
                   "externalIdentifier":"12343234_2", "label":"fileset#2"
                 }
-              ]
+              ],
+              "isMemberOf":"druid:bc777df7777"
             }
           }
         JSON
@@ -221,6 +224,7 @@ RSpec.describe Cocina::Models::DRO do
         tags = dro.administrative.releaseTags
         expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
         expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(dro.structural.isMemberOf).to eq 'druid:bc777df7777'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
we need to know the collection for a DRO


## Was the documentation (README, wiki) updated?
 n/a