### PR TITLE
Allow a RequestDRO to ommit access subschema

### DIFF
--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -25,7 +25,7 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
-      attribute(:access, DROAccess.default { DROAccess.new })
+      attribute :access, DROAccess.optional.meta(omittable: true)
       attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
       attribute :identification, Identification.optional.meta(omittable: true)

--- a/openapi.yml
+++ b/openapi.yml
@@ -547,7 +547,7 @@ components:
         - version
         - access
     RequestDRO:
-      description: Same as a DRO, but doesn't have an externalIdentifier as one will be created
+      description: A request to create a DRO.  This has the same general structure as a DRO but doesn't have externalIdentifier and doesn't require the access subschema. If no access subschema is provided, these values will be inherited from the AdminPolicy.
       type: object
       properties:
         type:
@@ -589,7 +589,6 @@ components:
         - label
         - type
         - version
-        - access
     RequestDROStructural:
       description: Structural metadata
       type: object

--- a/spec/cocina/models/dro_shared_examples.rb
+++ b/spec/cocina/models/dro_shared_examples.rb
@@ -29,15 +29,6 @@ RSpec.shared_examples 'it has dro attributes' do
         expect(instance.type).to eq required_properties[:type]
         expect(instance.version).to eq required_properties[:version]
       end
-
-      it 'populates non-passed required attributes with default values' do
-        access = instance.access
-        expect(access).to be_kind_of Cocina::Models::DROAccess
-        expect(access.access).to eq 'dark'
-        expect(access.copyright).to be_nil
-        expect(access.embargo).to be_nil
-        expect(access.useAndReproductionStatement).to be_nil
-      end
     end
 
     context 'with all specifiable properties' do

--- a/spec/cocina/models/dro_spec.rb
+++ b/spec/cocina/models/dro_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Cocina::Models::DRO do
 
   it_behaves_like 'it has dro attributes'
 
+  context 'when no access values are passed in' do
+    let(:instance) { described_class.new(required_properties) }
+    let(:access) { instance.access }
+
+    it 'populates non-passed required attributes with default values' do
+      expect(access).to be_kind_of Cocina::Models::DROAccess
+      expect(access.access).to eq 'dark'
+      expect(access.copyright).to be_nil
+      expect(access.embargo).to be_nil
+      expect(access.useAndReproductionStatement).to be_nil
+    end
+  end
+
   context 'when externalIdentifier is missing' do
     let(:fileset) { described_class.new(required_properties.reject { |k, _v| k == :externalIdentifier }) }
 

--- a/spec/cocina/models/request_dro_spec.rb
+++ b/spec/cocina/models/request_dro_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Cocina::Models::RequestDRO do
     {
       label: 'My object',
       type: item_type,
-      version: 7,
-      access: {}
+      version: 7
     }
   end
   let(:struct_class) { Cocina::Models::RequestDROStructural }
@@ -29,6 +28,24 @@ RSpec.describe Cocina::Models::RequestDRO do
   end
 
   it_behaves_like 'it has dro attributes'
+
+  describe '#access' do
+    context 'when no access values are passed in' do
+      subject(:access) { instance.access }
+
+      let(:instance) { described_class.new(required_properties) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when access values are passed in' do
+      subject(:access) { instance.access }
+
+      let(:instance) { described_class.new(required_properties.merge(access: {})) }
+
+      it { is_expected.to be_kind_of Cocina::Models::DROAccess }
+    end
+  end
 
   describe Cocina::Models::RequestDROStructural do
     context 'with RequestFileSet as contained class' do


### PR DESCRIPTION


## Why was this change made?

This allows us to inherit the access from the admin policy object.

## Was the documentation (README, wiki) updated?
n/a