### PR TITLE
Adds openapi validation. Removes unused schemas and refines openapi.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Layout/LineLength:
 
 Metrics/BlockLength:
   Exclude:
+    - cocina-models.gemspec
     - spec/cocina/**/*
 
 Metrics/MethodLength:

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -26,11 +26,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'
-  spec.add_dependency 'openapi3_parser'
+  spec.add_dependency 'openapi3_parser' # Parsing openapi doc
+  spec.add_dependency 'openapi_parser' # Validating openapi requests
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'committee'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.74.0'

--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -42,7 +42,7 @@ module Cocina
         FileUtils.rm_f(filepath)
 
         create_file filepath, vocab.generate
-        run("rubocop -x #{filepath}")
+        run("rubocop -a #{filepath}")
       end
 
       private
@@ -69,9 +69,10 @@ module Cocina
       def clean_output
         FileUtils.mkdir_p(options[:output])
         files = Dir.glob("#{options[:output]}/*.rb")
-        # Leave version.rb and checkable.rb
+        # Leave alone
         files.delete("#{options[:output]}/version.rb")
         files.delete("#{options[:output]}/checkable.rb")
+        files.delete("#{options[:output]}/validator.rb")
         FileUtils.rm_f(files)
       end
     end

--- a/lib/cocina/generator/vocab.rb
+++ b/lib/cocina/generator/vocab.rb
@@ -14,16 +14,17 @@ module Cocina
 
       def generate
         <<~RUBY
-          # frozen_string_literal: true
+                    # frozen_string_literal: true
 
-          module Cocina
-          module Models
-            # A digital repository object.  See http://sul-dlss.github.io/cocina-models/maps/DRO.json
-            class Vocab
+                    module Cocina
+                      module Models
+                        # A digital repository object.  See http://sul-dlss.github.io/cocina-models/maps/DRO.json
+                        class Vocab
+
           #{vocab_methods}
 
-            end
-          end
+                        end
+                      end
           end
         RUBY
       end
@@ -49,10 +50,11 @@ module Cocina
         # Note special handling of 3d
         vocabs.map do |vocab|
           name = vocab[38, vocab.size - 45].gsub('-', '_').gsub('3d', 'three_dimensional')
-          <<-RUBY
-    def self.#{name}
-      '#{vocab}'
-    end
+          <<~RUBY
+            def self.#{name}
+              "#{vocab}"
+            end
+
           RUBY
         end.join("\n")
       end

--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -5,13 +5,6 @@ module Cocina
     class Access < Struct
       # Access level
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
-      # The human readable copyright statement that applies
-      # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.meta(omittable: true)
-      # The human readable use and reproduction statement that applies
-      # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
-      attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
-      attribute :embargo, Embargo.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -13,11 +13,13 @@ module Cocina
       attribute :externalIdentifier, Types::Strict::String
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
-      attribute(:access, AdminPolicyAccess.default { AdminPolicyAccess.new })
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
-      attribute(:identification, AdminPolicyIdentification.default { AdminPolicyIdentification.new })
-      attribute(:structural, AdminPolicyStructural.default { AdminPolicyStructural.new })
       attribute :description, Description.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/admin_policy_access.rb
+++ b/lib/cocina/models/admin_policy_access.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class AdminPolicyAccess < Struct
-    end
-  end
-end

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     class AdminPolicyAdministrative < Struct
-      attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>')
+      attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
       attribute :registrationWorkflow, Types::Strict::String.meta(omittable: true)
       attribute :hasAdminPolicy, Types::Strict::String.meta(omittable: true)
     end

--- a/lib/cocina/models/admin_policy_identification.rb
+++ b/lib/cocina/models/admin_policy_identification.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class AdminPolicyIdentification < Struct
-    end
-  end
-end

--- a/lib/cocina/models/admin_policy_structural.rb
+++ b/lib/cocina/models/admin_policy_structural.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class AdminPolicyStructural < Struct
-    end
-  end
-end

--- a/lib/cocina/models/administrative.rb
+++ b/lib/cocina/models/administrative.rb
@@ -5,7 +5,7 @@ module Cocina
     class Administrative < Struct
       # example: druid:bc123df4567
       attribute :hasAdminPolicy, Types::Strict::String.meta(omittable: true)
