### PR TITLE
RequestFileSet contains RequestFiles

### DIFF
--- a/lib/cocina/models/request_file_set.rb
+++ b/lib/cocina/models/request_file_set.rb
@@ -14,7 +14,7 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Coercible::Integer
       attribute(:identification, FileSet::Identification.default { FileSet::Identification.new })
-      attribute(:structural, FileSet::Structural.default { FileSet::Structural.new })
+      attribute(:structural, Structural.default { Structural.new })
     end
   end
 end

--- a/spec/cocina/models/request_file_set_spec.rb
+++ b/spec/cocina/models/request_file_set_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::RequestFileSet do
+  subject(:item) { described_class.new(properties) }
+
+  let(:file_set_type) { 'http://cocina.sul.stanford.edu/models/fileset.jsonld' }
+
+  describe 'initialization' do
+    context 'with a minimal set' do
+      let(:properties) do
+        {
+          type: file_set_type,
+          label: 'My file',
+          version: 3
+        }
+      end
+
+      it 'has properties' do
+        expect(item.type).to eq file_set_type
+        expect(item.label).to eq 'My file'
+      end
+    end
+
+    context 'with a string version' do
+      let(:properties) do
+        {
+          type: file_set_type,
+          label: 'My file',
+          version: '3'
+        }
+      end
+
+      it 'coerces to integer' do
+        expect(item.version).to eq 3
+      end
+    end
+
+    context 'with a all properties' do
+      let(:properties) do
+        {
+          type: file_set_type,
+          label: 'My file',
+          version: 3,
+          administrative: {
+          },
+          structural: {
+            contains: [
+              {
+                type: Cocina::Models::Vocab.file,
+                label: 'file#1',
+                version: 3
+              },
+              {
+                type: Cocina::Models::Vocab.file,
+                label: 'file#2',
+                version: 3
+              }
+            ]
+          }
+        }
+      end
+
+      it 'has properties' do
+        expect(item.type).to eq file_set_type
+        expect(item.label).to eq 'My file'
+
+        expect(item.structural.contains).to all(be_instance_of(Cocina::Models::RequestFile))
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?
Because RequestFiles don't need to have externalIdentifiers


## Was the documentation (README, wiki) updated?

n/a
