### PR TITLE
Add the access property for items and collections

### DIFF
--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -16,6 +16,8 @@ module Cocina
 
       # Subschema for access concerns
       class Access < Struct
+        attribute :access, Types::String.default('dark')
+                                        .enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
       end
 
       # Subschema for administrative concerns

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -34,6 +34,8 @@ module Cocina
         end
 
         attribute :embargo, Embargo.optional.meta(omittable: true)
+        attribute :access, Types::String.default('dark')
+                                        .enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
       end
 
       # Subschema for administrative concerns

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Cocina::Models::Collection do
           label: 'My collection',
           version: 3,
           access: {
+            access: 'stanford'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -114,6 +115,8 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.externalIdentifier).to eq 'druid:ab123cd4567'
         expect(collection.type).to eq collection_type
         expect(collection.label).to eq 'My collection'
+
+        expect(collection.access.access).to eq 'stanford'
 
         expect(collection.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(collection.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
@@ -193,6 +196,7 @@ RSpec.describe Cocina::Models::Collection do
             "label":"my collection",
             "version": 3,
             "access": {
+              "access": "world"
             },
             "administrative": {
               "hasAdminPolicy":"druid:mx123cd4567",
@@ -237,6 +241,7 @@ RSpec.describe Cocina::Models::Collection do
         expect(collection.attributes).to include(externalIdentifier: 'druid:12343234',
                                                  label: 'my collection',
                                                  type: collection_type)
+        expect(collection.access.access).to eq 'world'
 
         expect(collection.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
 

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe Cocina::Models::DRO do
           access: {
             embargo: {
               releaseDate: '2009-12-14T07:00:00Z',
-              access: 'stanford'
-            }
+              access: 'world'
+            },
+            access: 'stanford'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -132,8 +133,9 @@ RSpec.describe Cocina::Models::DRO do
         expect(item.type).to eq item_type
         expect(item.label).to eq 'My object'
 
+        expect(item.access.access).to eq 'stanford'
         expect(item.access.embargo.releaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
-        expect(item.access.embargo.access).to eq 'stanford'
+        expect(item.access.embargo.access).to eq 'world'
 
         expect(item.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
         expect(item.administrative.releaseTags).to all(be_kind_of(Cocina::Models::ReleaseTag))
@@ -217,6 +219,7 @@ RSpec.describe Cocina::Models::DRO do
             "label":"my item",
             "version": 3,
             "access": {
+              "access": "dark",
               "embargo": {
                 "releaseDate":"2009-12-14T07:00:00Z"
               }
@@ -280,6 +283,9 @@ RSpec.describe Cocina::Models::DRO do
         expect(dro.attributes).to include(externalIdentifier: 'druid:12343234',
                                           label: 'my item',
                                           type: item_type)
+
+        expect(dro.access.access).to eq 'dark'
+
         embargo_attributes = dro.access.embargo.attributes
         expect(embargo_attributes).to eq(releaseDate: DateTime.parse('2009-12-14T07:00:00Z'), access: 'dark')
 


### PR DESCRIPTION
## Why was this change made?

This is required for registering from argo as the form lets you provide access.

## Was the documentation (README, wiki) updated?
n/a