-      attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
+      attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).meta(omittable: true)
       # Administrative or Internal project this resource is a part of
       # example: Google Books
       attribute :partOfProject, Types::Strict::String.meta(omittable: true)

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -21,10 +21,14 @@ module Cocina
       # Version for the Collection within SDR.
       attribute :version, Types::Strict::Integer
       attribute(:access, Access.default { Access.new })
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
-      attribute(:identification, CollectionIdentification.default { CollectionIdentification.new })
-      attribute(:structural, CollectionStructural.default { CollectionStructural.new })
+      attribute :identification, CollectionIdentification.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/collection_structural.rb
+++ b/lib/cocina/models/collection_structural.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class CollectionStructural < Struct
-    end
-  end
-end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -30,12 +30,17 @@ module Cocina
       attribute :label, Types::Strict::String
       # Version for the DRO within SDR.
       attribute :version, Types::Strict::Integer
-      attribute(:access, Access.default { Access.new })
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:access, DROAccess.default { DROAccess.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
-      attribute(:identification, Identification.default { Identification.new })
-      attribute(:structural, DROStructural.default { DROStructural.new })
+      attribute :identification, Identification.optional.meta(omittable: true)
+      attribute :structural, DROStructural.optional.meta(omittable: true)
       attribute :geographic, Geographic.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class DROAccess < Struct
+      attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
+      # The human readable copyright statement that applies
+      # example: Copyright World Trade Organization
+      attribute :copyright, Types::Strict::String.meta(omittable: true)
+      # The human readable use and reproduction statement that applies
+      # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+      attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
+      attribute :embargo, Embargo.optional.meta(omittable: true)
+    end
+  end
+end

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -26,8 +26,6 @@ module Cocina
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, Access.default { Access.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })
-      attribute :identification, FileIdentification.optional.meta(omittable: true)
-      attribute(:structural, FileStructural.default { FileStructural.new })
       attribute :presentation, Presentation.optional.meta(omittable: true)
     end
   end

--- a/lib/cocina/models/file_identification.rb
+++ b/lib/cocina/models/file_identification.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class FileIdentification < Struct
-    end
-  end
-end

--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -14,9 +14,7 @@ module Cocina
       attribute :label, Types::Strict::String
       # Version for the Fileset within SDR.
       attribute :version, Types::Strict::Integer
-      attribute(:access, Access.default { Access.new })
-      attribute(:identification, FileSetIdentification.default { FileSetIdentification.new })
-      attribute(:structural, FileSetStructural.default { FileSetStructural.new })
+      attribute :structural, FileSetStructural.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/file_set_identification.rb
+++ b/lib/cocina/models/file_set_identification.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class FileSetIdentification < Struct
-    end
-  end
-end

--- a/lib/cocina/models/file_structural.rb
+++ b/lib/cocina/models/file_structural.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Cocina
-  module Models
-    class FileStructural < Struct
-    end
-  end
-end

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -11,11 +11,13 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestAdminPolicy::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
-      attribute(:access, AdminPolicyAccess.default { AdminPolicyAccess.new })
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
-      attribute(:identification, AdminPolicyIdentification.default { AdminPolicyIdentification.new })
-      attribute(:structural, AdminPolicyStructural.default { AdminPolicyStructural.new })
       attribute :description, Description.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -16,10 +16,14 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
       attribute(:access, Access.default { Access.new })
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
-      attribute(:identification, CollectionIdentification.default { CollectionIdentification.new })
-      attribute(:structural, CollectionStructural.default { CollectionStructural.new })
+      attribute :identification, CollectionIdentification.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -25,12 +25,17 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
-      attribute(:access, Access.default { Access.new })
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:access, DROAccess.default { DROAccess.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
-      attribute(:identification, Identification.default { Identification.new })
-      attribute(:structural, RequestDROStructural.default { RequestDROStructural.new })
+      attribute :identification, Identification.optional.meta(omittable: true)
+      attribute :structural, RequestDROStructural.optional.meta(omittable: true)
       attribute :geographic, Geographic.optional.meta(omittable: true)
+
+      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
+        Validator.validate(self, attributes.with_indifferent_access) if validate
+        super(attributes, safe, &block)
+      end
     end
   end
 end

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -18,8 +18,6 @@ module Cocina
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, Access.default { Access.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })
-      attribute :identification, FileIdentification.optional.meta(omittable: true)
-      attribute :structural, FileStructural.optional.meta(omittable: true)
       attribute :presentation, Presentation.optional.meta(omittable: true)
     end
   end

