### PR TITLE
Add copyright and reuseAndReproductionStatement to DROs

### DIFF
--- a/docs/maps/Collection.json
+++ b/docs/maps/Collection.json
@@ -89,7 +89,7 @@
           "description": "The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).",
           "type": "string"
         },
-        "reuseAndReproductionStatement": {
+        "useAndReproductionStatement": {
           "description": "The human readable reuse and reproduction statement that applies to the Collection.",
           "type": "string"
         },

--- a/docs/maps/DRO.json
+++ b/docs/maps/DRO.json
@@ -107,7 +107,7 @@
           "description": "The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).",
           "type": "string"
         },
-        "reuseAndReproductionStatement": {
+        "useAndReproductionStatement": {
           "description": "The human readable reuse and reproduction statement that applies to the DRO.",
           "type": "string"
         },

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -180,7 +180,7 @@
                 "string"
               ]
             },
-            "reuseAndReproductionStatement": {
+            "useAndReproductionStatement": {
               "description": "The human readable reuse and reproduction statement that applies to the Collection.",
               "type": [
                 "string"
@@ -595,7 +595,7 @@
                 "string"
               ]
             },
-            "reuseAndReproductionStatement": {
+            "useAndReproductionStatement": {
               "description": "The human readable reuse and reproduction statement that applies to the DRO.",
               "type": [
                 "string"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -28,7 +28,7 @@ A group of Digital Repository Objects that indicate some type of conceptual grou
 | **access:download** | *string* | Download level for the Collection metadata.<br/> **one of:**`"world"` or `"stanford"` or `"location-based"` or `"citation-only"` or `"dark"` | `"world"` |
 | **access:embargoReleaseDate** | *date-time* | Date when the Collection is released from an embargo, if an embargo exists. | `"2015-01-01T12:00:00Z"` |
 | **access:license** | *string* | The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.). | `"example"` |
-| **access:reuseAndReproductionStatement** | *string* | The human readable reuse and reproduction statement that applies to the Collection. | `"example"` |
+| **access:useAndReproductionStatement** | *string* | The human readable reuse and reproduction statement that applies to the Collection. | `"example"` |
 | **access:termsOfUse** | *string* | License or terms of use governing reuse of the Collection. Should be a text statement. | `"example"` |
 | **administrative:created** | *date-time* | When the resource in SDR was created. | `"2015-01-01T12:00:00Z"` |
 | **administrative:deleted** | *boolean* | If the resource has been deleted (but not purged). | `true` |
@@ -84,7 +84,7 @@ Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction 
 | **access:embargo:access** | *string* | Access level for the DRO when released from embargo.<br/> **one of:**`"world"` or `"stanford"` or `"location-based"` or `"citation-only"` or `"dark"` | `"world"` |
 | **access:embargo:releaseDate** | *date-time* | Date when the DRO is released from an embargo. | `"2015-01-01T12:00:00Z"` |
 | **access:license** | *string* | The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.). | `"example"` |
-| **access:reuseAndReproductionStatement** | *string* | The human readable reuse and reproduction statement that applies to the DRO. | `"example"` |
+| **access:useAndReproductionStatement** | *string* | The human readable reuse and reproduction statement that applies to the DRO. | `"example"` |
 | **access:termsOfUse** | *string* | License or terms of use governing reuse of the DRO. Should be a text statement. | `"example"` |
 | **access:visibility** | *integer* | Percentage of the DRO that is visibility during an embargo period | `42` |
 | **administrative:created** | *date-time* | When the resource in SDR was created. | `"2015-01-01T12:00:00Z"` |

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -36,6 +36,8 @@ module Cocina
         attribute :embargo, Embargo.optional.meta(omittable: true)
         attribute :access, Types::String.default('dark')
                                         .enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
+        attribute :copyright, Types::Strict::String.meta(omittable: true)
+        attribute :reuseAndReproductionStatement, Types::Strict::String.meta(omittable: true)
       end
 
       # Subschema for administrative concerns

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -37,7 +37,7 @@ module Cocina
         attribute :access, Types::String.default('dark')
                                         .enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
         attribute :copyright, Types::Strict::String.meta(omittable: true)
-        attribute :reuseAndReproductionStatement, Types::Strict::String.meta(omittable: true)
+        attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
       end
 
       # Subschema for administrative concerns

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe Cocina::Models::DRO do
               releaseDate: '2009-12-14T07:00:00Z',
               access: 'world'
             },
-            access: 'stanford'
+            access: 'stanford',
+            copyright: 'All rights reserved unless otherwise indicated.',
+            reuseAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -147,6 +149,8 @@ RSpec.describe Cocina::Models::DRO do
         expect(item.label).to eq 'My object'
 
         expect(item.access.access).to eq 'stanford'
+        expect(item.access.copyright).to eq 'All rights reserved unless otherwise indicated.'
+        expect(item.access.reuseAndReproductionStatement).to eq 'Property rights reside with the repository...'
         expect(item.access.embargo.releaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
         expect(item.access.embargo.access).to eq 'world'
 

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Cocina::Models::DRO do
             },
             access: 'stanford',
             copyright: 'All rights reserved unless otherwise indicated.',
-            reuseAndReproductionStatement: 'Property rights reside with the repository...'
+            useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -150,7 +150,7 @@ RSpec.describe Cocina::Models::DRO do
 
         expect(item.access.access).to eq 'stanford'
         expect(item.access.copyright).to eq 'All rights reserved unless otherwise indicated.'
-        expect(item.access.reuseAndReproductionStatement).to eq 'Property rights reside with the repository...'
+        expect(item.access.useAndReproductionStatement).to eq 'Property rights reside with the repository...'
         expect(item.access.embargo.releaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
         expect(item.access.embargo.access).to eq 'world'
 

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Cocina::Models::RequestDRO do
             },
             access: 'stanford',
             copyright: 'All rights reserved unless otherwise indicated.',
-            reuseAndReproductionStatement: 'Property rights reside with the repository...'
+            useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -117,7 +117,7 @@ RSpec.describe Cocina::Models::RequestDRO do
 
         expect(item.access.access).to eq 'stanford'
         expect(item.access.copyright).to eq 'All rights reserved unless otherwise indicated.'
-        expect(item.access.reuseAndReproductionStatement).to eq 'Property rights reside with the repository...'
+        expect(item.access.useAndReproductionStatement).to eq 'Property rights reside with the repository...'
         expect(item.access.embargo.releaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
         expect(item.access.embargo.access).to eq 'stanford'
 

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -56,7 +56,10 @@ RSpec.describe Cocina::Models::RequestDRO do
             embargo: {
               releaseDate: '2009-12-14T07:00:00Z',
               access: 'stanford'
-            }
+            },
+            access: 'stanford',
+            copyright: 'All rights reserved unless otherwise indicated.',
+            reuseAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             hasAdminPolicy: 'druid:mx123cd4567',
@@ -112,6 +115,9 @@ RSpec.describe Cocina::Models::RequestDRO do
         expect(item.type).to eq item_type
         expect(item.label).to eq 'My object'
 
+        expect(item.access.access).to eq 'stanford'
+        expect(item.access.copyright).to eq 'All rights reserved unless otherwise indicated.'
+        expect(item.access.reuseAndReproductionStatement).to eq 'Property rights reside with the repository...'
         expect(item.access.embargo.releaseDate).to eq DateTime.parse('2009-12-14T07:00:00Z')
         expect(item.access.embargo.access).to eq 'stanford'
 


### PR DESCRIPTION
## Why was this change made?

To support properties required by rightsMetadata

## Was the documentation (README, wiki) updated?

n/a

## Does this change affect how this gem integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
