### PR TITLE
Add optional geo metadata

### DIFF
--- a/docs/maps/DRO.json
+++ b/docs/maps/DRO.json
@@ -176,6 +176,17 @@
       "description": "Descriptive metadata for the DRO.",
       "$ref": "/Description"
     },
+    "geographic": {
+      "description": "Geographic metadata for the DRO.",
+      "type": "object",
+      "required": ["iso19139"],
+      "properties": {
+        "iso19139": {
+          "description": "Geographic ISO 19139 XML metadata",
+          "type": "string"
+        }
+      }
+    },
     "identification": {
       "description": "Identifying information for the DRO.",
       "type": "object",

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -694,6 +694,23 @@
           "description": "Descriptive metadata for the DRO.",
           "$ref": "#/definitions/Description"
         },
+        "geographic": {
+          "description": "Geographic metadata for the DRO.",
+          "type": [
+            "object"
+          ],
+          "required": [
+            "iso19139"
+          ],
+          "properties": {
+            "iso19139": {
+              "description": "Geographic ISO 19139 XML metadata",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
         "identification": {
           "description": "Identifying information for the DRO.",
           "type": [

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -103,6 +103,7 @@ Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction 
 | **description:title** | *array* | The title of the item. | `[{"primary":true,"titleFull":"example"}]` |
 | **externalIdentifier** | *string* | Identifier for the resource within the SDR architecture but outside of the repository. DRUID or UUID depending on resource type. Constant across resource versions. What clients will use calling the repository. Same as `identification.identifier` | `"example"` |
 | **followingVersion** | *string* | Following version for the Object within SDR. | `"example"` |
+| **geographic:iso19139** | *string* | Geographic ISO 19139 XML metadata | `"example"` |
 | **identification:catalogLinks/catalog** | *string* | Catalog that is the source of the linked record. | `"example"` |
 | **identification:catalogLinks/catalogRecordId** | *string* | Record identifier that is unique within the context of the linked record's catalog. | `"example"` |
 | **identification:catalogLinks/deliverMetadata** | *boolean* | If the linked record should be automatically updated when the DRO descriptive metadata changes. | `true` |

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -60,6 +60,11 @@ module Cocina
         attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).meta(omittable: true)
       end
 
+      # Geographic sub-schema for the DRO
+      class Geographic < Struct
+        attribute :iso19139, Types::Strict::String
+      end
+
       attribute :externalIdentifier, Types::Strict::String
       attribute :type, Types::String.enum(*TYPES)
       attribute :label, Types::Strict::String
@@ -69,6 +74,7 @@ module Cocina
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
       attribute :description, Description.optional.meta(omittable: true)
+      attribute :geographic, Geographic.optional.meta(omittable: true)
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -21,6 +21,7 @@ module Cocina
       # Allowing description to be omittable for now (until rolled out to consumers),
       # but I think it's actually required for every DRO
       attribute :description, Description.optional.meta(omittable: true)
+      attribute :geographic, DRO::Geographic.optional.meta(omittable: true)
       attribute(:identification, DRO::Identification.default { DRO::Identification.new })
       attribute(:structural, Structural.default { Structural.new })
 

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -114,6 +114,9 @@ RSpec.describe Cocina::Models::DRO do
               }
             ]
           },
+          geographic: {
+            iso19139: '<geoXML></geoXML>'
+          },
           identification: {
             sourceId: 'source:999',
             catalogLinks: [
@@ -153,6 +156,8 @@ RSpec.describe Cocina::Models::DRO do
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
         expect(tag.to).to eq 'Searchworks'
         expect(tag.release).to be true
+
+        expect(item.geographic.iso19139).to eq '<geoXML></geoXML>'
 
         expect(item.identification.sourceId).to eq 'source:999'
         link = item.identification.catalogLinks.first

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe Cocina::Models::RequestDRO do
               }
             ]
           },
+          geographic: {
+            iso19139: '<geoXML></geoXML>'
+          },
           identification: {
             sourceId: 'source:999',
             catalogLinks: [
@@ -118,6 +121,8 @@ RSpec.describe Cocina::Models::RequestDRO do
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
         expect(tag.to).to eq 'Searchworks'
         expect(tag.release).to be true
+
+        expect(item.geographic.iso19139).to eq '<geoXML></geoXML>'
 
         expect(item.identification.sourceId).to eq 'source:999'
         link = item.identification.catalogLinks.first


### PR DESCRIPTION
## Why was this change made?

This will support geographic objects (e.g. https://argo.stanford.edu/view/druid:bb033gt0615)

## Was the documentation (README, wiki) updated?

yes