--- a/lib/cocina/models/request_file_set.rb
+++ b/lib/cocina/models/request_file_set.rb
@@ -10,8 +10,6 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestFileSet::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
-      attribute :access, Access.optional.meta(omittable: true)
-      attribute(:identification, FileSetIdentification.default { FileSetIdentification.new })
       attribute(:structural, RequestFileSetStructural.default { RequestFileSetStructural.new })
     end
   end

--- a/lib/cocina/models/validator.rb
+++ b/lib/cocina/models/validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # Perform validation against openapi
+    class Validator
+      # rubocop:disable Style/ClassVars
+      def self.root
+        @@root ||=  OpenAPIParser.parse(YAML.load_file('openapi.yml'))
+      end
+      # rubocop:enable Style/ClassVars
+
+      def self.validate(clazz, attributes)
+        method_name = clazz.name.split('::').last
+        request_operation = root.request_operation(:post, "/validate/#{method_name}")
+        request_operation.validate_request_body('application/json', attributes)
+      rescue OpenAPIParser::OpenAPIError => e
+        raise ValidationError, e.message
+      end
+    end
+  end
+end

--- a/openapi.yml
+++ b/openapi.yml
@@ -7,12 +7,79 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
-  /v1/noop:
-    get:
-      summary: noop
+  /validate/DRO:
+    post:
+      summary: Validate a DRO
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DRO'
       responses:
         '200':
           description: noop
+  /validate/RequestDRO:
+    post:
+      summary: Validate a Request DRO
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestDRO'
+      responses:
+        '200':
+          description: noop
+  /validate/Collection:
+    post:
+      summary: Validate a Collection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+      responses:
+        '200':
+          description: noop
+  /validate/RequestCollection:
+    post:
+      summary: Validate a Request Collection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestCollection'
+      responses:
+        '200':
+          description: noop
+  /validate/AdminPolicy:
+    post:
+      summary: Validate an AdminPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminPolicy'
+      responses:
+        '200':
+          description: noop
+  /validate/RequestAdminPolicy:
+    post:
+      summary: Validate a Request AdminPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestAdminPolicy'
+      responses:
+        '200':
+          description: noop
+
 components:
   schemas:
     Access:
@@ -29,16 +96,6 @@ components:
             - 'citation-only'
             - 'dark'
           default: 'dark'
-        copyright:
-          description: The human readable copyright statement that applies
-          example: Copyright World Trade Organization
-          type: string
-        useAndReproductionStatement:
-          description: The human readable use and reproduction statement that applies
-          example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
-          type: string
-        embargo:
-          $ref: '#/components/schemas/Embargo'
     Administrative:
       type: object
       properties:
@@ -53,8 +110,6 @@ components:
           description: Administrative or Internal project this resource is a part of
           example: Google Books
           type: string
-      required:
-        - releaseTags
     AdminPolicy:
       type: object
       properties:
@@ -69,14 +124,8 @@ components:
           type: string
         version:
           type: integer
-        access:
-          $ref: '#/components/schemas/AdminPolicyAccess'
         administrative:
           $ref: '#/components/schemas/AdminPolicyAdministrative'
-        identification:
-          $ref: '#/components/schemas/AdminPolicyIdentification'
-        structural:
-          $ref: '#/components/schemas/AdminPolicyStructural'
         description:
           $ref: '#/components/schemas/Description'
       required:
@@ -84,16 +133,9 @@ components:
         - label
         - type
         - version
-        - access
         - administrative
-        - identification
-        - structural
-    AdminPolicyAccess:
-      type: object
     AdminPolicyAdministrative:
       type: object
-      required:
-        - defaultObjectRights
       properties:
         defaultObjectRights:
           type: string
@@ -102,11 +144,6 @@ components:
           type: string
         hasAdminPolicy:
           type: string
-    AdminPolicyIdentification:
-      type: object
-    AdminPolicyStructural:
-      description: Structural metadata
-      type: object
     CatalogLink:
       type: object
       required:
