### PR TITLE
File objects require a filename

### DIFF
--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -14,7 +14,7 @@ module Cocina
       # Primary processing label (can be same as title) for a File.
       attribute :label, Types::Strict::String
       # Filename for a file. Can be same as label.
-      attribute :filename, Types::Strict::String.meta(omittable: true)
+      attribute :filename, Types::Strict::String
       # Size of the File (binary) in bytes.
       attribute :size, Types::Strict::Integer.meta(omittable: true)
       # Version for the File within SDR.

--- a/openapi.yml
+++ b/openapi.yml
@@ -642,6 +642,7 @@ components:
       required:
         - externalIdentifier
         - label
+        - filename
         - type
         - version
         - access


### PR DESCRIPTION
## Why was this change made?

We need to depend on Files having a Filename, so we should enforce this with the model.

