### PR TITLE
file spec tests subschema type coercion in right place

### DIFF
--- a/spec/cocina/models/file_shared_examples.rb
+++ b/spec/cocina/models/file_shared_examples.rb
@@ -94,27 +94,6 @@ RSpec.shared_examples 'it has file attributes' do
         expect(item.size).to eq 666
         expect(item.use).to eq 'transcription'
       end
-
-      context 'with a string administrative boolean property' do
-        let(:properties) do
-          {
-            administrative: {
-              shelve: 'true',
-              sdrPreserve: 'false'
-            },
-            externalIdentifier: 'druid:ab123cd4567',
-            label: 'My file',
-            type: file_type,
-            version: '3'
-          }
-        end
-
-        it 'coerces to boolean' do
-          expect(item.administrative).to be_kind_of(Cocina::Models::File::Administrative)
-          expect(item.administrative.shelve).to be true
-          expect(item.administrative.sdrPreserve).to be false
-        end
-      end
     end
 
     context 'with empty optional properties that have default values' do

--- a/spec/cocina/models/file_spec.rb
+++ b/spec/cocina/models/file_spec.rb
@@ -34,4 +34,40 @@ RSpec.describe Cocina::Models::File do
     it { is_expected.to be_file }
     it { is_expected.not_to be_file_set }
   end
+
+  describe Cocina::Models::File::Administrative do
+    let(:instance) { described_class.new(properties) }
+
+    context 'with boolean properties as strings' do
+      let(:properties) do
+        {
+          shelve: 'true',
+          sdrPreserve: 'false'
+        }
+      end
+
+      it 'coerces to boolean' do
+        expect(instance.shelve).to be true
+        expect(instance.sdrPreserve).to be false
+      end
+    end
+  end
+
+  describe Cocina::Models::File::Presentation do
+    let(:instance) { described_class.new(properties) }
+
+    context 'with height and width as strings' do
+      let(:properties) do
+        {
+          height: '666',
+          width: '777'
+        }
+      end
+
+      it 'coerces to integer' do
+        expect(instance.height).to eq 666
+        expect(instance.width).to eq 777
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Tests for the subschemas defined in a Model should go with the model spec.

## Was the documentation (README, wiki) updated?

na