### PR TITLE
Create request models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,4 +18,4 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 12
+  Max: 15

--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -12,6 +12,10 @@ class CocinaModelsInflector < Zeitwerk::Inflector
     case basename
     when 'dro'
       'DRO'
+    when 'dro_builder'
+      'DROBuilder'
+    when 'request_dro'
+      'RequestDRO'
     when 'version'
       'VERSION'
     else

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -67,18 +67,7 @@ module Cocina
       attribute(:structural, Structural.default { Structural.new })
 
       def self.from_dynamic(dyn)
-        params = {
-          externalIdentifier: dyn['externalIdentifier'],
-          type: dyn['type'],
-          label: dyn['label'],
-          version: dyn['version']
-        }
-
-        # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
-        params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
-        params[:description] = Description.from_dynamic(dyn.fetch('description'))
-        params[:identification] = Identification.from_dynamic(dyn['identification']) if dyn['identification']
-        Collection.new(params)
+        CollectionBuilder.build(self, dyn)
       end
 
       def self.from_json(json)

--- a/lib/cocina/models/collection_builder.rb
+++ b/lib/cocina/models/collection_builder.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # This creates a Collection or a RequestCollection from dynamic attributes
+    class CollectionBuilder
+      # @return [Collection,RequestCollection]
+      # rubocop:disable Metrics/MethodLength
+      def self.build(klass, dyn)
+        params = {
+          type: dyn['type'],
+          label: dyn['label'],
+          version: dyn['version'],
+          description: Description.from_dynamic(dyn.fetch('description'))
+        }
+        params[:externalIdentifier] = dyn['externalIdentifier'] if needs_id?(klass)
+        # params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
+        if dyn['administrative']
+          params[:administrative] = Collection::Administrative
+                                    .from_dynamic(dyn['administrative'])
+        end
+        if dyn['identification']
+          params[:identification] = Collection::Identification
+                                    .from_dynamic(dyn['identification'])
+        end
+        klass.new(params)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def self.needs_id?(klass)
+        klass.attribute_names.include?(:externalIdentifier)
+      end
+    end
+  end
+end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -90,23 +90,9 @@ module Cocina
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 
-      # rubocop:disable Metrics/AbcSize
       def self.from_dynamic(dyn)
-        params = {
-          externalIdentifier: dyn['externalIdentifier'],
-          type: dyn['type'],
-          label: dyn['label'],
-          version: dyn['version']
-        }
-
-        params[:access] = Access.from_dynamic(dyn['access']) if dyn['access']
-        params[:administrative] = Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
-        params[:description] = Description.from_dynamic(dyn.fetch('description'))
-        params[:identification] = Identification.from_dynamic(dyn['identification']) if dyn['identification']
-        params[:structural] = Structural.from_dynamic(dyn['structural']) if dyn['structural']
-        DRO.new(params)
+        DROBuilder.build(self, dyn)
       end
-      # rubocop:enable Metrics/AbcSize
 
       def self.from_json(json)
         from_dynamic(JSON.parse(json))

