### PR TITLE
Items should have a source_id

### DIFF
--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -52,7 +52,15 @@ module Cocina
         end
       end
 
+      # Identification sub-schema for the DRO
       class Identification < Dry::Struct
+        attribute :sourceId, Types::Strict::String.meta(omittable: true)
+
+        def self.from_dynamic(dyn)
+          params = {}
+          params[:sourceId] = dyn['sourceId'] if dyn['sourceId']
+          params
+        end
       end
 
       # Structural sub-schema for the DRO
@@ -80,6 +88,7 @@ module Cocina
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 
+      # rubocop:disable Metrics/AbcSize
       def self.from_dynamic(dyn)
         params = {
           externalIdentifier: dyn['externalIdentifier'],
@@ -91,9 +100,11 @@ module Cocina
         params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
         params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
         params[:structural] = Structural.from_dynamic(dyn['structural']) if dyn['structural']
+        params[:identification] = Identification.from_dynamic(dyn['identification']) if dyn['identification']
         params[:description] = Description.from_dynamic(dyn.fetch('description'))
         DRO.new(params)
       end
+      # rubocop:enable Metrics/AbcSize
 
       def self.from_json(json)
         from_dynamic(JSON.parse(json))

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -104,6 +104,9 @@ RSpec.describe Cocina::Models::DRO do
               }
             ]
           },
+          identification: {
+            sourceId: 'source:999'
+          },
           structural: {
             isMemberOf: 'druid:bc777df7777',
             contains: [
@@ -131,6 +134,8 @@ RSpec.describe Cocina::Models::DRO do
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
         expect(tag.to).to eq 'Searchworks'
         expect(tag.release).to be true
+
+        expect(item.identification.sourceId).to eq 'source:999'
 
         expect(item.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
         expect(item.structural.isMemberOf).to eq 'druid:bc777df7777'
@@ -231,6 +236,9 @@ RSpec.describe Cocina::Models::DRO do
                 }
               ]
             },
+            "identification": {
+              "sourceId":"source:9999"
+            },
             "structural": {
               "contains": [
                 {
@@ -261,6 +269,9 @@ RSpec.describe Cocina::Models::DRO do
 
         tags = dro.administrative.releaseTags
         expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
+
+        expect(dro.identification.sourceId).to eq 'source:9999'
+
         expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
         expect(dro.structural.isMemberOf).to eq 'druid:bc777df7777'
         expect(dro.description.title.first.attributes).to eq(primary: true,


### PR DESCRIPTION
## Why was this change made?

So we can provide a sourceId property.

## Was the documentation (README, wiki) updated?
n/a