### PR TITLE
Add members to Sequence 

### DIFF
--- a/lib/cocina/models/sequence.rb
+++ b/lib/cocina/models/sequence.rb
@@ -3,6 +3,7 @@
 module Cocina
   module Models
     class Sequence < Struct
+      attribute :members, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
       # The direction that a sequence of canvases should be displayed to the user
       attribute :viewingDirection, Types::Strict::String.enum('right-to-left', 'left-to-right').meta(omittable: true)
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -959,6 +959,11 @@ components:
       type: object
       additionalProperties: false
       properties:
+        members:
+          description: "Identifiers for Members in their stated Order for the Sequence."
+          type: array
+          items:
+            type: string
         viewingDirection:
           description: The direction that a sequence of canvases should be displayed to the user
           type: string


### PR DESCRIPTION

## Why was this change made?

so that we can model virtual objects as a Sequence

See https://argo.stanford.edu/view/druid:hj097bm8879 as an example of a virtual object