--- a/lib/cocina/models/dro_builder.rb
+++ b/lib/cocina/models/dro_builder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # This creates a DRO or a RequestDRO from dynamic attributes
+    class DROBuilder
+      # @return [DRO,RequestDRO]
+      # rubocop:disable Metrics/AbcSize
+      def self.build(klass, dyn)
+        params = {
+          type: dyn['type'],
+          label: dyn['label'],
+          version: dyn['version'],
+          description: Description.from_dynamic(dyn.fetch('description'))
+        }
+        params[:externalIdentifier] = dyn['externalIdentifier'] if needs_id?(klass)
+
+        params[:access] = DRO::Access.from_dynamic(dyn['access']) if dyn['access']
+        params[:administrative] = DRO::Administrative.from_dynamic(dyn['administrative']) if dyn['administrative']
+        params[:identification] = DRO::Identification.from_dynamic(dyn['identification']) if dyn['identification']
+        params[:structural] = DRO::Structural.from_dynamic(dyn['structural']) if dyn['structural']
+        klass.new(params)
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      def self.needs_id?(klass)
+        klass.attribute_names.include?(:externalIdentifier)
+      end
+    end
+  end
+end

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # A request to create a digital repository collection.
+    # This is the same as Collection, except it doesn't have externalIdentifier.
+    # See http://sul-dlss.github.io/cocina-models/maps/Collection.json
+    class RequestCollection < Dry::Struct
+      attribute :type, Types::String.enum(*Collection::TYPES)
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Coercible::Integer
+      attribute(:access, Collection::Access.default { Collection::Access.new })
+      attribute(:administrative, Collection::Administrative.default { Collection::Administrative.new })
+      # Allowing description to be omittable for now (until rolled out to consumers),
+      # but I think it's actually required for every DRO
+      attribute :description, Description.optional.default(nil)
+      attribute(:identification, Collection::Identification.default { Collection::Identification.new })
+      attribute(:structural, Collection::Structural.default { Collection::Structural.new })
+
+      def self.from_dynamic(dyn)
+        CollectionBuilder.build(self, dyn)
+      end
+
+      def self.from_json(json)
+        from_dynamic(JSON.parse(json))
+      end
+    end
+  end
+end

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # A Request to create a digital repository object. (to create) object.
+    # This is same as a DRO, but without externalIdentifier (as that wouldn't have been created yet)
+    # See http://sul-dlss.github.io/cocina-models/maps/DRO.json
+    class RequestDRO < Dry::Struct
+      attribute :type, Types::String.enum(*DRO::TYPES)
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Coercible::Integer
+      attribute(:access, DRO::Access.default { DRO::Access.new })
+      attribute(:administrative, DRO::Administrative.default { DRO::Administrative.new })
+      # Allowing description to be omittable for now (until rolled out to consumers),
+      # but I think it's actually required for every DRO
+      attribute :description, Description.optional.default(nil)
+      attribute(:identification, DRO::Identification.default { DRO::Identification.new })
+      attribute(:structural, DRO::Structural.default { DRO::Structural.new })
+
+      def self.from_dynamic(dyn)
+        DROBuilder.build(self, dyn)
+      end
+
+      def self.from_json(json)
+        from_dynamic(JSON.parse(json))
+      end
+    end
+  end
+end

--- a/spec/cocina/models/request_collection_spec.rb
+++ b/spec/cocina/models/request_collection_spec.rb
@@ -2,44 +2,25 @@
 
 require 'spec_helper'
 
-RSpec.describe Cocina::Models::Collection do
+RSpec.describe Cocina::Models::RequestCollection do
   subject(:collection) { described_class.new(properties) }
 
   let(:collection_type) { Cocina::Models::Vocab.collection }
-  let(:properties) do
-    {
-      externalIdentifier: 'druid:ab123cd4567',
-      type: collection_type,
-      label: 'My collection',
-      version: 3,
-      description: {
-        title: []
-      }
-    }
-  end
-
-  describe 'model check methods' do
-    it { is_expected.not_to be_admin_policy }
-    it { is_expected.to be_collection }
-    it { is_expected.not_to be_dro }
-    it { is_expected.not_to be_file }
-    it { is_expected.not_to be_file_set }
-  end
-
-  describe Cocina::Models::Collection::Administrative do
-    let(:instance) { described_class.new }
-
-    describe '#releaseTags' do
-      subject { instance.releaseTags }
-
-      it { is_expected.to be_empty }
-    end
-  end
 
   describe 'initialization' do
-    context 'with a minimal set, defined above' do
+    context 'with a minimal set' do
+      let(:properties) do
+        {
+          type: collection_type,
+          label: 'My collection',
+          version: 3,
+          description: {
+            title: []
+          }
+        }
+      end
+
       it 'has properties' do
