### PR TITLE
Add the beginnings of a descriptive metadata schema

### DIFF
--- a/docs/maps/Collection.json
+++ b/docs/maps/Collection.json
@@ -4,7 +4,7 @@
   "title": "Digital Repository Collection",
   "description": "A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.",
   "type": "object",
-  "required": ["@context", "@type", "externalIdentifier", "label", "internalIdentifier", "version", "administrative", "access", "identification", "structural"],
+  "required": ["@context", "@type", "externalIdentifier", "label", "internalIdentifier", "version", "administrative", "access", "description", "identification", "structural"],
   "properties": {
     "@context": {
       "description": "URI for the JSON-LD context definitions.",
@@ -32,6 +32,10 @@
     "depositor": {
       "description": "The Agent (User, Group, Application, Department, other) that deposited the Collection into SDR.",
       "$ref": "/Agent"
+    },
+    "description": {
+      "description": "Descriptive metadata for the DRO.",
+      "$ref": "/Description"
     },
     "externalIdentifier": {
       "description": "Identifier for the resource within the SDR architecture but outside of the repository. DRUID or UUID depending on resource type. Constant across resource versions. What clients will use calling the repository. Same as `identification.identifier`",

--- a/docs/maps/DRO.json
+++ b/docs/maps/DRO.json
@@ -4,7 +4,7 @@
   "title": "Digital Repository Object",
   "description": "Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.",
   "type": "object",
-  "required": ["@context", "@type", "externalIdentifier", "label", "internalIdentifier", "version", "administrative", "access", "identification", "structural"],
+  "required": ["@context", "@type", "externalIdentifier", "label", "internalIdentifier", "version", "administrative", "access", "description", "identification", "structural"],
   "properties": {
     "@context": {
       "description": "URI for the JSON-LD context definitions.",
@@ -159,6 +159,10 @@
           }
         }
       }
+    },
+    "description": {
+      "description": "Descriptive metadata for the DRO.",
+      "$ref": "/Description"
     },
     "identification": {
       "description": "Identifying information for the DRO.",

--- a/docs/maps/Description.json
+++ b/docs/maps/Description.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "id": "http://cocina.sul.stanford.edu/schemas/Description",
+  "title": "Description",
+  "description": "The description of a work",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "description": "The title of the item.",
+      "type": "array",
+      "items": {
+        "$ref": "/Title"
+      }
+    }
+  }
+}

--- a/docs/maps/Title.json
+++ b/docs/maps/Title.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "id": "http://cocina.sul.stanford.edu/schemas/Title",
+  "title": "Title",
+  "description": "A title of a work",
+  "type": "object",
+  "required": ["titleFull", "primary"],
+  "properties": {
+    "primary": {
+      "description": "Is this the primary title for the object",
+      "type": "boolean"
+    },
+    "titleFull": {
+      "description": "The full title for the object",
+      "type": "string"
+    }
+  }
+}

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -82,6 +82,9 @@ module Cocina
       attribute :version, Types::Coercible::Integer
       attribute(:access, Access.default { Access.new })
       attribute(:administrative, Administrative.default { Administrative.new })
+      # Allowing description to be omittable for now (until rolled out to consumers),
+      # but I think it's actually required for every DRO
+      attribute :description, Description.optional.default(nil)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 
@@ -95,6 +98,7 @@ module Cocina
 
         # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
         params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
+        params[:description] = Description.from_dynamic(dyn.fetch('description'))
         AdminPolicy.new(params)
       end
 

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -51,6 +51,9 @@ module Cocina
       attribute :version, Types::Coercible::Integer
       attribute(:access, Access.default { Access.new })
       attribute(:administrative, Administrative.default { Administrative.new })
+      # Allowing description to be omittable for now (until rolled out to consumers),
+      # but I think it's actually required for every DRO
+      attribute :description, Description.optional.default(nil)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 
@@ -64,7 +67,7 @@ module Cocina
 
         # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
         params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
