### PR TITLE
Add a RequestFileSet which does not require an externalIdentifier

### DIFF
--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -6,6 +6,13 @@ module Cocina
     # This is same as a DRO, but without externalIdentifier (as that wouldn't have been created yet)
     # See http://sul-dlss.github.io/cocina-models/maps/DRO.json
     class RequestDRO < Struct
+      # Structural sub-schema that contains RequestFileSet (unlike the DRO which contains FileSet)
+      class Structural < Struct
+        attribute :contains, Types::Strict::Array.of(RequestFileSet).meta(omittable: true)
+        attribute :isMemberOf, Types::Strict::String.meta(omittable: true)
+        attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).meta(omittable: true)
+      end
+
       attribute :type, Types::String.enum(*DRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Coercible::Integer
@@ -15,7 +22,7 @@ module Cocina
       # but I think it's actually required for every DRO
       attribute :description, Description.optional.meta(omittable: true)
       attribute(:identification, DRO::Identification.default { DRO::Identification.new })
-      attribute(:structural, DRO::Structural.default { DRO::Structural.new })
+      attribute(:structural, Structural.default { Structural.new })
 
       def self.from_dynamic(dyn)
         RequestDRO.new(dyn)

--- a/lib/cocina/models/request_file_set.rb
+++ b/lib/cocina/models/request_file_set.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # A Request to create a FileSet object.
+    # This is same as a FileSet, but without externalIdentifier (as that wouldn't have been created yet)
+    # See http://sul-dlss.github.io/cocina-models/maps/FileSet.json
+    class RequestFileSet < Struct
+      attribute :type, Types::String.enum(*FileSet::TYPES)
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Coercible::Integer
+      attribute(:identification, FileSet::Identification.default { FileSet::Identification.new })
+      attribute(:structural, FileSet::Structural.default { FileSet::Structural.new })
+    end
+  end
+end

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe Cocina::Models::RequestDRO do
           structural: {
             isMemberOf: 'druid:bc777df7777',
             contains: [
-              Cocina::Models::FileSet.new(type: fileset_type,
-                                          version: 3,
-                                          externalIdentifier: '12343234_1', label: 'Resource #1'),
-              Cocina::Models::FileSet.new(type: fileset_type,
-                                          version: 3,
-                                          externalIdentifier: '12343234_2', label: 'Resource #2')
+              Cocina::Models::RequestFileSet.new(type: fileset_type,
+                                                 version: 3,
+                                                 label: 'Resource #1'),
+              Cocina::Models::RequestFileSet.new(type: fileset_type,
+                                                 version: 3,
+                                                 label: 'Resource #2')
             ]
           }
         }
@@ -124,7 +124,7 @@ RSpec.describe Cocina::Models::RequestDRO do
         expect(link.catalog).to eq 'symphony'
         expect(link.catalogRecordId).to eq '44444'
 
-        expect(item.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(item.structural.contains).to all(be_instance_of(Cocina::Models::RequestFileSet))
         expect(item.structural.isMemberOf).to eq 'druid:bc777df7777'
       end
     end
@@ -178,7 +178,7 @@ RSpec.describe Cocina::Models::RequestDRO do
         expect(dro.access).to be_kind_of Cocina::Models::DRO::Access
         expect(dro.administrative).to be_kind_of Cocina::Models::DRO::Administrative
         expect(dro.identification).to be_kind_of Cocina::Models::DRO::Identification
-        expect(dro.structural).to be_kind_of Cocina::Models::DRO::Structural
+        expect(dro.structural).to be_kind_of Cocina::Models::RequestDRO::Structural
       end
     end
 
@@ -266,7 +266,7 @@ RSpec.describe Cocina::Models::RequestDRO do
         expect(link.catalog).to eq 'symphony'
         expect(link.catalogRecordId).to eq '44444'
 
-        expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::FileSet))
+        expect(dro.structural.contains).to all(be_instance_of(Cocina::Models::RequestFileSet))
         expect(dro.structural.isMemberOf).to eq 'druid:bc777df7777'
         expect(dro.description.title.first.attributes).to eq(primary: true,
                                                              titleFull: 'my object')


### PR DESCRIPTION


## Why was this change made?

This identifer will be assigned after registration, so shouldn't be required when doing a registration.

## Was the documentation (README, wiki) updated?
n/a