@@ -151,17 +188,12 @@ components:
           $ref: '#/components/schemas/Description'
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
-        structural:
-          $ref: '#/components/schemas/CollectionStructural'
       required:
         - externalIdentifier
         - label
         - type
         - version
         - access
-        - administrative
-        - identification
-        - structural
     CollectionIdentification:
       type: object
       properties:
@@ -169,10 +201,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-    CollectionStructural:
-      description: Structural metadata
-      type: object
-      properties: {}
     Description:
       description: Descriptive metadata
       type: object
@@ -216,7 +244,7 @@ components:
           description: Version for the DRO within SDR.
           type: integer
         access:
-          $ref: '#/components/schemas/Access'
+          $ref: '#/components/schemas/DROAccess'
         administrative:
           $ref: '#/components/schemas/Administrative'
         description:
@@ -233,9 +261,28 @@ components:
         - type
         - version
         - access
-        - administrative
-        - identification
-        - structural
+    DROAccess:
+      type: object
+      properties:
+        access:
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'citation-only'
+            - 'dark'
+          default: 'dark'
+        copyright:
+          description: The human readable copyright statement that applies
+          example: Copyright World Trade Organization
+          type: string
+        useAndReproductionStatement:
+          description: The human readable use and reproduction statement that applies
+          example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+          type: string
+        embargo:
+          $ref: '#/components/schemas/Embargo'
     DROStructural:
       description: Structural metadata
       type: object
@@ -321,10 +368,6 @@ components:
           $ref: '#/components/schemas/Access'
         administrative:
           $ref: '#/components/schemas/FileAdministrative'
-        identification:
-          $ref: '#/components/schemas/FileIdentification'
-        structural:
-          $ref: '#/components/schemas/FileStructural'
         presentation:
           $ref: '#/components/schemas/Presentation'
       required:
@@ -333,7 +376,6 @@ components:
         - type
         - version
         - access
-        - structural
         - administrative
         - hasMessageDigests
     FileAdministrative:
@@ -348,8 +390,6 @@ components:
       required:
         - sdrPreserve
         - shelve
-    FileIdentification:
-      type: object
     FileSet:
       description: Relevant groupings of Files. Also called a File Grouping.
       type: object
@@ -367,10 +407,6 @@ components:
         version:
           description: Version for the Fileset within SDR.
           type: integer
-        access:
-          $ref: '#/components/schemas/Access'
-        identification:
-          $ref: '#/components/schemas/FileSetIdentification'
         structural:
           $ref: '#/components/schemas/FileSetStructural'
       required:
@@ -378,11 +414,6 @@ components:
         - label
         - type
         - version
-        - access
-        - identification
-        - structural
-    FileSetIdentification:
-      type: object
     FileSetStructural:
       description: Structural metadata
       type: object
@@ -391,10 +422,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/File'
-    FileStructural:
-      description: Structural metadata
-      type: object
-      properties: {}
     Geographic:
       description: Geographic metadata
       type: object
@@ -480,24 +507,15 @@ components:
           type: string
         version:
           type: integer
-        access:
-          $ref: '#/components/schemas/AdminPolicyAccess'
         administrative:
           $ref: '#/components/schemas/AdminPolicyAdministrative'
-        identification:
-          $ref: '#/components/schemas/AdminPolicyIdentification'
-        structural:
-          $ref: '#/components/schemas/AdminPolicyStructural'
         description:
           $ref: '#/components/schemas/Description'
       required:
         - label
         - type
         - version
-        - access
         - administrative
-        - identification
-        - structural
     RequestCollection:
       description: Same as a Collection, but doesn't have an externalIdentifier as one will be created
       type: object
@@ -523,16 +541,11 @@ components:
           $ref: '#/components/schemas/Description'
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
-        structural:
-          $ref: '#/components/schemas/CollectionStructural'
       required:
         - label
         - type
         - version
         - access
-        - administrative
-        - structural
-        - identification
     RequestDRO:
       description: Same as a DRO, but doesn't have an externalIdentifier as one will be created
       type: object
@@ -561,7 +574,7 @@ components:
         version:
           type: integer
         access:
-          $ref: '#/components/schemas/Access'
+          $ref: '#/components/schemas/DROAccess'
         administrative:
           $ref: '#/components/schemas/Administrative'
         description:
