### PR TITLE
refactor (request_)admin_policy specs to use admin_policy_shared_examples

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -50,7 +50,7 @@ module Cocina
         # which workflow to start when registering (used by Web Archive apos to start wasCrawlPreassemblyWF)
         attribute :registration_workflow, Types::String.optional.default(nil)
 
-        # Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
+        # TODO: Allowing hasAdminPolicy to be omittable for now (until rolled out to consumers),
         # but I think it's actually required for every Admin Policy
         attribute :hasAdminPolicy, Types::Coercible::String.optional.default(nil)
       end

--- a/lib/cocina/models/admin_policy_attributes.rb
+++ b/lib/cocina/models/admin_policy_attributes.rb
@@ -7,7 +7,7 @@ module Cocina
       def self.included(obj)
         obj.attribute(:access, AdminPolicy::Access.default { AdminPolicy::Access.new })
         obj.attribute(:administrative, AdminPolicy::Administrative.default { AdminPolicy::Administrative.new })
-        # Allowing description to be omittable for now (until rolled out to consumers),
+        # TODO: Allowing description to be omittable for now (until rolled out to consumers),
         # but I think it's actually required for every admin policy
         obj.attribute :description, Description.optional.meta(omittable: true)
         obj.attribute(:identification, AdminPolicy::Identification.default { AdminPolicy::Identification.new })

