### PR TITLE
Allow admin policies to assert parent admin policies

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -56,11 +56,16 @@ module Cocina
         # which workflow to start when registering (used by Web Archive apos to start wasCrawlPreassemblyWF)
         attribute :registration_workflow, Types::String.optional.default(nil)
 
+        # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
+        # but I think it's actually required for every Admin Policy
+        attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)
+
         def self.from_dynamic(dyn)
           params = {
             default_object_rights: dyn['default_object_rights'],
             registration_workflow: dyn['registration_workflow']
           }
+          params[:hasAdminPolicy] = dyn['hasAdminPolicy']
           Administrative.new(params)
         end
       end

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Cocina::Models::AdminPolicy do
       end
     end
 
-    context 'with a all properties' do
+    context 'with all properties' do
       let(:properties) do
         {
           externalIdentifier: 'druid:ab123cd4567',
@@ -60,7 +60,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
           },
           administrative: {
             default_object_rights: '<rightsMetadata></rightsMetadata>',
-            registration_workflow: 'wasCrawlPreassemblyWF'
+            registration_workflow: 'wasCrawlPreassemblyWF',
+            hasAdminPolicy: 'druid:mx123cd4567'
           }
         }
       end
@@ -69,6 +70,7 @@ RSpec.describe Cocina::Models::AdminPolicy do
         expect(admin_policy.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(admin_policy.type).to eq type
         expect(admin_policy.label).to eq 'My admin_policy'
+        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
         expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
       end
@@ -88,7 +90,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
           'access' => {},
           'administrative' => {
             'default_object_rights' => '<rightsMetadata></rightsMetadata>',
-            'registration_workflow' => 'wasCrawlPreassemblyWF'
+            'registration_workflow' => 'wasCrawlPreassemblyWF',
+            'hasAdminPolicy' => 'druid:mx123cd4567'
           },
           'identification' => {},
           'structural' => {}
@@ -97,6 +100,7 @@ RSpec.describe Cocina::Models::AdminPolicy do
 
       it 'has properties' do
         expect(admin_policy.externalIdentifier).to eq 'druid:kv840rx2720'
+        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
         expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
       end
@@ -141,7 +145,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
             },
             "administrative": {
               "default_object_rights":"<rightsMetadata></rightsMetadata>",
-              "registration_workflow":"wasCrawlPreassemblyWF"
+              "registration_workflow":"wasCrawlPreassemblyWF",
+              "hasAdminPolicy":"druid:mx123cd4567"
             }
           }
         JSON
@@ -153,6 +158,7 @@ RSpec.describe Cocina::Models::AdminPolicy do
                                                    type: type)
 
         expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
+        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
       end
     end
   end


### PR DESCRIPTION
Connects to sul-dlss/common-accessioning#556

## Why was this change made?

To resolve https://github.com/sul-dlss/common-accessioning/issues/556 and allow future APOs to assert parent APOs.

## Was the documentation (README, wiki) updated?

no