### PR TITLE
Makes embargo trully optional.

### DIFF
--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -33,7 +33,7 @@ module Cocina
                                           .enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
         end
 
-        attribute :embargo, Embargo.optional.default(nil)
+        attribute :embargo, Embargo.optional.meta(omittable: true)
       end
 
       # Subschema for administrative concerns


### PR DESCRIPTION
## Why was this change made?
So that embargo is actually optional.


## Was the documentation (README, wiki) updated?
No.