### PR TITLE
Fixes for description v4 branch.

### DIFF
--- a/lib/cocina/models/contributor.rb
+++ b/lib/cocina/models/contributor.rb
@@ -6,7 +6,7 @@ module Cocina
       attribute :name, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # Entity type of the contributor (person, organization, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the contributor relative to other parallel contributors.
+      # Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
       attribute :status, Types::Strict::String.meta(omittable: true)
       attribute :role, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)

--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -3,11 +3,13 @@
 module Cocina
   module Models
     class DescriptiveBasicValue < Struct
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # String value of the descriptive element.
       attribute :value, Types::Strict::String.meta(omittable: true)
       # Type of value provided by the descriptive element.
       attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the descriptive element relative to other instances of the element.
+      # Status of the descriptive element value relative to other instances of the element.
       attribute :status, Types::Strict::String.meta(omittable: true)
       # Code value of the descriptive element.
       attribute :code, Types::Strict::String.meta(omittable: true)
@@ -16,11 +18,11 @@ module Cocina
       attribute :standard, Standard.optional.meta(omittable: true)
       attribute :encoding, Standard.optional.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The preferred display label to use for the descriptive element in access systems.
       attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/descriptive_parallel_value.rb
+++ b/lib/cocina/models/descriptive_parallel_value.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class DescriptiveParallelValue < Struct
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+    end
+  end
+end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -3,11 +3,13 @@
 module Cocina
   module Models
     class DescriptiveValue < Struct
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # String value of the descriptive element.
       attribute :value, Types::Strict::String.meta(omittable: true)
       # Type of value provided by the descriptive element.
       attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the descriptive element relative to other instances of the element.
+      # Status of the descriptive element value relative to other instances of the element.
       attribute :status, Types::Strict::String.meta(omittable: true)
       # Code value of the descriptive element.
       attribute :code, Types::Strict::String.meta(omittable: true)
@@ -16,11 +18,11 @@ module Cocina
       attribute :standard, Standard.optional.meta(omittable: true)
       attribute :encoding, Standard.optional.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The preferred display label to use for the descriptive element in access systems.
       attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/descriptive_value_required.rb
+++ b/lib/cocina/models/descriptive_value_required.rb
@@ -3,11 +3,13 @@
 module Cocina
   module Models
     class DescriptiveValueRequired < Struct
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # String value of the descriptive element.
       attribute :value, Types::Strict::String.meta(omittable: true)
       # Type of value provided by the descriptive element.
       attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the descriptive element relative to other instances of the element.
+      # Status of the descriptive element value relative to other instances of the element.
       attribute :status, Types::Strict::String.meta(omittable: true)
       # Code value of the descriptive element.
       attribute :code, Types::Strict::String.meta(omittable: true)
@@ -16,11 +18,11 @@ module Cocina
       attribute :standard, Standard.optional.meta(omittable: true)
       attribute :encoding, Standard.optional.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The preferred display label to use for the descriptive element in access systems.
       attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/event.rb
+++ b/lib/cocina/models/event.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     class Event < Struct
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # Description of the event (creation, publication, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
       attribute :date, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class Identification < Struct
+      # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation.
+
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
       attribute :sourceId, Types::Strict::String.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -3,11 +3,13 @@
 module Cocina
   module Models
     class Language < Struct
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # String value of the descriptive element.
       attribute :value, Types::Strict::String.meta(omittable: true)
       # Type of value provided by the descriptive element.
       attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the descriptive element relative to other instances of the element.
+      # Status of the descriptive element value relative to other instances of the element.
       attribute :status, Types::Strict::String.meta(omittable: true)
       # Code value of the descriptive element.
       attribute :code, Types::Strict::String.meta(omittable: true)
@@ -16,13 +18,12 @@ module Cocina
       attribute :standard, Standard.optional.meta(omittable: true)
       attribute :encoding, Standard.optional.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The preferred display label to use for the descriptive element in access systems.
       attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
-      # Alphabet or other notation used to represent a language or other symbolic system
       attribute :script, DescriptiveValue.optional.meta(omittable: true)
     end
   end

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -3,6 +3,7 @@
 module Cocina
   module Models
     class RelatedResource < Struct
