### PR TITLE
Adds partOfProject to Dro.

### DIFF
--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -48,6 +48,7 @@ module Cocina
         # but I think it's actually required for every DRO
         attribute :hasAdminPolicy, Types::Strict::String.optional.default(nil)
         attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true).default([].freeze)
+        attribute :partOfProject, Types::Strict::String.meta(omittable: true)
       end
 
       # Identification sub-schema for the DRO

--- a/spec/cocina/models/dro_shared_examples.rb
+++ b/spec/cocina/models/dro_shared_examples.rb
@@ -79,7 +79,8 @@ RSpec.shared_examples 'it has dro attributes' do
                 to: 'Searchworks',
                 release: false
               }
-            ]
+            ],
+            partOfProject: 'Google Books'
           },
           description: {
             title: [
@@ -135,6 +136,7 @@ RSpec.shared_examples 'it has dro attributes' do
         expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
         expect(tag.to).to eq 'Searchworks'
         expect(tag.release).to be true
+        expect(admin.partOfProject).to eq('Google Books')
 
         desc = instance.description
         expect(desc.title).to all(be_kind_of(Cocina::Models::Description::Title))


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/415

## Why was this change made?
Allow setting partOfProject (equivalent to a project tag).

## Was the documentation (README, wiki) updated?
No.