@@ -577,9 +590,6 @@ components:
         - type
         - version
         - access
-        - administrative
-        - identification
-        - structural
     RequestDROStructural:
       description: Structural metadata
       type: object
@@ -625,10 +635,6 @@ components:
           $ref: '#/components/schemas/Access'
         administrative:
           $ref: '#/components/schemas/FileAdministrative'
-        identification:
-          $ref: '#/components/schemas/FileIdentification'
-        structural:
-          $ref: '#/components/schemas/FileStructural'
         presentation:
           $ref: '#/components/schemas/Presentation'
       required:
@@ -650,10 +656,6 @@ components:
           type: string
         version:
           type: integer
-        access:
-          $ref: '#/components/schemas/Access'
-        identification:
-          $ref: '#/components/schemas/FileSetIdentification'
         structural:
           $ref: '#/components/schemas/RequestFileSetStructural'
       required:
@@ -661,7 +663,6 @@ components:
         - type
         - version
         - structural
-        - identification
     RequestFileSetStructural:
       description: Structural metadata
       type: object

--- a/spec/cocina/models/admin_policy_shared_examples.rb
+++ b/spec/cocina/models/admin_policy_shared_examples.rb
@@ -27,19 +27,10 @@ RSpec.shared_examples 'it has admin_policy attributes' do
       end
 
       it 'populates non-passed required attributes with default values' do
-        expect(admin_policy.access).to be_kind_of(Cocina::Models::AdminPolicyAccess)
-        expect(admin_policy.access.attributes.size).to eq 0
-
         expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicyAdministrative)
         expect(admin_policy.administrative.defaultObjectRights).to eq admin_policy_default_rights
         expect(admin_policy.administrative.registrationWorkflow).to be_nil
         expect(admin_policy.administrative.hasAdminPolicy).to be_nil
-
-        expect(admin_policy.identification).to be_kind_of(Cocina::Models::AdminPolicyIdentification)
-        expect(admin_policy.identification.attributes.size).to eq 0
-
-        expect(admin_policy.structural).to be_kind_of(Cocina::Models::AdminPolicyStructural)
-        expect(admin_policy.structural.attributes.size).to eq 0
       end
     end
 
@@ -67,19 +58,8 @@ RSpec.shared_examples 'it has admin_policy attributes' do
         expect(admin_policy.administrative.defaultObjectRights).to eq '<rightsMetadata></rightsMetadata>'
         expect(admin_policy.administrative.registrationWorkflow).to eq 'wasCrawlPreassemblyWF'
 
-        # expect(admin_policy.description.title.first.attributes).to eq(primary: true,
-        #                                                               titleFull: 'My admin_policy')
-      end
-    end
-
-    context 'with empty optional properties that have default values' do
-      let(:properties) { required_properties.merge(administrative: nil) }
-
-      it 'uses default values' do
-        expect(admin_policy.administrative).to be_kind_of(Cocina::Models::AdminPolicyAdministrative)
-        expect(admin_policy.administrative.defaultObjectRights).to eq admin_policy_default_rights
-        expect(admin_policy.administrative.registrationWorkflow).to be_nil
-        expect(admin_policy.administrative.hasAdminPolicy).to be_nil
+        expect(admin_policy.description.title.first.attributes).to eq(primary: true,
+                                                                      titleFull: 'My admin_policy')
       end
     end
   end

--- a/spec/cocina/models/admin_policy_spec.rb
+++ b/spec/cocina/models/admin_policy_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Cocina::Models::AdminPolicy do
   # but I think it's actually required for every admin policy
   let(:required_properties) do
     {
-      externalIdentifier: 'druid:ab123cd4567',
+      externalIdentifier: 'druid:bc123df4567',
       label: 'My admin_policy',
       type: type,
-      version: 3
+      version: 3,
+      administrative: {}
     }
   end
 
@@ -21,9 +22,8 @@ RSpec.describe Cocina::Models::AdminPolicy do
   context 'when externalIdentifier is missing' do
     let(:admin_policy) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
 
-    it 'raises a Dry::Struct::Error' do
-      err_msg = '[Cocina::Models::AdminPolicy.new] :externalIdentifier is missing in Hash input'
-      expect { admin_policy }.to raise_error(Dry::Struct::Error, err_msg)
+    it 'raises a Cocina::Models::ValidationError' do
+      expect { admin_policy }.to raise_error(Cocina::Models::ValidationError)
     end
   end
 

