### PR TITLE
Add a build_request method

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -48,11 +48,28 @@ module Cocina
     def self.build(dyn)
       case dyn.fetch('type')
       when *DRO::TYPES
-        DRO.from_dynamic(dyn)
+        DRO.new(dyn)
       when *Collection::TYPES
-        Collection.from_dynamic(dyn)
+        Collection.new(dyn)
       when *AdminPolicy::TYPES
-        AdminPolicy.from_dynamic(dyn)
+        AdminPolicy.new(dyn)
+      else
+        raise UnknownTypeError, "Unknown type: '#{dyn.fetch('type')}'"
+      end
+    end
+
+    # @param [Hash] dyn a ruby hash representation of the JSON serialization of a request for a Collection or DRO
+    # @return [RequestDRO,RequestCollection,RequestAdminPolicy]
+    # @raises [UnknownTypeError] if a valid type is not found in the data
+    # @raises [KeyError] if a type field cannot be found in the data
+    def self.build_request(dyn)
+      case dyn.fetch('type')
+      when *DRO::TYPES
+        RequestDRO.new(dyn)
+      when *Collection::TYPES
+        RequestCollection.new(dyn)
+      when *AdminPolicy::TYPES
+        RequestAdminPolicy.new(dyn)
       else
         raise UnknownTypeError, "Unknown type: '#{dyn.fetch('type')}'"
       end

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -76,4 +76,73 @@ RSpec.describe Cocina::Models do
       end
     end
   end
+
+  describe '.build_request' do
+    subject(:build) { described_class.build_request(data) }
+
+    context 'with a collection type' do
+      let(:data) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
+          'label' => 'bar',
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
+        }
+      end
+
+      it { is_expected.to be_kind_of Cocina::Models::RequestCollection }
+    end
+
+    context 'with a DRO type' do
+      let(:data) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
+          'label' => 'bar',
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
+        }
+      end
+
+      it { is_expected.to be_kind_of Cocina::Models::RequestDRO }
+    end
+
+    context 'with an AdminPolicy type' do
+      let(:data) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
+          'label' => 'bar',
+          'version' => 5,
+          'description' => {
+            'title' => []
+          }
+        }
+      end
+
+      it { is_expected.to be_kind_of Cocina::Models::RequestAdminPolicy }
+    end
+
+    context 'with an invalid type' do
+      let(:data) do
+        { 'type' => 'foo' }
+      end
+
+      it 'raises an error' do
+        expect { build }.to raise_error Cocina::Models::UnknownTypeError, "Unknown type: 'foo'"
+      end
+    end
+
+    context 'without a type' do
+      let(:data) do
+        {}
+      end
+
+      it 'raises an error' do
+        expect { build }.to raise_error KeyError
+      end
+    end
+  end
 end


### PR DESCRIPTION
For building Request* objects

## Why was this change made?
This pattern is used in dor-services-app and it is so similar to the build method, it seems it should be here.


## Was the documentation (README, wiki) updated?
n/a