-        expect(collection.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(collection.type).to eq collection_type
         expect(collection.label).to eq 'My collection'
 
@@ -50,7 +31,6 @@ RSpec.describe Cocina::Models::Collection do
     context 'with a string version' do
       let(:properties) do
         {
-          externalIdentifier: 'druid:ab123cd4567',
           type: collection_type,
           label: 'My collection',
           version: '3',
@@ -68,7 +48,6 @@ RSpec.describe Cocina::Models::Collection do
     context 'with a all properties' do
       let(:properties) do
         {
-          externalIdentifier: 'druid:ab123cd4567',
           type: collection_type,
           label: 'My collection',
           version: 3,
@@ -111,7 +90,6 @@ RSpec.describe Cocina::Models::Collection do
       end
 
       it 'has properties' do
-        expect(collection.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(collection.type).to eq collection_type
         expect(collection.label).to eq 'My collection'
 
@@ -135,7 +113,6 @@ RSpec.describe Cocina::Models::Collection do
     context 'with empty subschemas' do
       let(:properties) do
         {
-          'externalIdentifier' => 'druid:kv840rx2720',
           'type' => collection_type,
           'label' => 'Examination of the memorial of the owners and underwriters ...',
           'version' => 1,
@@ -150,7 +127,7 @@ RSpec.describe Cocina::Models::Collection do
       end
 
       it 'has properties' do
-        expect(collection.externalIdentifier).to eq 'druid:kv840rx2720'
+        expect(collection.label).to eq 'Examination of the memorial of the owners and underwriters ...'
       end
     end
   end
@@ -162,7 +139,6 @@ RSpec.describe Cocina::Models::Collection do
       let(:json) do
         <<~JSON
           {
-            "externalIdentifier":"druid:12343234",
             "type":"#{collection_type}",
             "label":"my collection",
             "version": 3,
@@ -174,8 +150,7 @@ RSpec.describe Cocina::Models::Collection do
       end
 
       it 'has the attributes' do
-        expect(collection.attributes).to include(externalIdentifier: 'druid:12343234',
-                                                 label: 'my collection',
+        expect(collection.attributes).to include(label: 'my collection',
                                                  type: collection_type)
         expect(collection.access).to be_kind_of Cocina::Models::Collection::Access
         expect(collection.administrative).to be_kind_of Cocina::Models::Collection::Administrative
@@ -188,7 +163,6 @@ RSpec.describe Cocina::Models::Collection do
       let(:json) do
         <<~JSON
           {
-            "externalIdentifier":"druid:12343234",
             "type":"#{collection_type}",
             "label":"my collection",
             "version": 3,
@@ -234,8 +208,7 @@ RSpec.describe Cocina::Models::Collection do
       end
 
       it 'has the attributes' do
-        expect(collection.attributes).to include(externalIdentifier: 'druid:12343234',
-                                                 label: 'my collection',
+        expect(collection.attributes).to include(label: 'my collection',
                                                  type: collection_type)
 
         expect(collection.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::RequestDRO do
+  subject(:item) { described_class.new(properties) }
+
+  let(:item_type) { Cocina::Models::Vocab.object }
+  let(:fileset_type) { Cocina::Models::Vocab.fileset }
+
+  describe 'initialization' do
+    context 'with a minimal set' do
+      let(:properties) do
+        {
+          type: item_type,
+          label: 'My object',
+          version: 3,
+          description: {
+            title: []
+          }
+        }
+      end
+
+      it 'has properties' do
+        expect(item.type).to eq item_type
+        expect(item.label).to eq 'My object'
+
+        expect(item.access).to be_kind_of Cocina::Models::DRO::Access
+      end
+    end
+
+    context 'with a string version' do
+      let(:properties) do
+        {
+          type: item_type,
+          label: 'My object',
+          version: '3',
+          description: {
+            title: []
+          }
+        }
+      end
+
+      it 'coerces to integer' do
+        expect(item.version).to eq 3
+      end
+    end
+
+    context 'with a all properties' do
+      let(:properties) do
+        {
+          type: item_type,
+          label: 'My object',
+          version: 3,
+          access: {
+            embargoReleaseDate: '2009-12-14T07:00:00Z'
+          },
+          administrative: {
+            hasAdminPolicy: 'druid:mx123cd4567',
+            releaseTags: [
+              {
+                who: 'Justin',
+                what: 'collection',
+                date: '2018-11-23T00:44:52Z',
+                to: 'Searchworks',
+                release: 'true'
+              },
+              {
+                who: 'Other Justin',
+                what: 'self',
+                date: '2017-10-20T15:42:15Z',
+                to: 'Searchworks',
+                release: 'false'
+              }
+            ]
+          },
+          description: {
+            title: [
+              {
+                primary: true,
+                titleFull: 'My object'
+              }
+            ]
+          },
+          identification: {
+            sourceId: 'source:999',
+            catalogLinks: [
+              { catalog: 'symphony', catalogRecordId: '44444' }
+            ]
+          },
+          structural: {
+            isMemberOf: 'druid:bc777df7777',
+            contains: [
+              Cocina::Models::FileSet.new(type: fileset_type,
+                                          version: 3,
+                                          externalIdentifier: '12343234_1', label: 'Resource #1'),
+              Cocina::Models::FileSet.new(type: fileset_type,
+                                          version: 3,
+                                          externalIdentifier: '12343234_2', label: 'Resource #2')
+            ]
+          }
+        }
+      end
+
+      it 'has properties' do
+        expect(item.type).to eq item_type
+        expect(item.label).to eq 'My object'
+
+        expect(item.access.embargoReleaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
+
+        expect(item.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+        expect(item.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
+        tag = item.administrative.releaseTags.first
+        expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
+        expect(tag.to).to eq 'Searchworks'
+        expect(tag.release).to be true
+
+        expect(item.identification.sourceId).to eq 'source:999'
+        link = item.identification.catalogLinks.first
+        expect(link.catalog).to eq 'symphony'
+        expect(link.catalogRecordId).to eq '44444'
+
+        expect(item.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(item.structural.isMemberOf).to eq 'druid:bc777df7777'
+      end
+    end
+  end
+
+  describe '.from_dynamic' do
+    subject(:item) { described_class.from_dynamic(properties) }
+
+    context 'with empty subschemas' do
+      let(:properties) do
+        {
+          'type' => item_type,
+          'label' => 'Examination of the memorial of the owners and underwriters ...',
+          'version' => 1,
+          'access' => {},
+          'administrative' => { 'releaseTags' => [] },
+          'description' => {
+            'title' => []
+          },
+          'identification' => {},
+          'structural' => {}
+        }
+      end
+
+      it 'has properties' do
+        expect(item.label).to eq 'Examination of the memorial of the owners and underwriters ...'
+      end
+    end
+  end
+
+  describe '.from_json' do
+    subject(:dro) { described_class.from_json(json) }
+
+    context 'with a minimal object' do
+      let(:json) do
+        <<~JSON
+          {
+            "type":"#{item_type}",
+            "label":"my item",
+            "version": 3,
+            "description": {
+              "title": []
+            }
+          }
+        JSON
+      end
+
+      it 'has the attributes' do
+        expect(dro.attributes).to include(label: 'my item',
+                                          type: item_type)
+        expect(dro.access).to be_kind_of Cocina::Models::DRO::Access
+        expect(dro.administrative).to be_kind_of Cocina::Models::DRO::Administrative
+        expect(dro.identification).to be_kind_of Cocina::Models::DRO::Identification
+        expect(dro.structural).to be_kind_of Cocina::Models::DRO::Structural
+      end
+    end
+
+    context 'with a full object' do
+      let(:json) do
+        <<~JSON
+          {
+            "type":"#{item_type}",
+            "label":"my item",
+            "version": 3,
+            "access": {
+              "embargoReleaseDate":"2009-12-14T07:00:00Z"
+            },
+            "administrative": {
+              "hasAdminPolicy":"druid:mx123cd4567",
+              "releaseTags": [
+                {
+                  "who":"Justin",
+                  "what":"collection",
+                  "date":"2018-11-23T00:44:52Z",
+                  "to":"Searchworks",
+                  "release":true
+                },
+                {
+                  "who":"Other Justin",
+                  "what":"self",
+                  "date":"2017-10-20T15:42:15Z",
+                  "to":"Searchworks",
+                  "release":false
+                }
+              ]
+            },
+            "description": {
+              "title": [
+                {
+                  "primary": true,
+                  "titleFull":"my object"
+                }
+              ]
+            },
+            "identification": {
+              "sourceId":"source:9999",
+              "catalogLinks":[
+                {
+                  "catalog":"symphony",
+                  "catalogRecordId":"44444"
+                }
+              ]
+            },
+            "structural": {
+              "contains": [
+                {
+                  "type":"#{fileset_type}",
+                  "version":3,
+                  "externalIdentifier":"12343234_1", "label":"Resource #1"
+                },
+                {
+                  "type":"#{fileset_type}",
+                  "version":3,
+                  "externalIdentifier":"12343234_2", "label":"fileset#2"
+                }
+              ],
+              "isMemberOf":"druid:bc777df7777"
+            }
+          }
+        JSON
+      end
+
+      it 'has the attributes' do
+        expect(dro.attributes).to include(label: 'my item',
+                                          type: item_type)
+        access_attributes = dro.access.attributes
+        expect(access_attributes).to eq(embargoReleaseDate: DateTime.parse('2009-12-14T07:00:00Z'))
+
+        expect(dro.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+
+        tags = dro.administrative.releaseTags
+        expect(tags).to all(be_instance_of Cocina::Models::ReleaseTag)
+
+        expect(dro.identification.sourceId).to eq 'source:9999'
+        link = dro.identification.catalogLinks.first
+        expect(link.catalog).to eq 'symphony'
+        expect(link.catalogRecordId).to eq '44444'
+
+        expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(dro.structural.isMemberOf).to eq 'druid:bc777df7777'
+        expect(dro.description.title.first.attributes).to eq(primary: true,
+                                                             titleFull: 'my object')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

So that we can model requests that don't have identifiers

## Was the documentation (README, wiki) updated?
n/a