### PR TITLE
Group include statements in model classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-rspec
 
+Layout/ClassStructure:
+  Enabled: true
+
 Metrics/BlockLength:
   Exclude:
     - spec/cocina/**/*

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -5,10 +5,13 @@ module Cocina
     # An admin policy object.
     class AdminPolicy < Struct
       include Checkable
+      include AdminPolicyAttributes
 
       TYPES = [
         Vocab.admin_policy
       ].freeze
+
+      attribute :externalIdentifier, Types::Strict::String
 
       # Subschema for access concerns
       class Access < Struct
@@ -60,9 +63,6 @@ module Cocina
 
       class Structural < Struct
       end
-
-      include AdminPolicyAttributes
-      attribute :externalIdentifier, Types::Strict::String
 
       def self.from_dynamic(dyn)
         AdminPolicy.new(dyn)

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -6,6 +6,7 @@ module Cocina
     # See http://sul-dlss.github.io/cocina-models/maps/Collection.json
     class Collection < Struct
       include Checkable
+      include CollectionAttributes
 
       TYPES = [
         Vocab.collection,
@@ -14,6 +15,8 @@ module Cocina
         Vocab.series,
         Vocab.user_collection
       ].freeze
+
+      attribute :externalIdentifier, Types::Strict::String
 
       # Subschema for access concerns
       class Access < Struct
@@ -36,9 +39,6 @@ module Cocina
 
       class Structural < Struct
       end
-
-      include CollectionAttributes
-      attribute :externalIdentifier, Types::Strict::String
 
       def self.from_dynamic(dyn)
         Collection.new(dyn)

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -6,6 +6,7 @@ module Cocina
     # See http://sul-dlss.github.io/cocina-models/maps/DRO.json
     class DRO < Struct
       include Checkable
+      include DroAttributes
 
       TYPES = [
         Vocab.object,
@@ -24,6 +25,9 @@ module Cocina
         Vocab.webarchive_binary,
         Vocab.webarchive_seed
       ].freeze
+
+      attribute :externalIdentifier, Types::Strict::String
+      attribute(:structural, Structural.default { Structural.new })
 
       # Subschema for access concerns
       class Access < Struct
@@ -67,10 +71,6 @@ module Cocina
         attribute :isMemberOf, Types::Strict::String.meta(omittable: true)
         attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).meta(omittable: true)
       end
-
-      include DroAttributes
-      attribute :externalIdentifier, Types::Strict::String
-      attribute(:structural, Structural.default { Structural.new })
 
       def self.from_dynamic(dyn)
         DRO.new(dyn)

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -6,10 +6,13 @@ module Cocina
     # See http://sul-dlss.github.io/cocina-models/maps/File.json
     class File < Struct
       include Checkable
+      include FileAttributes
 
       TYPES = [
         Vocab.file
       ].freeze
+
+      attribute :externalIdentifier, Types::Strict::String
 
       # Represents access controls on the file
       class Access < Struct
@@ -40,9 +43,6 @@ module Cocina
 
       class Structural < Struct
       end
-
-      include FileAttributes
-      attribute :externalIdentifier, Types::Strict::String
 
       def self.from_dynamic(dyn)
         File.new(dyn)

--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -6,10 +6,14 @@ module Cocina
     # See http://sul-dlss.github.io/cocina-models/maps/Fileset.json
     class FileSet < Struct
       include Checkable
+      include FileSetAttributes
 
       TYPES = [
         Vocab.fileset
       ].freeze
+
+      attribute :externalIdentifier, Types::Strict::String
+      attribute(:structural, Structural.default { Structural.new })
 
       class Identification < Struct
       end
@@ -18,10 +22,6 @@ module Cocina
       class Structural < Struct
         attribute :contains, Types::Strict::Array.of(Cocina::Models::File).meta(omittable: true)
       end
-
-      include FileSetAttributes
-      attribute :externalIdentifier, Types::Strict::String
-      attribute(:structural, Structural.default { Structural.new })
 
       def self.from_dynamic(dyn)
         FileSet.new(dyn)


### PR DESCRIPTION
And pull attributes up between constants and inner classes. Solicit help from Rubocop in so doing.

## Why was this change made?

To make it easier to see at a glance where included code is pulled in.

## Was the documentation (README, wiki) updated?

No.

## Does this change affect how this gem integrates with other services?

No.