### PR TITLE
Bump rake to 13

### DIFF
--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'committee'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.74.0'
   spec.add_development_dependency 'rubocop-rspec'


### PR DESCRIPTION
## Why was this change made?
Rake 13 is the latest version


## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

n/a