--- a/spec/cocina/models/admin_policy_shared_examples.rb
+++ b/spec/cocina/models/admin_policy_shared_examples.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These shared_examples are meant to be used by AdminPolicy and RequestAdminPolicy specs in
+# order to de-dup test code for all the functionality they have in common.
+# The caller must define required_properties as a hash containing
+#   the minimal required properties that must be provided to (Request)AdminPolicy.new
+RSpec.shared_examples 'it has admin_policy attributes' do
+  let(:admin_policy) { described_class.new(properties) }
+  let(:type) { Cocina::Models::Vocab.admin_policy }
+  # see block comment for info about required_properties
+  let(:properties) { required_properties }
+  let(:admin_policy_default_rights) { Cocina::Models::AdminPolicy::Administrative::DEFAULT_OBJECT_RIGHTS }
+
+  describe 'initialization' do
+    context 'with minimal required properties provided' do
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(admin_policy.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(admin_policy.label).to eq required_properties[:label]
+        expect(admin_policy.type).to eq required_properties[:type]
+        expect(admin_policy.version).to eq required_properties[:version]
+      end
+
+      it 'populates non-passed required attributes with default values' do
+        expect(admin_policy.access).to be_kind_of(Cocina::Models::AdminPolicy::Access)
+        expect(admin_policy.access.attributes.size).to eq 0
+
+        expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicy::Administrative)
+        expect(admin_policy.administrative.default_object_rights).to eq admin_policy_default_rights
+        expect(admin_policy.administrative.registration_workflow).to be_nil
+        expect(admin_policy.administrative.hasAdminPolicy).to be_nil
+
+        expect(admin_policy.identification).to be_kind_of(Cocina::Models::AdminPolicy::Identification)
+        expect(admin_policy.identification.attributes.size).to eq 0
+
+        expect(admin_policy.structural).to be_kind_of(Cocina::Models::AdminPolicy::Structural)
+        expect(admin_policy.structural.attributes.size).to eq 0
+      end
+    end
+
+    context 'with a string version property' do
+      let(:properties) { required_properties.merge(version: required_properties[:version].to_s) }
+
+      it 'coerces to integer' do
+        expect(admin_policy.version).to eq required_properties[:version]
+      end
+    end
+
+    context 'with all specifiable properties' do
+      let(:properties) do
+        required_properties.merge(
+          administrative: {
+            default_object_rights: '<rightsMetadata></rightsMetadata>',
+            registration_workflow: 'wasCrawlPreassemblyWF',
+            hasAdminPolicy: 'druid:mx123cd4567'
+          },
+          description: {
+            title: [
+              {
+                primary: true,
+                titleFull: 'My admin_policy'
+              }
+            ]
+          }
+        )
+      end
+
+      it 'populates all attributes passed in' do
+        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
+        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
+
+        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
+                                                                      titleFull: 'My admin_policy')
+      end
+
+      context 'with a string description title primary boolean property' do
+        let(:properties) do
+          required_properties.merge(
+            administrative: {
+              default_object_rights: '<rightsMetadata></rightsMetadata>',
+              registration_workflow: 'wasCrawlPreassemblyWF',
+              hasAdminPolicy: 'druid:mx123cd4567'
+            },
+            description: {
+              title: [
+                {
+                  primary: 'true',
+                  titleFull: 'My admin_policy'
+                }
+              ]
+            }
+          )
+        end
+
+        it 'raises a Dry::Struct::Error' do
+          err_msg = '[Cocina::Models::Description::Title.new] "true" (String) ' \
+                    'has invalid type for :primary violates constraints (type?(FalseClass, "true") failed)'
+          expect { admin_policy }.to raise_error(Dry::Struct::Error, err_msg)
+        end
+      end
+    end
+
+    context 'with empty optional properties that have default values' do
+      let(:properties) { required_properties.merge(administrative: nil) }
+
+      it 'uses default values' do
+        expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicy::Administrative)
+        expect(admin_policy.administrative.default_object_rights).to eq admin_policy_default_rights
+        expect(admin_policy.administrative.registration_workflow).to be_nil
+        expect(admin_policy.administrative.hasAdminPolicy).to be_nil
+      end
+    end
+  end
+
+  describe '.from_dynamic' do
+    let(:admin_policy) { described_class.from_dynamic(properties) }
+
+    context 'with empty subschemas' do
+      let(:properties) do
+        required_properties.merge(
+          'access' => {},
+          'administrative' => {},
+          'description' => {
+            'title' => []
+          },
+          'identification' => {},
+          'structural' => {}
+        )
+      end
+
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(admin_policy.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(admin_policy.label).to eq required_properties[:label]
+        expect(admin_policy.type).to eq required_properties[:type]
+        expect(admin_policy.version).to eq required_properties[:version]
+
+        expect(admin_policy.description).to be_kind_of(Cocina::Models::Description)
+        expect(admin_policy.description.attributes.size).to eq 1
+        expect(admin_policy.description.title).to be_kind_of(Array)
+        expect(admin_policy.description.title.size).to eq 0
+      end
+
+      it 'populates attribute subschemas with default values' do
+        expect(admin_policy.access).to be_kind_of(Cocina::Models::AdminPolicy::Access)
+        expect(admin_policy.access.attributes.size).to eq 0
+
+        expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicy::Administrative)
+        expect(admin_policy.administrative.default_object_rights).to eq admin_policy_default_rights
+        expect(admin_policy.administrative.registration_workflow).to be_nil
+        expect(admin_policy.administrative.hasAdminPolicy).to be_nil
+
+        expect(admin_policy.identification).to be_kind_of(Cocina::Models::AdminPolicy::Identification)
+        expect(admin_policy.identification.attributes.size).to eq 0
+
+        expect(admin_policy.structural).to be_kind_of(Cocina::Models::AdminPolicy::Structural)
+        expect(admin_policy.structural.attributes.size).to eq 0
+      end
+    end
+  end
+
+  describe '.from_json' do
+    let(:admin_policy) { described_class.from_json(json) }
+
+    context 'with minimal required properties' do
+      let(:json) do
+        required_properties.to_json
+      end
+
+      it 'populates required attributes passed in' do
+        if required_properties[:externalIdentifier]
+          expect(admin_policy.externalIdentifier).to eq required_properties[:externalIdentifier]
+        end
+        expect(admin_policy.label).to eq required_properties[:label]
+        expect(admin_policy.type).to eq required_properties[:type]
+        expect(admin_policy.version).to eq required_properties[:version]
+      end
+
+      it 'populates non-passed required attributes with default values' do
+        expect(admin_policy.access).to be_kind_of(Cocina::Models::AdminPolicy::Access)
+        expect(admin_policy.access.attributes.size).to eq 0
+
+        expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicy::Administrative)
+        expect(admin_policy.administrative.default_object_rights).to eq admin_policy_default_rights
+        expect(admin_policy.administrative.registration_workflow).to be_nil
+        expect(admin_policy.administrative.hasAdminPolicy).to be_nil
+
+        expect(admin_policy.identification).to be_kind_of(Cocina::Models::AdminPolicy::Identification)
+        expect(admin_policy.identification.attributes.size).to eq 0
+
+        expect(admin_policy.structural).to be_kind_of(Cocina::Models::AdminPolicy::Structural)
+        expect(admin_policy.structural.attributes.size).to eq 0
+      end
+    end
+
+    context 'with optional attributes' do
+      let(:json) do
+        <<~JSON
+          {
+            "externalIdentifier":"druid:12343234",
+            "type":"#{type}",
+            "label":"my admin_policy",
+            "version": 3,
+            "access": {
+            },
+            "administrative": {
+              "default_object_rights":"<rightsMetadata></rightsMetadata>",
+              "registration_workflow":"wasCrawlPreassemblyWF",
+              "hasAdminPolicy":"druid:mx123cd4567"
+            },
+            "description": {
+              "title": [
+                {
+                  "primary": true,
+                  "titleFull":"my admin_policy"
+                }
+              ]
+            }
+          }
+        JSON
+      end
+
+      it 'populates required attributes passed in' do
+        expect(admin_policy.externalIdentifier).to eq 'druid:12343234' if required_properties[:externalIdentifier]
+        expect(admin_policy.label).to eq 'my admin_policy'
+        expect(admin_policy.type).to eq type
+        expect(admin_policy.version).to eq 3
+      end
+
+      it 'populates all optional attributes passed in' do
+        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
+        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
+        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
+        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
+
+        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
+                                                                      titleFull: 'my admin_policy')
+      end
+    end
+  end
+end

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -1,195 +1,39 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+load 'spec/cocina/models/admin_policy_shared_examples.rb'
 
 RSpec.describe Cocina::Models::AdminPolicy do
