### PR TITLE
Added additionalProperties:false to all objects in openapi.

### DIFF
--- a/lib/cocina/models/event.rb
+++ b/lib/cocina/models/event.rb
@@ -3,13 +3,13 @@
 module Cocina
   module Models
     class Event < Struct
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
       # Description of the event (creation, publication, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
       attribute :date, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -96,6 +96,7 @@ components:
     Access:
       description: Access metadata
       type: object
+      additionalProperties: false
       properties:
         access:
           description: Access level
@@ -109,6 +110,7 @@ components:
           default: 'dark'
     Administrative:
       type: object
+      additionalProperties: false
       properties:
         hasAdminPolicy:
           $ref: '#/components/schemas/Druid'
@@ -123,6 +125,7 @@ components:
           type: string
     AdminPolicy:
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -147,6 +150,7 @@ components:
         - administrative
     AdminPolicyAdministrative:
       type: object
+      additionalProperties: false
       properties:
         defaultObjectRights:
           type: string
@@ -159,6 +163,7 @@ components:
       description: Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.
       type: object
+      additionalProperties: false
       properties:
         appliesTo:
           type: array
@@ -166,6 +171,7 @@ components:
             $ref: "#/components/schemas/DescriptiveBasicValue"
     CatalogLink:
       type: object
+      additionalProperties: false
       required:
         - catalog
         - catalogRecordId
@@ -181,6 +187,7 @@ components:
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
+      additionalProperties: false
       properties:
         type:
           description: The content type of the Collection. Selected from an established set of values.
@@ -216,6 +223,7 @@ components:
         - access
     CollectionIdentification:
       type: object
+      additionalProperties: false
       properties:
         catalogLinks:
           type: array
@@ -225,6 +233,7 @@ components:
       description: Property model for describing agents contributing in some way to
         the creation and history of the resource
       type: object
+      additionalProperties: false
       properties:
         name:
           description: Names associated with a contributor.
@@ -246,6 +255,7 @@ components:
     DescriptiveAdminMetadata:
       description: Information about this description of the resource.
       type: object
+      additionalProperties: false
       properties:
         contributor:
           type: array
@@ -266,6 +276,7 @@ components:
     DescriptiveBasicValue:
       description: Value model for descriptive elements without recursive properties.
       type: object
+      additionalProperties: false
       properties:
         value:
           description: String value of the descriptive element.
@@ -299,6 +310,7 @@ components:
     DescriptiveStructuredValue:
       description: Value model for descriptive elements structured as typed values.
       type: object
+      additionalProperties: false
       properties:
         structuredValue:
           type: array
@@ -307,12 +319,14 @@ components:
     DescriptiveValue:
       description: Default value model for descriptive elements.
       type: object
+      additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveBasicValue"
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
         - $ref: "#/components/schemas/AppliesTo"
     DescriptiveValueRequired:
       type: object
+      additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveValue"
         - anyOf:
@@ -324,6 +338,7 @@ components:
                 - structuredValue
     Description:
       type: object
+      additionalProperties: false
       properties:
         title:
           description: Titles of the resource.
@@ -384,6 +399,7 @@ components:
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
+      additionalProperties: false
       properties:
         type:
           description: The content type of the DRO. Selected from an established set of values.
@@ -433,6 +449,7 @@ components:
         - access
     DROAccess:
       type: object
+      additionalProperties: false
       properties:
         access:
           type: string
@@ -456,6 +473,7 @@ components:
     DROStructural:
       description: Structural metadata
       type: object
+      additionalProperties: false
       properties:
         contains:
           description: Filesets that contain the digital representations (Files)
@@ -478,6 +496,7 @@ components:
       example: 'druid:bc123df4567'
     Embargo:
       type: object
+      additionalProperties: false
       properties:
         releaseDate:
           description: Date when the Collection is released from an embargo.
@@ -503,35 +522,40 @@ components:
     Event:
       description: Property model for describing events in the history of the resource.
       type: object