--- a/spec/cocina/models/collection_shared_examples.rb
+++ b/spec/cocina/models/collection_shared_examples.rb
@@ -26,16 +26,6 @@ RSpec.shared_examples 'it has collection attributes' do
       it 'populates non-passed required attributes with default values' do
         expect(instance.access).to be_kind_of(Cocina::Models::Access)
         expect(instance.access.access).to eq 'dark'
-
-        expect(instance.administrative).to be_kind_of(Cocina::Models::Administrative)
-        expect(instance.administrative.releaseTags).to eq []
-        expect(instance.administrative.hasAdminPolicy).to be_nil
-
-        expect(instance.identification).to be_kind_of(Cocina::Models::CollectionIdentification)
-        expect(instance.identification.catalogLinks).to be_nil
-
-        expect(instance.structural).to be_kind_of(Cocina::Models::CollectionStructural)
-        expect(instance.structural.attributes.size).to eq 0
       end
     end
 
@@ -97,32 +87,6 @@ RSpec.shared_examples 'it has collection attributes' do
         link = instance.identification.catalogLinks.first
         expect(link.catalog).to eq 'symphony'
         expect(link.catalogRecordId).to eq '44444'
-      end
-    end
-
-    context 'with empty properties that have default values' do
-      let(:properties) do
-        required_properties.merge(
-          access: {},
-          administrative: nil,
-          identification: nil,
-          structural: {}
-        )
-      end
-
-      it 'uses default values' do
-        expect(instance.access).to be_kind_of(Cocina::Models::Access)
-        expect(instance.access.access).to eq 'dark'
-
-        expect(instance.administrative).to be_kind_of(Cocina::Models::Administrative)
-        expect(instance.administrative.releaseTags).to eq []
-        expect(instance.administrative.hasAdminPolicy).to be_nil
-
-        expect(instance.identification).to be_kind_of(Cocina::Models::CollectionIdentification)
-        expect(instance.identification.catalogLinks).to be_nil
-
-        expect(instance.structural).to be_kind_of(Cocina::Models::CollectionStructural)
-        expect(instance.structural.attributes.size).to eq 0
       end
     end
   end

--- a/spec/cocina/models/collection_spec.rb
+++ b/spec/cocina/models/collection_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Cocina::Models::Collection do
   let(:collection_type) { Cocina::Models::Vocab.collection }
   let(:required_properties) do
     {
-      externalIdentifier: 'druid:ab123cd4567',
+      externalIdentifier: 'druid:bc123df4567',
       type: collection_type,
       label: 'My collection',
-      version: 3
+      version: 3,
+      access: {}
     }
   end
 
@@ -19,9 +20,8 @@ RSpec.describe Cocina::Models::Collection do
   context 'when externalIdentifier is missing' do
     let(:instance) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
 
-    it 'raises a Dry::Struct::Error' do
-      err_msg = '[Cocina::Models::Collection.new] :externalIdentifier is missing in Hash input'
-      expect { instance }.to raise_error(Dry::Struct::Error, err_msg)
+    it 'raises a Cocina::Models::ValidationError' do
+      expect { instance }.to raise_error(Cocina::Models::ValidationError)
     end
   end
 
@@ -44,10 +44,10 @@ RSpec.describe Cocina::Models::Collection do
       it { is_expected.to be_nil }
     end
 
-    describe ':releaseTags default is empty array' do
+    describe ':releaseTags default is nil' do
       subject { instance.releaseTags }
 
-      it { is_expected.to eq [] }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/cocina/models/dro_shared_examples.rb
+++ b/spec/cocina/models/dro_shared_examples.rb
@@ -32,22 +32,11 @@ RSpec.shared_examples 'it has dro attributes' do
 
       it 'populates non-passed required attributes with default values' do
         access = instance.access
-        expect(access).to be_kind_of Cocina::Models::Access
+        expect(access).to be_kind_of Cocina::Models::DROAccess
         expect(access.access).to eq 'dark'
         expect(access.copyright).to be_nil
         expect(access.embargo).to be_nil
         expect(access.useAndReproductionStatement).to be_nil