-
+        params[:description] = Description.from_dynamic(dyn.fetch('description'))
         Collection.new(params)
       end
 

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Cocina
+  module Models
+    # Descriptive metadata.  See http://sul-dlss.github.io/cocina-models/maps/Description.json
+    class Description < Dry::Struct
+      # Title element.  See http://sul-dlss.github.io/cocina-models/maps/Title.json
+      class Title < Dry::Struct
+        attribute :primary, Types::Strict::Bool
+        attribute :titleFull, Types::Strict::String
+
+        def self.from_dynamic(dyn)
+          Title.new(primary: dyn['primary'],
+                    titleFull: dyn['titleFull'])
+        end
+      end
+
+      attribute :title, Types::Strict::Array.of(Title)
+
+      def self.from_dynamic(dyn)
+        params = {
+          title: dyn.fetch('title').map { |title| Title.from_dynamic(title) }
+        }
+        Description.new(params)
+      end
+    end
+  end
+end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -74,6 +74,9 @@ module Cocina
       attribute :version, Types::Coercible::Integer
       attribute(:access, Access.default { Access.new })
       attribute(:administrative, Administrative.default { Administrative.new })
+      # Allowing description to be omittable for now (until rolled out to consumers),
+      # but I think it's actually required for every DRO
+      attribute :description, Description.optional.default(nil)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 
@@ -88,7 +91,7 @@ module Cocina
         params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
         params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
         params[:structural] = Structural.from_dynamic(dyn['structural']) if dyn['structural']
-
+        params[:description] = Description.from_dynamic(dyn.fetch('description'))
         DRO.new(params)
       end
 

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe Cocina::Models::AdminPolicy do
       externalIdentifier: 'druid:ab123cd4567',
       type: type,
       label: 'My admin_policy',
-      version: 3
+      version: 3,
+      description: {
+        title: []
+      }
     }
   end
   let(:type) { 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld' }
@@ -40,7 +43,10 @@ RSpec.describe Cocina::Models::AdminPolicy do
           externalIdentifier: 'druid:ab123cd4567',
           type: type,
           label: 'My admin_policy',
-          version: '3'
+          version: '3',
+          description: {
+            title: []
+          }
         }
       end
 
@@ -62,6 +68,14 @@ RSpec.describe Cocina::Models::AdminPolicy do
             default_object_rights: '<rightsMetadata></rightsMetadata>',
             registration_workflow: 'wasCrawlPreassemblyWF',
             hasAdminPolicy: 'druid:mx123cd4567'
+          },
+          description: {
+            title: [
+              {
+                primary: true,
+                titleFull: 'My admin_policy'
+              }
+            ]
           }
         }
       end
@@ -93,6 +107,9 @@ RSpec.describe Cocina::Models::AdminPolicy do
             'registration_workflow' => 'wasCrawlPreassemblyWF',
             'hasAdminPolicy' => 'druid:mx123cd4567'
           },
+          'description' => {
+            'title' => []
+          },
           'identification' => {},
           'structural' => {}
         }
@@ -117,7 +134,10 @@ RSpec.describe Cocina::Models::AdminPolicy do
             "externalIdentifier":"druid:12343234",
             "type":"#{type}",
             "label":"my admin_policy",
-            "version": 3
+            "version": 3,
+            "description": {
+              "title": []
+            }
           }
         JSON
       end
@@ -147,6 +167,14 @@ RSpec.describe Cocina::Models::AdminPolicy do
               "default_object_rights":"<rightsMetadata></rightsMetadata>",
               "registration_workflow":"wasCrawlPreassemblyWF",
               "hasAdminPolicy":"druid:mx123cd4567"
+            },
+            "description": {
+              "title": [
+                {
+                  "primary": true,
+                  "titleFull":"my admin_policy"
+                }
+              ]
             }
           }
         JSON
@@ -159,6 +187,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
 
         expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
         expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
+                                                                      titleFull: 'my admin_policy')
       end
     end
   end

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Cocina::Models::Collection do
       externalIdentifier: 'druid:ab123cd4567',
       type: collection_type,
       label: 'My collection',
-      version: 3
+      version: 3,
+      description: {
+        title: []
+      }
     }
   end
 
@@ -50,7 +53,10 @@ RSpec.describe Cocina::Models::Collection do
           externalIdentifier: 'druid:ab123cd4567',
           type: collection_type,
           label: 'My collection',
-          version: '3'
+          version: '3',
+          description: {
+            title: []
+          }
         }
       end
 
@@ -86,6 +92,14 @@ RSpec.describe Cocina::Models::Collection do
                 release: 'false'
               }
             ]
