### PR TITLE
Made description omittable, not nil.

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -69,7 +69,7 @@ module Cocina
       attribute(:administrative, Administrative.default { Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -44,7 +44,7 @@ module Cocina
       attribute(:administrative, Administrative.default { Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -67,7 +67,7 @@ module Cocina
       attribute(:administrative, Administrative.default { Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -12,7 +12,7 @@ module Cocina
       attribute(:administrative, AdminPolicy::Administrative.default { AdminPolicy::Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, AdminPolicy::Identification.default { AdminPolicy::Identification.new })
       attribute(:structural, AdminPolicy::Structural.default { AdminPolicy::Structural.new })
 

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -13,7 +13,7 @@ module Cocina
       attribute(:administrative, Collection::Administrative.default { Collection::Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, Collection::Identification.default { Collection::Identification.new })
       attribute(:structural, Collection::Structural.default { Collection::Structural.new })
 

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -13,7 +13,7 @@ module Cocina
       attribute(:administrative, DRO::Administrative.default { DRO::Administrative.new })
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
-      attribute :description, Description.optional.default(nil)
+      attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, DRO::Identification.default { DRO::Identification.new })
       attribute(:structural, DRO::Structural.default { DRO::Structural.new })
 


### PR DESCRIPTION
## Why was this change made?
Description should be omitted, not produce nil. Nil disagrees with openapi.yml.


## Was the documentation (README, wiki) updated?
No.