### PR TITLE
refactor file and request_file specs to use file_shared_examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,4 +18,4 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 15
+  Max: 18

--- a/spec/cocina/models/file_shared_examples.rb
+++ b/spec/cocina/models/file_shared_examples.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These shared_examples are meant to be used by File and RequestFile specs in
+# order to de-dup test code for all the functionality they have in common.
+# The caller must define required_properties as a hash containing
+#   the minimal required properties that must be provided to (Request)File.new
+RSpec.shared_examples 'it has file attributes' do
+  let(:item) { described_class.new(properties) }
+  let(:file_type) { 'http://cocina.sul.stanford.edu/models/file.jsonld' }
+  # see block comment for info about required_properties
+  let(:properties) { required_properties }
+
+  describe 'initialization' do
+    context 'with minimal required properties provided' do
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(item.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(item.label).to eq required_properties[:label]
+        expect(item.type).to eq required_properties[:type]
+        expect(item.version).to eq required_properties[:version]
+      end
+
+      it 'populates non-passed required attributes with default values' do
+        expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+        expect(item.administrative.shelve).to be false
+        expect(item.administrative.sdrPreserve).to be false
+
+        expect(item.hasMessageDigests).to eq []
+      end
+    end
+
+    context 'with a string version property' do
+      let(:properties) { required_properties.merge(version: required_properties[:version].to_s) }
+
+      it 'coerces to integer' do
+        expect(item.version).to eq required_properties[:version]
+      end
+    end
+
+    context 'with all optional properties provided' do
+      let(:properties) do
+        required_properties.merge(
+          access: {
+            access: 'citation-only'
+          },
+          administrative: {
+            shelve: true,
+            sdrPreserve: true
+          },
+          filename: 'filename!!',
+          hasMessageDigests: [
+            {
+              type: 'md5',
+              digest: 'd57db4241d7da0eecba5b33abf13f448'
+            },
+            {
+              type: 'sha1',
+              digest: '600a43324ea40ae1ba0c7ffa83965830d384c086'
+            }
+          ],
+          hasMimeType: 'image/jp2',
+          presentation: { height: 5, width: 8 },
+          size: 666,
+          structural: {},
+          use: 'transcription'
+        )
+      end
+
+      it 'populates all optional attributes passed in' do
+        expect(item.access).to be_kind_of(Cocina::Models::File::Access)
+        expect(item.access.access).to eq 'citation-only'
+
+        expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+        expect(item.administrative.shelve).to be true
+        expect(item.administrative.sdrPreserve).to be true
+
+        expect(item.filename).to eq 'filename!!'
+
+        expect(item.hasMessageDigests).to be_kind_of(Array)
+        expect(item.hasMessageDigests).to all(be_kind_of(Cocina::Models::File::Fixity))
+        fixity = item.hasMessageDigests.first
+        expect(fixity.type).to eq 'md5'
+        expect(fixity.digest).to eq 'd57db4241d7da0eecba5b33abf13f448'
+
+        expect(item.hasMimeType).to eq 'image/jp2'
+
+        expect(item.presentation).to be_kind_of(Cocina::Models::File::Presentation)
+        expect(item.presentation.height).to eq 5
+        expect(item.presentation.width).to eq 8
+
+        expect(item.size).to eq 666
+        expect(item.use).to eq 'transcription'
+      end
+
+      context 'with a string administrative boolean property' do
+        let(:properties) do
+          {
+            administrative: {
+              shelve: 'true',
+              sdrPreserve: 'false'
+            },
+            externalIdentifier: 'druid:ab123cd4567',
+            label: 'My file',
+            type: file_type,
+            version: '3'
+          }
+        end
+
+        it 'coerces to boolean' do
+          expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+          expect(item.administrative.shelve).to be true
+          expect(item.administrative.sdrPreserve).to be false
+        end
+      end
+    end
+
+    context 'with empty optional properties that have default values' do
+      let(:properties) do
+        required_properties.merge(
+          access: {},
+          filename: nil,
+          hasMessageDigests: [],
+          size: nil
+        )
+      end
+
+      it 'uses default values' do
+        expect(item.access).to be_kind_of(Cocina::Models::File::Access)
+        expect(item.access.access).to eq 'dark'
+
+        expect(item.filename).to eq nil
+        expect(item.hasMessageDigests).to eq []
+        expect(item.size).to eq nil
+      end
+    end
+  end
+
+  describe '.from_dynamic' do
+    let(:item) { described_class.from_dynamic(properties) }
+
+    context 'with empty subschemas' do
+      let(:properties) do
+        required_properties.merge(
+          'access' => {},
+          'identification' => {},
+          'structural' => {}
+        )
+      end
+
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(item.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(item.label).to eq required_properties[:label]
+        expect(item.type).to eq required_properties[:type]
+        expect(item.version).to eq required_properties[:version]
+      end
+
+      it 'populates non-passed required attributes with default values' do
+        expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+        expect(item.administrative.shelve).to be false
+        expect(item.administrative.sdrPreserve).to be false
+
+        expect(item.hasMessageDigests).to eq []
+      end
+
+      it 'populates optional attributes that have defaults' do
+        expect(item.access).to be_kind_of(Cocina::Models::File::Access)
+        expect(item.access.access).to eq 'dark'
+      end
+
+      it 'has a class responding to Dry::Struct methods for empty subschemas without defaults' do
+        expect(item.identification.attributes.size).to eq 0
+        expect(item.identification).to respond_to(:to_hash)
+        expect(item.structural.attributes.size).to eq 0
+        expect(item.structural).to respond_to(:to_hash)
+      end
+    end
+  end
+
+  describe '.from_json' do
+    subject(:item) { described_class.from_json(json) }
+
+    context 'with minimal required properties' do
+      let(:json) do
+        required_properties.to_json
+      end
+
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(item.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(item.label).to eq required_properties[:label]
+        expect(item.type).to eq required_properties[:type]
+        expect(item.version).to eq required_properties[:version]
+      end
+
+      it 'populates non-passed required attributes with default values' do
+        expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+        expect(item.administrative.shelve).to be false
+        expect(item.administrative.sdrPreserve).to be false
+
+        expect(item.hasMessageDigests).to eq []
+      end
+    end
+
+    context 'with optional attributes' do
+      let(:json) do
+        <<~JSON
+          {
+            "access": {
+              "access": "world"
+            },
+            "administrative":{
+              "sdrPreserve":false,
+              "shelve":true
+            },
+            "externalIdentifier": "druid:ab123cd4567",
+            "filename": "filename!!",
+            "label": "nrs_19180211_0003.tiff",
+            "hasMessageDigests": [
+              {
+                "type": "md5",
+                "digest": "d57db4241d7da0eecba5b33abf13f448"
+              },
+              {
+                "type": "sha1",
+                "digest": "600a43324ea40ae1ba0c7ffa83965830d384c086"
+              }
+            ],
+            "hasMimeType": "image/tiff",
+            "presentation": {
+              "height": 5679,
+              "width": 4437
+            },
+            "size": 25243531,
+            "type": "#{file_type}",
+            "use": "transcription",
+            "version": 3
+          }
+        JSON
+      end
+
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(item.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(item.label).to eq 'nrs_19180211_0003.tiff'
+        expect(item.type).to eq file_type
+        expect(item.version).to eq 3
+      end
+
+      it 'populates all optional attributes passed in' do
+        expect(item.access).to be_kind_of(Cocina::Models::File::Access)
+        expect(item.access.access).to eq 'world'
+
+        expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
+        expect(item.administrative.sdrPreserve).to be false
+        expect(item.administrative.shelve).to be true
+
+        expect(item.filename).to eq 'filename!!'
+
+        expect(item.hasMessageDigests).to be_kind_of(Array)
+        expect(item.hasMessageDigests).to all(be_kind_of(Cocina::Models::File::Fixity))
+        fixity = item.hasMessageDigests.first
+        expect(fixity.type).to eq 'md5'
+        expect(fixity.digest).to eq 'd57db4241d7da0eecba5b33abf13f448'
+
+        expect(item.hasMimeType).to eq 'image/tiff'
+
+        expect(item.presentation).to be_kind_of(Cocina::Models::File::Presentation)
+        expect(item.presentation.height).to eq 5679
+        expect(item.presentation.width).to eq 4437
+
+        expect(item.size).to eq 25_243_531
+        expect(item.use).to eq 'transcription'
+      end
+    end
+  end
+end

--- a/spec/cocina/models/file_spec.rb
+++ b/spec/cocina/models/file_spec.rb
@@ -1,202 +1,37 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+load 'spec/cocina/models/file_shared_examples.rb'
 
 RSpec.describe Cocina::Models::File do
-  subject(:item) { described_class.new(properties) }
-
   let(:file_type) { 'http://cocina.sul.stanford.edu/models/file.jsonld' }
-  let(:properties) do
+  let(:required_properties) do
     {
       externalIdentifier: 'druid:ab123cd4567',
-      type: file_type,
       label: 'My file',
+      type: file_type,
       version: 3
     }
   end
 
-  describe 'model check methods' do
+  it_behaves_like 'it has file attributes'
+
+  context 'when externalIdentifier is missing' do
+    let(:item) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
+
+    it 'raises a Dry::Struct::Error' do
+      err_msg = '[Cocina::Models::File.new] :externalIdentifier is missing in Hash input'
+      expect { item }.to raise_error(Dry::Struct::Error, err_msg)
+    end
+  end
+
+  describe 'Checkable model methods' do
+    subject { described_class.new(required_properties) }
+
     it { is_expected.not_to be_admin_policy }
     it { is_expected.not_to be_collection }
     it { is_expected.not_to be_dro }
     it { is_expected.to be_file }
     it { is_expected.not_to be_file_set }
-  end
-
-  describe 'initialization' do
-    context 'with a minimal set, as defined above' do
-      it 'has properties' do
-        expect(item.externalIdentifier).to eq 'druid:ab123cd4567'
-        expect(item.type).to eq file_type
-        expect(item.label).to eq 'My file'
-      end
-    end
-
-    context 'with a string version' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: file_type,
-          label: 'My file',
-          version: '3'
-        }
-      end
-
-      it 'coerces to integer' do
-        expect(item.version).to eq 3
-      end
-    end
-
-    context 'with a all properties' do
-      let(:properties) do
-        {
-          access: {
-            access: 'citation-only'
-          },
-          externalIdentifier: 'druid:ab123cd4567',
-          type: file_type,
-          label: 'My file',
-          version: 3,
-          administrative: {
-            shelve: true,
-            sdrPreserve: false
-          },
-          hasMessageDigests: [
-            {
-              type: 'md5',
-              digest: 'd57db4241d7da0eecba5b33abf13f448'
-            },
-            {
-              type: 'sha1',
-              digest: '600a43324ea40ae1ba0c7ffa83965830d384c086'
-            }
-          ],
-          hasMimeType: 'image/jp2'
-        }
-      end
-
-      it 'has properties' do
-        expect(item.access.access).to eq 'citation-only'
-
-        expect(item.externalIdentifier).to eq 'druid:ab123cd4567'
-        expect(item.type).to eq file_type
-        expect(item.label).to eq 'My file'
-
-        expect(item.hasMessageDigests).to all(be_kind_of(Cocina::Models::File::Fixity))
-        fixity = item.hasMessageDigests.first
-        expect(fixity.type).to eq 'md5'
-        expect(fixity.digest).to eq 'd57db4241d7da0eecba5b33abf13f448'
-
-        expect(item.administrative.shelve).to be true
-        expect(item.administrative.sdrPreserve).to be false
-      end
-    end
-  end
-
-  describe '.from_dynamic' do
-    subject(:item) { described_class.from_dynamic(properties) }
-
-    context 'with empty subschemas' do
-      let(:properties) do
-        {
-          'externalIdentifier' => 'druid:kv840rx2720',
-          'type' => file_type,
-          'label' => 'Examination of the memorial of the owners and underwriters ...',
-          'version' => 1,
-          'access' => {},
-          'hasMessageDigests' => [
-            {
-              'type' => 'md5',
-              'digest' => 'd57db4241d7da0eecba5b33abf13f448'
-            }
-          ],
-          'identification' => {},
-          'structural' => {}
-        }
-      end
-
-      it 'has properties' do
-        expect(item.externalIdentifier).to eq 'druid:kv840rx2720'
-      end
-    end
-  end
-
-  describe '.from_json' do
-    subject(:file) { described_class.from_json(json) }
-
-    context 'with a minimal object' do
-      let(:json) do
-        <<~JSON
-          {
-            "externalIdentifier":"druid:12343234",
-            "type":"#{file_type}",
-            "label":"my item",
-            "version": 3
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(file.attributes).to include(externalIdentifier: 'druid:12343234',
-                                           label: 'my item',
-                                           type: file_type)
-      end
-    end
-
-    context 'with a full object' do
-      let(:json) do
-        <<~JSON
-          {
-            "access": {
-              "access":"world"
-            },
-            "administrative":{
-              "sdrPreserve":false,
-              "shelve":true
-            },
-            "externalIdentifier":"druid:12343234",
-            "type":"#{file_type}",
-            "label":"nrs_19180211_0003.tiff",
-            "size":25243531,
-            "version": 3,
-            "use": "transcription",
-            "presentation": {
-              "height":5679,
-              "width":4437
-            },
-            "hasMessageDigests": [
-              {
-                "type":"md5",
-                "digest":"d57db4241d7da0eecba5b33abf13f448"
-              },
-              {
-                "type":"sha1",
-                "digest":"600a43324ea40ae1ba0c7ffa83965830d384c086"
-              }
-            ]
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(file.attributes).to include(externalIdentifier: 'druid:12343234',
-                                           label: 'nrs_19180211_0003.tiff',
-                                           type: file_type)
-
-        expect(file.access.access).to eq 'world'
-
-        digests = file.hasMessageDigests
-        expect(digests).to all(be_instance_of Cocina::Models::File::Fixity)
-        expect(digests.first.type).to eq 'md5'
-
-        expect(file.presentation.height).to eq 5679
-        expect(file.presentation.width).to eq 4437
-        expect(file.size).to eq 25_243_531
-        expect(file.use).to eq 'transcription'
-
-        expect(file.administrative.shelve).to be true
-        expect(file.administrative.sdrPreserve).to be false
-      end
-    end
   end
 end

--- a/spec/cocina/models/request_file_spec.rb
+++ b/spec/cocina/models/request_file_spec.rb
@@ -1,188 +1,26 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+load 'spec/cocina/models/file_shared_examples.rb'
 
 RSpec.describe Cocina::Models::RequestFile do
-  subject(:item) { described_class.new(properties) }
-
   let(:file_type) { 'http://cocina.sul.stanford.edu/models/file.jsonld' }
-
-  describe 'initialization' do
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          type: file_type,
-          label: 'My file',
-          version: 3
-        }
-      end
-
-      it 'has properties' do
-        expect(item.type).to eq file_type
-        expect(item.label).to eq 'My file'
-      end
-    end
-
-    context 'with a string version' do
-      let(:properties) do
-        {
-          type: file_type,
-          label: 'My file',
-          version: '3'
-        }
-      end
-
-      it 'coerces to integer' do
-        expect(item.version).to eq 3
-      end
-    end
-
-    context 'with a all properties' do
-      let(:properties) do
-        {
-          access: {
-            access: 'citation-only'
-          },
-          type: file_type,
-          label: 'My file',
-          version: 3,
-          administrative: {
-            shelve: true,
-            sdrPreserve: false
-          },
-          hasMessageDigests: [
-            {
-              type: 'md5',
-              digest: 'd57db4241d7da0eecba5b33abf13f448'
-            },
-            {
-              type: 'sha1',
-              digest: '600a43324ea40ae1ba0c7ffa83965830d384c086'
-            }
-          ],
-          hasMimeType: 'image/jp2'
-        }
-      end
-
-      it 'has properties' do
-        expect(item.access.access).to eq 'citation-only'
-
-        expect(item.hasMimeType).to eq 'image/jp2'
-        expect(item.type).to eq file_type
-        expect(item.label).to eq 'My file'
-
-        expect(item.hasMessageDigests).to all(be_kind_of(Cocina::Models::File::Fixity))
-        fixity = item.hasMessageDigests.first
-        expect(fixity.type).to eq 'md5'
-        expect(fixity.digest).to eq 'd57db4241d7da0eecba5b33abf13f448'
-
-        expect(item.administrative.shelve).to be true
-        expect(item.administrative.sdrPreserve).to be false
-      end
-    end
+  let(:required_properties) do
+    {
+      label: 'My file',
+      type: file_type,
+      version: 3
+    }
   end
 
-  describe '.from_dynamic' do
-    subject(:item) { described_class.from_dynamic(properties) }
+  it_behaves_like 'it has file attributes'
 
-    context 'with empty subschemas' do
-      let(:properties) do
-        {
-          'type' => file_type,
-          'label' => 'Examination of the memorial of the owners and underwriters ...',
-          'version' => 1,
-          'access' => {},
-          'hasMessageDigests' => [
-            {
-              'type' => 'md5',
-              'digest' => 'd57db4241d7da0eecba5b33abf13f448'
-            }
-          ],
-          'identification' => {},
-          'structural' => {}
-        }
-      end
-
-      it 'has properties' do
-        expect(item.type).to eq file_type
-      end
-    end
-  end
-
-  describe '.from_json' do
-    subject(:file) { described_class.from_json(json) }
-
-    context 'with a minimal object' do
-      let(:json) do
-        <<~JSON
-          {
-            "type":"#{file_type}",
-            "label":"my item",
-            "version": 3
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(file.attributes).to include(label: 'my item',
-                                           type: file_type)
-      end
-    end
-
-    context 'with a full object' do
-      let(:json) do
-        <<~JSON
-          {
-            "access": {
-              "access":"world"
-            },
-            "administrative":{
-              "sdrPreserve":false,
-              "shelve":true
-            },
-            "type":"#{file_type}",
-            "label":"nrs_19180211_0003.tiff",
-            "size":25243531,
-            "version": 3,
-            "use": "transcription",
-            "presentation": {
-              "height":5679,
-              "width":4437
-            },
-            "hasMessageDigests": [
-              {
-                "type":"md5",
-                "digest":"d57db4241d7da0eecba5b33abf13f448"
-              },
-              {
-                "type":"sha1",
-                "digest":"600a43324ea40ae1ba0c7ffa83965830d384c086"
-              }
-            ],
-            "hasMimeType":"image/jp2"
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(file.attributes).to include(label: 'nrs_19180211_0003.tiff',
-                                           type: file_type,
-                                           hasMimeType: 'image/jp2')
-
-        expect(file.access.access).to eq 'world'
-
-        digests = file.hasMessageDigests
-        expect(digests).to all(be_instance_of Cocina::Models::File::Fixity)
-        expect(digests.first.type).to eq 'md5'
-
-        expect(file.presentation.height).to eq 5679
-        expect(file.presentation.width).to eq 4437
-        expect(file.size).to eq 25_243_531
-        expect(file.use).to eq 'transcription'
-
-        expect(file.administrative.shelve).to be true
-        expect(file.administrative.sdrPreserve).to be false
-      end
-    end
+  it 'does not have Checkable model methods' do
+    item = described_class.new(required_properties)
+    expect(item).not_to respond_to(:admin_policy?)
+    expect(item).not_to respond_to(:collection?)
+    expect(item).not_to respond_to(:dro?)
+    expect(item).not_to respond_to(:file?)
+    expect(item).not_to respond_to(:file_set?)
   end
 end


### PR DESCRIPTION
## Why was this change made?

- Reduce duplication of test code
- Ensure File and RequestFile models stay in sync.

Part of #70

## Was the documentation (README, wiki) updated?

na

## Does this change affect how this gem integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
