### PR TITLE
Allow File #use, #presentation, #identification and #structural to be…

### DIFF
--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -46,13 +46,13 @@ module Cocina
       attribute :type, Types::String.enum(*TYPES)
       attribute :label, Types::Strict::String
       attribute :filename, Types::String.optional.default(nil)
-      attribute :use, Types::String.enum('original', 'preservation', 'access').optional.default(nil)
+      attribute :use, Types::String.enum('original', 'preservation', 'access').optional.meta(omittable: true)
       attribute :size, Types::Coercible::Integer.optional.default(nil)
       attribute :hasMessageDigests, Types::Strict::Array.of(Fixity).default([].freeze)
-      attribute(:presentation, Presentation.optional.default { Presentation.new })
+      attribute(:presentation, Presentation.optional.meta(omittable: true))
       attribute :version, Types::Coercible::Integer
-      attribute(:identification, Identification.default { Identification.new })
-      attribute(:structural, Structural.default { Structural.new })
+      attribute(:identification, Identification.optional.meta(omittable: true))
+      attribute(:structural, Structural.optional.meta(omittable: true))
 
       def self.from_dynamic(dyn)
         File.new(dyn)

--- a/spec/cocina/models/file_spec.rb
+++ b/spec/cocina/models/file_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Cocina::Models::File do
   end
 
   describe '.from_json' do
-    subject(:dro) { described_class.from_json(json) }
+    subject(:file) { described_class.from_json(json) }
 
     context 'with a minimal object' do
       let(:json) do
@@ -136,11 +136,9 @@ RSpec.describe Cocina::Models::File do
       end
 
       it 'has the attributes' do
-        expect(dro.attributes).to include(externalIdentifier: 'druid:12343234',
-                                          label: 'my item',
-                                          type: file_type)
-        expect(dro.identification).to be_kind_of Cocina::Models::File::Identification
-        expect(dro.structural).to be_kind_of Cocina::Models::File::Structural
+        expect(file.attributes).to include(externalIdentifier: 'druid:12343234',
+                                           label: 'my item',
+                                           type: file_type)
       end
     end
 
@@ -180,23 +178,23 @@ RSpec.describe Cocina::Models::File do
       end
 
       it 'has the attributes' do
-        expect(dro.attributes).to include(externalIdentifier: 'druid:12343234',
-                                          label: 'nrs_19180211_0003.tiff',
-                                          type: file_type)
+        expect(file.attributes).to include(externalIdentifier: 'druid:12343234',
+                                           label: 'nrs_19180211_0003.tiff',
+                                           type: file_type)
 
-        expect(dro.access.access).to eq 'world'
+        expect(file.access.access).to eq 'world'
 
-        digests = dro.hasMessageDigests
+        digests = file.hasMessageDigests
         expect(digests).to all(be_instance_of Cocina::Models::File::Fixity)
         expect(digests.first.type).to eq 'md5'
 
-        expect(dro.presentation.height).to eq 5679
-        expect(dro.presentation.width).to eq 4437
-        expect(dro.size).to eq 25_243_531
-        expect(dro.use).to eq 'original'
+        expect(file.presentation.height).to eq 5679
+        expect(file.presentation.width).to eq 4437
+        expect(file.size).to eq 25_243_531
+        expect(file.use).to eq 'original'
 
-        expect(dro.administrative.shelve).to be true
-        expect(dro.administrative.sdrPreserve).to be false
+        expect(file.administrative.shelve).to be true
+        expect(file.administrative.sdrPreserve).to be false
       end
     end
   end


### PR DESCRIPTION

## Why was this change made?
… omittable

These are often not used, so no need to include them.



## Was the documentation (README, wiki) updated?
n/a