-
-        administrative = instance.administrative
-        expect(administrative).to be_kind_of Cocina::Models::Administrative
-        expect(administrative.hasAdminPolicy).to be_nil
-        expect(administrative.releaseTags).to eq []
-
-        expect(instance.identification).to be_kind_of Cocina::Models::Identification
-        expect(instance.identification.attributes.size).to eq 0
-
-        expect(instance.structural).to be_kind_of struct_class
-        expect(instance.structural.attributes.size).to eq 0
       end
     end
 
@@ -166,37 +155,6 @@ RSpec.shared_examples 'it has dro attributes' do
           expect(fileset2.externalIdentifier).to eq '12343234_2'
         end
         expect(structural.hasMemberOrders.first.viewingDirection).to eq 'right-to-left'
-      end
-    end
-
-    context 'with empty properties that have default values' do
-      let(:properties) do
-        required_properties.merge(
-          access: {},
-          administrative: {},
-          identification: {},
-          structural: {}
-        )
-      end
-
-      it 'uses default values' do
-        access = instance.access
-        expect(access).to be_kind_of Cocina::Models::Access
-        expect(access.access).to eq 'dark'
-        expect(access.copyright).to be_nil
-        expect(access.embargo).to be_nil
-        expect(access.useAndReproductionStatement).to be_nil
-
-        administrative = instance.administrative
-        expect(administrative).to be_kind_of Cocina::Models::Administrative
-        expect(administrative.hasAdminPolicy).to be_nil
-        expect(administrative.releaseTags).to eq []
-
-        expect(instance.identification).to be_kind_of Cocina::Models::Identification
-        expect(instance.identification.attributes.size).to eq 0
-
-        expect(instance.structural).to be_kind_of struct_class
-        expect(instance.structural.attributes.size).to eq 0
       end
     end
   end

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Cocina::Models::DRO do
   let(:item_type) { Cocina::Models::Vocab.object }
   let(:required_properties) do
     {
-      externalIdentifier: 'druid:ab123cd4567',
+      externalIdentifier: 'druid:bc123df4567',
       label: 'My object',
       type: item_type,
-      version: 2
+      version: 2,
+      access: {}
     }
   end
   let(:struct_class) { Cocina::Models::DROStructural }
@@ -33,9 +34,8 @@ RSpec.describe Cocina::Models::DRO do
   context 'when externalIdentifier is missing' do
     let(:fileset) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
 
-    it 'raises a Dry::Struct::Error' do
-      err_msg = '[Cocina::Models::DRO.new] :externalIdentifier is missing in Hash input'
-      expect { fileset }.to raise_error(Dry::Struct::Error, err_msg)
+    it 'raises a Cocina::Models::ValidationError' do
+      expect { fileset }.to raise_error(Cocina::Models::ValidationError)
     end
   end
 
@@ -47,16 +47,6 @@ RSpec.describe Cocina::Models::DRO do
     it { is_expected.to be_dro }
     it { is_expected.not_to be_file }
     it { is_expected.not_to be_file_set }
-  end
-
-  describe Cocina::Models::Administrative do
-    let(:instance) { described_class.new }
-
-    describe '#releaseTags' do
-      subject { instance.releaseTags }
-
-      it { is_expected.to be_empty }
-    end
   end
 
   describe Cocina::Models::DROStructural do

--- a/spec/cocina/models/file_set_shared_examples.rb
+++ b/spec/cocina/models/file_set_shared_examples.rb
@@ -26,17 +26,11 @@ RSpec.shared_examples 'it has file_set attributes' do
         expect(instance.type).to eq required_properties[:type]
         expect(instance.version).to eq required_properties[:version]
       end
