### PR TITLE
remove unnec parens

### DIFF
--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -50,10 +50,10 @@ module Cocina
       attribute :size, Types::Coercible::Integer.optional.default(nil)
       attribute :hasMessageDigests, Types::Strict::Array.of(Fixity).default([].freeze)
       attribute :hasMimeType, Types::String.optional.meta(omittable: true)
-      attribute(:presentation, Presentation.optional.meta(omittable: true))
+      attribute :presentation, Presentation.optional.meta(omittable: true)
       attribute :version, Types::Coercible::Integer
-      attribute(:identification, Identification.optional.meta(omittable: true))
-      attribute(:structural, Structural.optional.meta(omittable: true))
+      attribute :identification, Identification.optional.meta(omittable: true)
+      attribute :structural, Structural.optional.meta(omittable: true)
 
       def self.from_dynamic(dyn)
         File.new(dyn)

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -15,10 +15,10 @@ module Cocina
       attribute :size, Types::Coercible::Integer.optional.default(nil)
       attribute :hasMessageDigests, Types::Strict::Array.of(File::Fixity).default([].freeze)
       attribute :hasMimeType, Types::String.optional.meta(omittable: true)
-      attribute(:presentation, File::Presentation.optional.meta(omittable: true))
+      attribute :presentation, File::Presentation.optional.meta(omittable: true)
       attribute :version, Types::Coercible::Integer
-      attribute(:identification, File::Identification.optional.meta(omittable: true))
-      attribute(:structural, File::Structural.optional.meta(omittable: true))
+      attribute :identification, File::Identification.optional.meta(omittable: true)
+      attribute :structural, File::Structural.optional.meta(omittable: true)
 
       def self.from_dynamic(dyn)
         new(dyn)


### PR DESCRIPTION
## Why was this change made?

OCD.

We only NEED parens in these situations when there is ambiguity.  That is true for send line below due to curly braces, but NOT true for first line.

```ruby
      attribute :version, Types::Coercible::Integer
      attribute(:identification, Identification.default { Identification.new })
```

## Was the documentation (README, wiki) updated?

n/a

## Does this change affect how this gem integrates with other services?

n/a

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
