### PR TITLE
Removed problematic and duplicative Zeitwerks configuration.

### DIFF
--- a/exe/generator
+++ b/exe/generator
@@ -4,6 +4,6 @@
 require 'bundler/setup'
 $LOAD_PATH.unshift 'lib'
 
-require 'cocina/generator'
+require 'cocina/models'
 
 Cocina::Generator::Generator.start(ARGV)

--- a/lib/cocina/generator.rb
+++ b/lib/cocina/generator.rb
@@ -1,16 +1,5 @@
 # frozen_string_literal: true
 
-require 'zeitwerk'
-require 'yaml'
-require 'active_support/core_ext/string'
-require 'thor'
-require 'openapi3_parser'
-require 'byebug'
-
-loader = Zeitwerk::Loader.new
-loader.push_dir(File.absolute_path("#{__FILE__}/../.."))
-loader.setup
-
 module Cocina
   # Module for generating Cocina models from openapi.
   module Generator

--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -5,9 +5,12 @@ require 'zeitwerk'
 require 'dry-struct'
 require 'dry-types'
 require 'json'
-require 'openapi_parser'
-require 'active_support/core_ext/hash/indifferent_access'
 require 'yaml'
+require 'openapi_parser'
+require 'openapi3_parser'
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/string'
+require 'thor'
 
 # Help Zeitwerk find some of our classes
 class CocinaModelsInflector < Zeitwerk::Inflector


### PR DESCRIPTION
## Why was this change made?
Having two zeitwerks configs was causing problems in SDR API. Only a single is necessary.


## Was the documentation (README, wiki) updated?
No.