-  subject(:admin_policy) { described_class.new(properties) }
-
-  let(:properties) do
+  let(:type) { Cocina::Models::Vocab.admin_policy }
+  # TODO: Allowing description to be omittable for now (until rolled out to consumers),
+  # but I think it's actually required for every admin policy
+  let(:required_properties) do
     {
       externalIdentifier: 'druid:ab123cd4567',
-      type: type,
       label: 'My admin_policy',
-      version: 3,
-      description: {
-        title: []
-      }
+      type: type,
+      version: 3
     }
   end
-  let(:type) { Cocina::Models::Vocab.admin_policy }
 
-  describe 'model check methods' do
+  it_behaves_like 'it has admin_policy attributes'
+
+  context 'when externalIdentifier is missing' do
+    let(:admin_policy) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
+
+    it 'raises a Dry::Struct::Error' do
+      err_msg = '[Cocina::Models::AdminPolicy.new] :externalIdentifier is missing in Hash input'
+      expect { admin_policy }.to raise_error(Dry::Struct::Error, err_msg)
+    end
+  end
+
+  describe 'Checkable model methods' do
+    subject { described_class.new(required_properties) }
+
     it { is_expected.to be_admin_policy }
     it { is_expected.not_to be_collection }
     it { is_expected.not_to be_dro }
     it { is_expected.not_to be_file }
     it { is_expected.not_to be_file_set }
