### PR TITLE
Use the correct namespace for LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-rspec
 
-Layout/LineLength:
+Metrics/LineLength:
   Max: 114
   Exclude:
     - lib/cocina/models/*

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -4,11 +4,11 @@ module Cocina
   module Generator
     # Class for generating from an openapi value
     class SchemaValue < SchemaBase
-      # rubocop:disable Layout/LineLength
+      # rubocop:disable Metrics/LineLength
       def generate
         "#{description}#{example}attribute :#{name.camelize(:lower)}, Types::#{dry_datatype}#{default}#{enum}#{omittable}"
       end
-      # rubocop:enable Layout/LineLength
+      # rubocop:enable Metrics/LineLength
 
       private
 

--- a/spec/cocina/models/admin_policy_shared_examples.rb
+++ b/spec/cocina/models/admin_policy_shared_examples.rb
@@ -11,9 +11,9 @@ RSpec.shared_examples 'it has admin_policy attributes' do
   let(:type) { Cocina::Models::Vocab.admin_policy }
   # see block comment for info about required_properties
   let(:properties) { required_properties }
-  # rubocop:disable Layout/LineLength
+  # rubocop:disable Metrics/LineLength
   let(:admin_policy_default_rights) { '<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>' }
-  # rubocop:enable Layout/LineLength
+  # rubocop:enable Metrics/LineLength
 
   describe 'initialization' do
     context 'with minimal required properties provided' do


### PR DESCRIPTION
## Why was this change made?

Fixes warnings like this:
```
Layout/LineLength has the wrong namespace - should be Metrics
```

## Was the documentation (README, wiki) updated?
no