### PR TITLE
Add a field for download level access

### DIFF
--- a/docs/maps/DRO.json
+++ b/docs/maps/DRO.json
@@ -84,7 +84,7 @@
         "download": {
           "description": "Download level for the DRO metadata.",
           "type": "string",
-          "enum": ["world", "stanford", "location-based", "citation-only", "dark"]
+          "enum": ["world", "stanford", "location-based", "none"]
         },
         "embargo": {
           "description": "Embargo metadata",

--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -5,6 +5,8 @@ module Cocina
     class Access < Struct
       # Access level
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
+      # Download access level for a file
+      attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
       # If access is "location-based", which location should have access.
       attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
     end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -7,13 +7,16 @@ module Cocina
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute :copyright, Types::Strict::String.meta(omittable: true)
+      attribute :embargo, Embargo.optional.meta(omittable: true)
+      # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
+
+      attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
       # If access is "location-based", which location should have access. This is used in the transition from Fedora as a way to set a default readLocation at registration that is copied down to all the files.
 
       attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
-      attribute :embargo, Embargo.optional.meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -108,6 +108,15 @@ components:
             - 'citation-only'
             - 'dark'
           default: 'dark'
+        download:
+          description: Download access level for a file
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'none'
+          default: 'none'
         readLocation:
           description: If access is "location-based", which location should have access.
           type: string
@@ -474,6 +483,21 @@ components:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
+        embargo:
+          $ref: '#/components/schemas/Embargo'
+        download:
+          description: >
+            Download access level. This is used in the transition from Fedora as
+            a way to set a default download level at registration that is copied
+            down to all the files.
+
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'none'
+          default: 'none'
         readLocation:
           description: >
             If access is "location-based", which location should have access.
@@ -492,8 +516,6 @@ components:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
           type: string
-        embargo:
-          $ref: '#/components/schemas/Embargo'
     DROStructural:
       description: Structural metadata
       type: object


### PR DESCRIPTION
## Why was this change made?

This allows us to do registration using the cocina endpoint.  This requires us to be able to set a download access level.

Ref https://github.com/sul-dlss/dor-services-app/issues/772


## Was the documentation (README, wiki) updated?

no