+          },
+          description: {
+            title: [
+              {
+                primary: true,
+                titleFull: 'My collection'
+              }
+            ]
           }
         }
       end
@@ -117,6 +131,9 @@ RSpec.describe Cocina::Models::Collection do
           'version' => 1,
           'access' => {},
           'administrative' => {},
+          'description' => {
+            'title' => []
+          },
           'identification' => {},
           'structural' => {}
         }
@@ -138,7 +155,10 @@ RSpec.describe Cocina::Models::Collection do
             "externalIdentifier":"druid:12343234",
             "type":"#{collection_type}",
             "label":"my collection",
-            "version": 3
+            "version": 3,
+            "description": {
+              "title": []
+            }
           }
         JSON
       end
@@ -182,6 +202,14 @@ RSpec.describe Cocina::Models::Collection do
                   "release":false
                 }
               ]
+            },
+            "description": {
+              "title": [
+                {
+                  "primary": true,
+                  "titleFull":"my collection"
+                }
+              ]
             }
           }
         JSON
@@ -196,6 +224,9 @@ RSpec.describe Cocina::Models::Collection do
 
         tags = collection.administrative.releaseTags
         expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
+
+        expect(collection.description.title.first.attributes).to eq(primary: true,
+                                                                    titleFull: 'my collection')
       end
     end
   end

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Cocina::Models::DRO do
       externalIdentifier: 'druid:ab123cd4567',
       type: item_type,
       label: 'My object',
-      version: 3
+      version: 3,
+      description: {
+        title: []
+      }
     }
   end
 
@@ -52,7 +55,10 @@ RSpec.describe Cocina::Models::DRO do
           externalIdentifier: 'druid:ab123cd4567',
           type: item_type,
           label: 'My object',
-          version: '3'
+          version: '3',
+          description: {
+            title: []
+          }
         }
       end
 
@@ -87,6 +93,14 @@ RSpec.describe Cocina::Models::DRO do
                 date: '2017-10-20T15:42:15Z',
                 to: 'Searchworks',
                 release: 'false'
+              }
+            ]
+          },
+          description: {
+            title: [
+              {
+                primary: true,
+                titleFull: 'My object'
               }
             ]
           },
@@ -136,6 +150,9 @@ RSpec.describe Cocina::Models::DRO do
           'version' => 1,
           'access' => {},
           'administrative' => { 'releaseTags' => [] },
+          'description' => {
+            'title' => []
+          },
           'identification' => {},
           'structural' => {}
         }
@@ -157,7 +174,10 @@ RSpec.describe Cocina::Models::DRO do
             "externalIdentifier":"druid:12343234",
             "type":"#{item_type}",
             "label":"my item",
-            "version": 3
+            "version": 3,
+            "description": {
+              "title": []
+            }
           }
         JSON
       end
@@ -203,6 +223,14 @@ RSpec.describe Cocina::Models::DRO do
                 }
               ]
             },
+            "description": {
+              "title": [
+                {
+                  "primary": true,
+                  "titleFull":"my object"
+                }
+              ]
+            },
             "structural": {
               "contains": [
                 {
@@ -235,6 +263,8 @@ RSpec.describe Cocina::Models::DRO do
         expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
         expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
         expect(dro.structural.isMemberOf).to eq 'druid:bc777df7777'
+        expect(dro.description.title.first.attributes).to eq(primary: true,
+                                                             titleFull: 'my object')
       end
     end
   end
@@ -247,7 +277,10 @@ RSpec.describe Cocina::Models::DRO do
         externalIdentifier: 'druid:ab123cd4567',
         type: item_type,
         label: 'My object',
-        version: 3
+        version: 3,
+        description: {
+          title: []
+        }
       }
     end
 

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
           'externalIdentifier' => 'foo',
           'label' => 'bar',
-          'version' => 5
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
         }
       end
 
@@ -27,7 +30,10 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
           'externalIdentifier' => 'foo',
           'label' => 'bar',
-          'version' => 5
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
         }
       end
 
@@ -40,7 +46,10 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
           'externalIdentifier' => 'foo',
           'label' => 'bar',
-          'version' => 5
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
         }
       end
 


### PR DESCRIPTION
## Why was this change made?

So we can store descriptive metadata

## Was the documentation (README, wiki) updated?
n/a