-      properties:
-        type:
-          description: Description of the event (creation, publication, etc.).
-          type: string
-        date:
-          description: Dates associated with the event.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        contributor:
-          description: Contributors associated with the event.
-          type: array
-          items:
-            $ref: "#/components/schemas/Contributor"
-        location:
-          description: Locations associated with the event.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        note:
-          description: Other information about the event.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
+      additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
+        - type: object
+          additionalProperties: false
+          properties:
+            type:
+              description: Description of the event (creation, publication, etc.).
+              type: string
+            date:
+              description: Dates associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            contributor:
+              description: Contributors associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/Contributor"
+            location:
+              description: Locations associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            note:
+              description: Other information about the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+
     File:
       description: Binaries that are the basis of what our domain manages. Binaries here do not include metadata files generated for the domain's own management purposes.
       type: object
+      additionalProperties: false
       properties:
         type:
           description: The content type of the File.
@@ -579,6 +603,7 @@ components:
         - hasMessageDigests
     FileAdministrative:
       type: object
+      additionalProperties: false
       properties:
         sdrPreserve:
           type: boolean
@@ -592,6 +617,7 @@ components:
     FileSet:
       description: Relevant groupings of Files. Also called a File Grouping.
       type: object
+      additionalProperties: false
       properties:
         type:
           description: The content type of the Fileset.
@@ -616,6 +642,7 @@ components:
     FileSetStructural:
       description: Structural metadata
       type: object
+      additionalProperties: false
       properties:
         contains:
           type: array
@@ -624,6 +651,7 @@ components:
     Geographic:
       description: Geographic metadata
       type: object
+      additionalProperties: false
       properties:
         iso19139:
           description: Geographic ISO 19139 XML metadata
@@ -632,6 +660,7 @@ components:
         - iso19139
     Identification:
       type: object
+      additionalProperties: false
       properties:
         sourceId:
           type: string
@@ -643,6 +672,7 @@ components:
     MessageDigest:
       description: The output of the message digest algorithm.
       type: object
+      additionalProperties: false
       properties:
         type:
           description: The algorithm that was used
@@ -659,6 +689,7 @@ components:
     Presentation:
       description: Presentation data for the File.
       type: object
+      additionalProperties: false
       properties:
         height:
           description: Height in pixels
@@ -669,6 +700,7 @@ components:
     ReleaseTag:
       description: A tag that indicates the item or collection should be released.
       type: object
+      additionalProperties: false
       required:
         - release
       properties:
@@ -696,6 +728,7 @@ components:
     RequestAdminPolicy:
       description: Same as an AdminPolicy, but doesn't have an externalIdentifier as one will be created
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -718,6 +751,7 @@ components:
     RequestCollection:
       description: Same as a Collection, but doesn't have an externalIdentifier as one will be created
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -748,6 +782,7 @@ components:
     RequestDRO:
       description: A request to create a DRO.  This has the same general structure as a DRO but doesn't have externalIdentifier and doesn't require the access subschema. If no access subschema is provided, these values will be inherited from the AdminPolicy.
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -791,6 +826,7 @@ components:
     RequestDROStructural:
       description: Structural metadata
       type: object
+      additionalProperties: false
       properties:
         contains:
           type: array
@@ -806,6 +842,7 @@ components:
           type: string
     RequestFile:
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -845,6 +882,7 @@ components:
         - hasMessageDigests
     RequestFileSet:
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string
@@ -864,6 +902,7 @@ components:
     RequestFileSetStructural:
       description: Structural metadata
       type: object
+      additionalProperties: false
       properties:
         contains:
           type: array
@@ -872,6 +911,7 @@ components:
     Sequence:
       description: A sequence or ordering of resources within a Collection or Object.
       type: object
+      additionalProperties: false
       properties:
         viewingDirection:
           description: The direction that a sequence of canvases should be displayed to the user
@@ -883,6 +923,7 @@ components:
       description: Property model for indicating the vocabulary, authority, or other
         origin for a term, code, or identifier.
       type: object
+      additionalProperties: false
       properties:
         code:
           description: Code representing the value source.


### PR DESCRIPTION
closes #98

## Why was this change made?
To better validate objects by disallowing unexpected properties.


## Was the documentation (README, wiki) updated?
No