### PR TITLE
Adds externalIdentifier as optional attribute of Request File.

### DIFF
--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -7,6 +7,9 @@ module Cocina
     # See http://sul-dlss.github.io/cocina-models/maps/File.json
     class RequestFile < Struct
       include FileAttributes
+      # externalIdentifier is used when submitting files to the SDR API to identify the file so that the
+      # uploaded files can be associated with the DRO.
+      attribute :externalIdentifier, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/spec/cocina/models/request_file_spec.rb
+++ b/spec/cocina/models/request_file_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe Cocina::Models::RequestFile do
   end
 
   it_behaves_like 'it has file attributes'
+
+  context 'when externalIdentifier provided' do
+    let(:item) { described_class.new(properties) }
+
+    let(:properties) do
+      { externalIdentifier: 'abc123' }.merge(required_properties)
+    end
+
+    it 'has externalIdentifier attribute' do
+      expect(item.externalIdentifier).to eq('abc123')
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
External identifier is used by SDR API.


## Was the documentation (README, wiki) updated?
No.