### PR TITLE
description and release_tag specs for string coerced to boolean

### DIFF
--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -6,7 +6,7 @@ module Cocina
     class Description < Struct
       # Title element.  See http://sul-dlss.github.io/cocina-models/maps/Title.json
       class Title < Struct
-        attribute :primary, Types::Strict::Bool
+        attribute :primary, Types::Params::Bool # will coerce 'true' to true
         attribute :titleFull, Types::Strict::String
       end
 

--- a/lib/cocina/models/release_tag.rb
+++ b/lib/cocina/models/release_tag.rb
@@ -9,7 +9,7 @@ module Cocina
       # we use 'when' other places, but that's reserved word, so 'date' it is!
       attribute :date, Types::Params::DateTime
       attribute :who, Types::Strict::String
-      attribute :release, Types::Params::Bool
+      attribute :release, Types::Params::Bool # will coerce 'true' to true
 
       def self.from_dynamic(dyn)
         ReleaseTag.new(dyn)

--- a/spec/cocina/models/admin_policy_shared_examples.rb
+++ b/spec/cocina/models/admin_policy_shared_examples.rb
@@ -76,32 +76,6 @@ RSpec.shared_examples 'it has admin_policy attributes' do
         expect(admin_policy.description.title.first.attributes).to eq(primary: true,
                                                                       titleFull: 'My admin_policy')
       end
-
-      context 'with a string description title primary boolean property' do
-        let(:properties) do
-          required_properties.merge(
-            administrative: {
-              default_object_rights: '<rightsMetadata></rightsMetadata>',
-              registration_workflow: 'wasCrawlPreassemblyWF',
-              hasAdminPolicy: 'druid:mx123cd4567'
-            },
-            description: {
-              title: [
-                {
-                  primary: 'true',
-                  titleFull: 'My admin_policy'
-                }
-              ]
-            }
-          )
-        end
-
-        it 'raises a Dry::Struct::Error' do
-          err_msg = '[Cocina::Models::Description::Title.new] "true" (String) ' \
-                    'has invalid type for :primary violates constraints (type?(FalseClass, "true") failed)'
-          expect { admin_policy }.to raise_error(Dry::Struct::Error, err_msg)
-        end
-      end
     end
 
     context 'with empty optional properties that have default values' do
@@ -168,9 +142,7 @@ RSpec.shared_examples 'it has admin_policy attributes' do
     let(:admin_policy) { described_class.from_json(json) }
 
     context 'with minimal required properties' do
-      let(:json) do
-        required_properties.to_json
-      end
+      let(:json) { required_properties.to_json }
 
       it 'populates required attributes passed in' do
         if required_properties[:externalIdentifier]

--- a/spec/cocina/models/description_spec.rb
+++ b/spec/cocina/models/description_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Description do
+  context 'with title primary property as string' do
+    let(:instance) { described_class.new(properties) }
+    let(:properties) do
+      {
+        title: [
+          {
+            primary: 'true',
+            titleFull: 'true as string'
+          },
+          {
+            primary: 'false',
+            titleFull: 'false as string'
+          }
+        ]
+      }
+    end
+
+    it 'coerces to boolean' do
+      expect(instance.title.first.primary).to eq true
+      expect(instance.title.last.primary).to eq false
+    end
+  end
+end

--- a/spec/cocina/models/release_tag_spec.rb
+++ b/spec/cocina/models/release_tag_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::ReleaseTag do
+  context 'with release property as string' do
+    let(:instance) { described_class.new(properties) }
+    let(:properties) do
+      {
+        who: 'Justin',
+        what: 'collection',
+        date: '2018-11-23T00:44:52Z',
+        to: 'Searchworks',
+        release: 'true'
+      }
+    end
+
+    it 'coerces to boolean' do
+      expect(instance.release).to eq true
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

in https://github.com/sul-dlss/cocina-models/pull/76#discussion_r387955380, @justinlittman rightly questioned why I was testing that a string boolean value passed as a Description model attribute raised an error.  This PR:

- changes the Description model to have a coercible boolean value
    - I can't see the point in making it more restrictive than the other boolean types in ReleaseTag and File.Adminstrative
- has specs specific to the files declaring the models with coercible boolean values
    - just as we show the version attribute to be coercible from a string in checkable model tests
- removes the spec in admin_policy_shared_examples from PR #76 that started this whole mess.

## Was the documentation (README, wiki) updated?

na