-  end
-
-  describe 'initialization' do
-    context 'with a minimal set, defined above' do
-      it 'has properties' do
-        expect(admin_policy.externalIdentifier).to eq 'druid:ab123cd4567'
-        expect(admin_policy.type).to eq type
-        expect(admin_policy.label).to eq 'My admin_policy'
-
-        expect(admin_policy.access).to be_kind_of Cocina::Models::AdminPolicy::Access
-      end
-    end
-
-    context 'with a string version' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: type,
-          label: 'My admin_policy',
-          version: '3',
-          description: {
-            title: []
-          }
-        }
-      end
-
-      it 'coerces to integer' do
-        expect(admin_policy.version).to eq 3
-      end
-    end
-
-    context 'with all properties' do
-      let(:properties) do
-        {
-          externalIdentifier: 'druid:ab123cd4567',
-          type: type,
-          label: 'My admin_policy',
-          version: 3,
-          access: {
-          },
-          administrative: {
-            default_object_rights: '<rightsMetadata></rightsMetadata>',
-            registration_workflow: 'wasCrawlPreassemblyWF',
-            hasAdminPolicy: 'druid:mx123cd4567'
-          },
-          description: {
-            title: [
-              {
-                primary: true,
-                titleFull: 'My admin_policy'
-              }
-            ]
-          }
-        }
-      end
-
-      it 'has properties' do
-        expect(admin_policy.externalIdentifier).to eq 'druid:ab123cd4567'
-        expect(admin_policy.type).to eq type
-        expect(admin_policy.label).to eq 'My admin_policy'
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
-        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
-      end
-    end
-  end
-
-  describe '.from_dynamic' do
-    subject(:admin_policy) { described_class.from_dynamic(properties) }
-
-    context 'with empty subschemas' do
-      let(:properties) do
-        {
-          'externalIdentifier' => 'druid:kv840rx2720',
-          'type' => type,
-          'label' => 'Examination of the memorial of the owners and underwriters ...',
-          'version' => 1,
-          'access' => {},
-          'administrative' => {
-            'default_object_rights' => '<rightsMetadata></rightsMetadata>',
-            'registration_workflow' => 'wasCrawlPreassemblyWF',
-            'hasAdminPolicy' => 'druid:mx123cd4567'
-          },
-          'description' => {
-            'title' => []
-          },
-          'identification' => {},
-          'structural' => {}
-        }
-      end
-
-      it 'has properties' do
-        expect(admin_policy.externalIdentifier).to eq 'druid:kv840rx2720'
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
-        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
-      end
-    end
-  end
-
-  describe '.from_json' do
-    subject(:admin_policy) { described_class.from_json(json) }
-
-    context 'with a minimal admin_policy' do
-      let(:json) do
-        <<~JSON
-          {
-            "externalIdentifier":"druid:12343234",
-            "type":"#{type}",
-            "label":"my admin_policy",
-            "version": 3,
-            "description": {
-              "title": []
-            }
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(admin_policy.attributes).to include(externalIdentifier: 'druid:12343234',
-                                                   label: 'my admin_policy',
-                                                   type: type)
-        expect(admin_policy.access).to be_kind_of Cocina::Models::AdminPolicy::Access
-        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
-        expect(admin_policy.identification).to be_kind_of Cocina::Models::AdminPolicy::Identification
-        expect(admin_policy.structural).to be_kind_of Cocina::Models::AdminPolicy::Structural
-      end
-    end
-
-    context 'with a full admin_policy' do
-      let(:json) do
-        <<~JSON
-          {
-            "externalIdentifier":"druid:12343234",
-            "type":"#{type}",
-            "label":"my admin_policy",
-            "version": 3,
-            "access": {
-            },
-            "administrative": {
-              "default_object_rights":"<rightsMetadata></rightsMetadata>",
-              "registration_workflow":"wasCrawlPreassemblyWF",
-              "hasAdminPolicy":"druid:mx123cd4567"
-            },
-            "description": {
-              "title": [
-                {
-                  "primary": true,
-                  "titleFull":"my admin_policy"
-                }
-              ]
-            }
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(admin_policy.attributes).to include(externalIdentifier: 'druid:12343234',
-                                                   label: 'my admin_policy',
-                                                   type: type)
-
-        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
-                                                                      titleFull: 'my admin_policy')
-      end
-    end
   end
 end

--- a/spec/cocina/models/request_admin_policy_spec.rb
+++ b/spec/cocina/models/request_admin_policy_spec.rb
@@ -1,178 +1,26 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+load 'spec/cocina/models/admin_policy_shared_examples.rb'
 
 RSpec.describe Cocina::Models::RequestAdminPolicy do
-  subject(:admin_policy) { described_class.new(properties) }
-
   let(:type) { Cocina::Models::Vocab.admin_policy }
-
-  describe 'initialization' do
-    context 'with a minimal set' do
-      let(:properties) do
-        {
-          type: type,
-          label: 'My admin_policy',
-          version: 3,
-          description: {
-            title: []
-          }
-        }
-      end
-
-      it 'has properties' do
-        expect(admin_policy.type).to eq type
-        expect(admin_policy.label).to eq 'My admin_policy'
-
-        expect(admin_policy.access).to be_kind_of Cocina::Models::AdminPolicy::Access
-      end
-    end
-
-    context 'with a string version' do
-      let(:properties) do
-        {
-          type: type,
-          label: 'My admin_policy',
-          version: '3',
-          description: {
-            title: []
-          }
-        }
-      end
-
-      it 'coerces to integer' do
-        expect(admin_policy.version).to eq 3
-      end
-    end
-
-    context 'with all properties' do
-      let(:properties) do
-        {
-          type: type,
-          label: 'My admin_policy',
-          version: 3,
-          access: {
-          },
-          administrative: {
-            default_object_rights: '<rightsMetadata></rightsMetadata>',
-            registration_workflow: 'wasCrawlPreassemblyWF',
-            hasAdminPolicy: 'druid:mx123cd4567'
-          },
-          description: {
-            title: [
-              {
-                primary: true,
-                titleFull: 'My admin_policy'
-              }
-            ]
-          }
-        }
-      end
-
-      it 'has properties' do
-        expect(admin_policy.type).to eq type
-        expect(admin_policy.label).to eq 'My admin_policy'
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
-        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
-      end
-    end
+  let(:required_properties) do
+    {
+      type: type,
+      label: 'My admin_policy',
+      version: 3
+    }
   end
 
-  describe '.from_dynamic' do
-    subject(:admin_policy) { described_class.from_dynamic(properties) }
+  it_behaves_like 'it has admin_policy attributes'
 
-    context 'with empty subschemas' do
-      let(:properties) do
-        {
-          'type' => type,
-          'label' => 'Examination of the memorial of the owners and underwriters ...',
-          'version' => 1,
-          'access' => {},
-          'administrative' => {
-            'default_object_rights' => '<rightsMetadata></rightsMetadata>',
-            'registration_workflow' => 'wasCrawlPreassemblyWF',
-            'hasAdminPolicy' => 'druid:mx123cd4567'
-          },
-          'description' => {
-            'title' => []
-          },
-          'identification' => {},
-          'structural' => {}
-        }
-      end
-
-      it 'has properties' do
-        expect(admin_policy.label).to eq 'Examination of the memorial of the owners and underwriters ...'
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.administrative.default_object_rights).to eq '<rightsMetadata></rightsMetadata>'
-        expect(admin_policy.administrative.registration_workflow).to eq 'wasCrawlPreassemblyWF'
-      end
-    end
-  end
-
-  describe '.from_json' do
-    subject(:admin_policy) { described_class.from_json(json) }
-
-    context 'with a minimal admin_policy' do
-      let(:json) do
-        <<~JSON
-          {
-            "type":"#{type}",
-            "label":"my admin_policy",
-            "version": 3,
-            "description": {
-              "title": []
-            }
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(admin_policy.attributes).to include(label: 'my admin_policy',
-                                                   type: type)
-        expect(admin_policy.access).to be_kind_of Cocina::Models::AdminPolicy::Access
-        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
-        expect(admin_policy.identification).to be_kind_of Cocina::Models::AdminPolicy::Identification
-        expect(admin_policy.structural).to be_kind_of Cocina::Models::AdminPolicy::Structural
-      end
-    end
-
-    context 'with a full admin_policy' do
-      let(:json) do
-        <<~JSON
-          {
-            "type":"#{type}",
-            "label":"my admin_policy",
-            "version": 3,
-            "access": {
-            },
-            "administrative": {
-              "default_object_rights":"<rightsMetadata></rightsMetadata>",
-              "registration_workflow":"wasCrawlPreassemblyWF",
-              "hasAdminPolicy":"druid:mx123cd4567"
-            },
-            "description": {
-              "title": [
-                {
-                  "primary": true,
-                  "titleFull":"my admin_policy"
-                }
-              ]
-            }
-          }
-        JSON
-      end
-
-      it 'has the attributes' do
-        expect(admin_policy.attributes).to include(label: 'my admin_policy',
-                                                   type: type)
-
-        expect(admin_policy.administrative).to be_kind_of Cocina::Models::AdminPolicy::Administrative
-        expect(admin_policy.administrative.hasAdminPolicy).to eq 'druid:mx123cd4567'
-        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
-                                                                      titleFull: 'my admin_policy')
-      end
-    end
+  it 'does not have Checkable model methods' do
+    item = described_class.new(required_properties)
+    expect(item).not_to respond_to(:admin_policy?)
+    expect(item).not_to respond_to(:collection?)
+    expect(item).not_to respond_to(:dro?)
+    expect(item).not_to respond_to(:file?)
+    expect(item).not_to respond_to(:file_set?)
   end
 end


### PR DESCRIPTION
## Why was this change made?

-    Reduce duplication of test code
-    Ensure AdminPolicy and RequestAdminPolicy models stay in sync.

Part of #70  (akin to PR #75 for File and RequestFile models)

## Was the documentation (README, wiki) updated?

na