-
-      it 'populates non-passed required attributes with default values' do
-        expect(instance.structural).to be_kind_of struct_class
-        expect(instance.structural.attributes.size).to eq 0
-      end
     end
 
     context 'with all specifiable properties' do
       let(:properties) do
         required_properties.merge(
-          identification: {},
           structural: {
             contains: [
               struct_contains_class.new(
@@ -59,9 +53,6 @@ RSpec.shared_examples 'it has file_set attributes' do
       end
 
       it 'populates all attributes passed in' do
-        expect(instance.identification).to be_kind_of Cocina::Models::FileSetIdentification
-        expect(instance.identification.attributes.size).to eq 0
-
         expect(instance.structural).to be_kind_of struct_class
         struct_contains = instance.structural.contains
         expect(struct_contains).to all(be_kind_of(struct_contains_class))
@@ -78,23 +69,6 @@ RSpec.shared_examples 'it has file_set attributes' do
           expect(file1.externalIdentifier).to eq 'file#1'
           expect(file2.externalIdentifier).to eq 'file#2'
         end
-      end
-    end
-
-    context 'with empty properties that have default values' do
-      let(:properties) do
-        required_properties.merge(
-          identification: {},
-          structural: {}
-        )
-      end
-
-      it 'uses default values' do
-        expect(instance.identification).to be_kind_of Cocina::Models::FileSetIdentification
-        expect(instance.identification.attributes.size).to eq 0
-
-        expect(instance.structural).to be_kind_of struct_class
-        expect(instance.structural.attributes.size).to eq 0
       end
     end
   end

--- a/spec/cocina/models/file_shared_examples.rb
+++ b/spec/cocina/models/file_shared_examples.rb
@@ -55,7 +55,6 @@ RSpec.shared_examples 'it has file attributes' do
           hasMimeType: 'image/jp2',
           presentation: { height: 5, width: 8 },
           size: 666,
-          structural: {},
           use: 'transcription'
         )
       end

--- a/spec/cocina/models/request_admin_policy_spec.rb
+++ b/spec/cocina/models/request_admin_policy_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Cocina::Models::RequestAdminPolicy do
     {
       type: type,
       label: 'My admin_policy',
-      version: 3
+      version: 3,
+      administrative: {}
     }
   end
 

--- a/spec/cocina/models/request_collection_spec.rb
+++ b/spec/cocina/models/request_collection_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Cocina::Models::RequestCollection do
     {
       type: collection_type,
       label: 'My collection',
-      version: 3
+      version: 3,
+      access: {}
     }
   end
 

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Cocina::Models::RequestDRO do
     {
       label: 'My object',
       type: item_type,
-      version: 7
+      version: 7,
+      access: {}
     }
   end
   let(:struct_class) { Cocina::Models::RequestDROStructural }
@@ -18,10 +19,12 @@ RSpec.describe Cocina::Models::RequestDRO do
     [
       { type: file_set_type,
         version: 1,
-        label: 'Resource #1' },
+        label: 'Resource #1',
+        structural: {} },
       { type: file_set_type,
         version: 2,
-        label: 'Resource #2' }
+        label: 'Resource #2',
+        structural: {} }
     ]
   end
 

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -14,31 +14,40 @@ RSpec.describe Cocina::Models do
       let(:data) do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
-          'externalIdentifier' => 'foo',
+          'externalIdentifier' => 'druid:bc123df4567',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          }
+          'access' => {}
         }
       end
 
       it { is_expected.to be_kind_of Cocina::Models::Collection }
     end
 
-    context 'with a DRO type' do
+    context 'with an invalid DRO (openapi)' do
       let(:data) do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
           'externalIdentifier' => 'foo',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          },
-          'structural' => {
-            'hasAgreement' => ''
-          }
+          'access' => {}
+        }
+      end
+
+      it 'raises' do
+        expect { build }.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+
+    context 'with a DRO type' do
+      let(:data) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
+          'externalIdentifier' => 'druid:bc123df4567',
+          'label' => 'bar',
+          'version' => 5,
+          'access' => {}
         }
       end
 
@@ -49,12 +58,10 @@ RSpec.describe Cocina::Models do
       let(:data) do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
-          'externalIdentifier' => 'foo',
+          'externalIdentifier' => 'druid:bc123df4567',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          }
+          'administrative' => {}
         }
       end
 
@@ -91,9 +98,7 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          }
+          'access' => {}
         }
       end
 
@@ -106,9 +111,7 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          }
+          'access' => {}
         }
       end
 
@@ -121,9 +124,7 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
           'label' => 'bar',
           'version' => 5,
-          'description' => {
-            'title' => []
-          }
+          'administrative' => {}
         }
       end
 


### PR DESCRIPTION
## Why was this change made?
* To use openapi for validation.
* Remove unused / empty parts of the openapi.
* Better align openapi with previous cocina models.

## Was the documentation (README, wiki) updated?
No.