+      # The relationship of the related resource to the described resource.
       attribute :type, Types::Strict::String.meta(omittable: true)
       attribute :title, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
@@ -12,7 +13,7 @@ module Cocina
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # Stanford persistent URL associated with the resource.
+      # Stanford persistent URL associated with the related resource.
       attribute :purl, Types::Strict::String.meta(omittable: true)
       attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
     end

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class RequestIdentification < Struct
+      # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation.
+
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
       attribute :sourceId, Types::Strict::String
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)

--- a/lib/cocina/models/source.rb
+++ b/lib/cocina/models/source.rb
@@ -9,7 +9,6 @@ module Cocina
       attribute :uri, Types::Strict::String.meta(omittable: true)
       # String describing the value source.
       attribute :value, Types::Strict::String.meta(omittable: true)
-      # Other information related to the value source.
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -3,15 +3,13 @@
 module Cocina
   module Models
     class Standard < Struct
-      # Code representing the value standard or encoding.
+      # Code representing the standard or encoding.
       attribute :code, Types::Strict::String.meta(omittable: true)
-      # URI for the value standard or encoding.
+      # URI for the standard or encoding.
       attribute :uri, Types::Strict::String.meta(omittable: true)
-      # String describing the value standard or encoding.
+      # String describing the standard or encoding.
       attribute :value, Types::Strict::String.meta(omittable: true)
-      # Other information related to the value standard or encoding.
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # Source of a code or URI.
       attribute :source, Source.optional.meta(omittable: true)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -421,7 +421,8 @@ components:
     DescriptiveBasicValue:
       description: Basic value model for descriptive elements.
       type: object
-      additionalProperties: false
+      # additionalProperties breaks the validator, unclear as to why.
+      # additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
         - $ref: "#/components/schemas/DescriptiveParallelValue"
@@ -817,7 +818,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/DescriptiveValue'
         - type: object
-          additionalProperties: false
+          # additionalProperties breaks the validator, presumably because it can't
+          # conform to other schemas (allOf) and not have additionalProperties
+          # additionalProperties: false
           properties:
             script:
               $ref: '#/components/schemas/DescriptiveValue'

--- a/openapi.yml
+++ b/openapi.yml
@@ -411,7 +411,7 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         standard:
-          description: Descriptive or content standard to which this resource description conforms.
+          # description: Descriptive or content standard to which this resource description conforms.
           $ref: "#/components/schemas/Standard"
         identifier:
           description: Identifiers associated with this resource description.
@@ -446,10 +446,10 @@ components:
               type: string
               format: uri
             standard:
-              description: Descriptive or content standard to which the value conforms.
+              # description: Descriptive or content standard to which the value conforms.
               $ref: "#/components/schemas/Standard"
             encoding:
-              description: Encoding schema, standard, or syntax to which the value conforms.
+              # description: Encoding schema, standard, or syntax to which the value conforms.
               $ref: "#/components/schemas/Standard"
             source:
               $ref: "#/components/schemas/Source"
@@ -820,9 +820,9 @@ components:
           additionalProperties: false
           properties:
             script:
-              description: An alphabet or other notation used to represent a
-                language or other symbolic system associated with the resource.
               $ref: '#/components/schemas/DescriptiveValue'
+              # description: An alphabet or other notation used to represent a
+              #   language or other symbolic system associated with the resource.
     MessageDigest:
       description: The output of the message digest algorithm.
       type: object

--- a/spec/cocina/generator/schema_array_spec.rb
+++ b/spec/cocina/generator/schema_array_spec.rb
@@ -4,16 +4,6 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Generator::SchemaArray do
   # This tests the outcome of running exe/generator generate against openapi.yml.
-
-  # context 'when an array of datatypes' do
-  #   # DescriptiveBasicValue.standard is an array of strings
-  #   let(:value) { Cocina::Models::DescriptiveBasicValue.new(standard: %w[marc bibframe]) }
-  #
-  #   it 'maps datatypes' do
-  #     expect(value.standard).to eq(%w[marc bibframe])
-  #   end
-  # end
-
   context 'when an array of schemas' do
     # Administrative.releaseTags is an array of ReleaseTags
 


### PR DESCRIPTION


## Why was this change made?

there are no longer any string arrays in the Description model

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?
n/a


