### PR TITLE
Generate without depending on rubocop for formatting

### DIFF
--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -15,12 +15,7 @@ module Cocina
           module Cocina
             module Models
               class #{name} < Struct
-
-                #{types}
-
-                #{model_attributes}
-
-                #{validate}
+          #{types}#{model_attributes}#{validate}
               end
             end
           end
@@ -51,24 +46,20 @@ module Cocina
         type_properties_doc = schema_doc.properties['type']
         return '' if type_properties_doc.nil? || type_properties_doc.enum.nil?
 
-        types_list = type_properties_doc.enum.map { |item| "'#{item}'" }.join(",\n ")
+        types_list = type_properties_doc.enum.map { |item| "        '#{item}'" }.join(",\n")
 
-        <<~RUBY
-          include Checkable
-
-          TYPES = [#{types_list}].freeze
-        RUBY
+        "      include Checkable\n\n" \
+        "      TYPES = [\n#{types_list}\n      ].freeze\n\n"
       end
 
       def validate
         return '' unless validatable?
 
-        <<~RUBY
-          def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-            Validator.validate(self, attributes.with_indifferent_access) if validate && name
-            super(attributes, safe, &block)
-                end
-        RUBY
+        "\n\n" \
+        "      def self.new(attributes = default_attributes, safe = false, validate = true, &block)\n" \
+        "        Validator.validate(self, attributes.with_indifferent_access) if validate && name\n" \
+        "        super(attributes, safe, &block)\n" \
+        '      end'
       end
 
       def validatable?

--- a/lib/cocina/generator/schema_array.rb
+++ b/lib/cocina/generator/schema_array.rb
@@ -5,7 +5,7 @@ module Cocina
     # Class for generating from an openapi array
     class SchemaArray < SchemaBase
       def generate
-        "attribute :#{name.camelize(:lower)}, Types::Strict::Array.of(#{array_of_type})#{omittable}"
+        "      attribute :#{name.camelize(:lower)}, Types::Strict::Array.of(#{array_of_type})#{omittable}"
       end
 
       def omittable

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -36,13 +36,13 @@ module Cocina
       def description
         return '' unless schema_doc.description
 
-        "# #{schema_doc.description}\n"
+        "      # #{schema_doc.description}\n"
       end
 
       def example
         return '' unless schema_doc.example
 
-        "# example: #{schema_doc.example}\n"
+        "      # example: #{schema_doc.example}\n"
       end
 
       def dry_datatype(doc)

--- a/lib/cocina/generator/schema_ref.rb
+++ b/lib/cocina/generator/schema_ref.rb
@@ -6,9 +6,9 @@ module Cocina
     class SchemaRef < SchemaBase
       def generate
         if required
-          "attribute(:#{name.camelize(:lower)}, #{schema_doc.name}.default { #{schema_doc.name}.new })"
+          "      attribute(:#{name.camelize(:lower)}, #{schema_doc.name}.default { #{schema_doc.name}.new })"
         else
-          "attribute :#{name.camelize(:lower)}, #{schema_doc.name}.optional.meta(omittable: true)"
+          "      attribute :#{name.camelize(:lower)}, #{schema_doc.name}.optional.meta(omittable: true)"
         end
       end
     end

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -6,7 +6,7 @@ module Cocina
     class SchemaValue < SchemaBase
       # rubocop:disable Layout/LineLength
       def generate
-        "#{description}#{example}attribute :#{name.camelize(:lower)}, Types::#{dry_datatype(schema_doc)}#{default}#{enum}#{omittable}"
+        "#{description}#{example}      attribute :#{name.camelize(:lower)}, Types::#{dry_datatype(schema_doc)}#{default}#{enum}#{omittable}"
       end
       # rubocop:enable Layout/LineLength
 

--- a/lib/cocina/generator/vocab.rb
+++ b/lib/cocina/generator/vocab.rb
@@ -14,17 +14,14 @@ module Cocina
 
       def generate
         <<~RUBY
-                    # frozen_string_literal: true
-
-                    module Cocina
-                      module Models
-                        # A digital repository object.  See http://sul-dlss.github.io/cocina-models/maps/DRO.json
-                        class Vocab
-
-          #{vocab_methods}
-
-                        end
-                      end
+          # frozen_string_literal: true
+          
+          module Cocina
+            module Models
+              # A digital repository object.  See http://sul-dlss.github.io/cocina-models/maps/DRO.json
+              class Vocab
+          #{vocab_methods}    end
+            end
           end
         RUBY
       end
@@ -50,12 +47,9 @@ module Cocina
         # Note special handling of 3d
         vocabs.map do |vocab|
           name = vocab[38, vocab.size - 45].gsub('-', '_').gsub('3d', 'three_dimensional')
-          <<~RUBY
-            def self.#{name}
-              "#{vocab}"
-            end
-
-          RUBY
+          "      def self.#{name}\n" \
+          "        '#{vocab}'\n" \
+          "      end\n"
         end.join("\n")
       end
     end

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -5,7 +5,9 @@ module Cocina
     class AdminPolicy < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
+      ].freeze
 
       # example: item
       attribute :type, Types::Strict::String.enum(*AdminPolicy::TYPES)

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -5,11 +5,13 @@ module Cocina
     class Collection < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/curated-collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/user-collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
-               'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/curated-collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/user-collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
+        'http://cocina.sul.stanford.edu/models/series.jsonld'
+      ].freeze
 
       # The content type of the Collection. Selected from an established set of values.
       # example: item

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -5,21 +5,23 @@ module Cocina
     class DRO < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/object.jsonld',
-               'http://cocina.sul.stanford.edu/models/3d.jsonld',
-               'http://cocina.sul.stanford.edu/models/agreement.jsonld',
-               'http://cocina.sul.stanford.edu/models/book.jsonld',
-               'http://cocina.sul.stanford.edu/models/document.jsonld',
-               'http://cocina.sul.stanford.edu/models/geo.jsonld',
-               'http://cocina.sul.stanford.edu/models/image.jsonld',
-               'http://cocina.sul.stanford.edu/models/page.jsonld',
-               'http://cocina.sul.stanford.edu/models/photograph.jsonld',
-               'http://cocina.sul.stanford.edu/models/manuscript.jsonld',
-               'http://cocina.sul.stanford.edu/models/map.jsonld',
-               'http://cocina.sul.stanford.edu/models/media.jsonld',
-               'http://cocina.sul.stanford.edu/models/track.jsonld',
-               'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
-               'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/object.jsonld',
+        'http://cocina.sul.stanford.edu/models/3d.jsonld',
+        'http://cocina.sul.stanford.edu/models/agreement.jsonld',
+        'http://cocina.sul.stanford.edu/models/book.jsonld',
+        'http://cocina.sul.stanford.edu/models/document.jsonld',
+        'http://cocina.sul.stanford.edu/models/geo.jsonld',
+        'http://cocina.sul.stanford.edu/models/image.jsonld',
+        'http://cocina.sul.stanford.edu/models/page.jsonld',
+        'http://cocina.sul.stanford.edu/models/photograph.jsonld',
+        'http://cocina.sul.stanford.edu/models/manuscript.jsonld',
+        'http://cocina.sul.stanford.edu/models/map.jsonld',
+        'http://cocina.sul.stanford.edu/models/media.jsonld',
+        'http://cocina.sul.stanford.edu/models/track.jsonld',
+        'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
+        'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'
+      ].freeze
 
       # The content type of the DRO. Selected from an established set of values.
       # example: item

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -5,7 +5,9 @@ module Cocina
     class File < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/file.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/file.jsonld'
+      ].freeze
 
       # The content type of the File.
       attribute :type, Types::Strict::String.enum(*File::TYPES)

--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -5,7 +5,9 @@ module Cocina
     class FileSet < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/fileset.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/fileset.jsonld'
+      ].freeze
 
       # The content type of the Fileset.
       attribute :type, Types::Strict::String.enum(*FileSet::TYPES)

--- a/lib/cocina/models/message_digest.rb
+++ b/lib/cocina/models/message_digest.rb
@@ -5,8 +5,10 @@ module Cocina
     class MessageDigest < Struct
       include Checkable
 
-      TYPES = %w[md5
-                 sha1].freeze
+      TYPES = %w[
+        md5
+        sha1
+      ].freeze
 
       # The algorithm that was used
       attribute :type, Types::Strict::String.enum(*MessageDigest::TYPES)

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -5,7 +5,9 @@ module Cocina
     class RequestAdminPolicy < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
+      ].freeze
 
       # example: item
       attribute :type, Types::Strict::String.enum(*RequestAdminPolicy::TYPES)

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -5,11 +5,13 @@ module Cocina
     class RequestCollection < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/curated-collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/user-collection.jsonld',
-               'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
-               'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/curated-collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/user-collection.jsonld',
+        'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
+        'http://cocina.sul.stanford.edu/models/series.jsonld'
+      ].freeze
 
       # example: item
       attribute :type, Types::Strict::String.enum(*RequestCollection::TYPES)

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -5,21 +5,23 @@ module Cocina
     class RequestDRO < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/object.jsonld',
-               'http://cocina.sul.stanford.edu/models/3d.jsonld',
-               'http://cocina.sul.stanford.edu/models/agreement.jsonld',
-               'http://cocina.sul.stanford.edu/models/book.jsonld',
-               'http://cocina.sul.stanford.edu/models/document.jsonld',
-               'http://cocina.sul.stanford.edu/models/geo.jsonld',
-               'http://cocina.sul.stanford.edu/models/image.jsonld',
-               'http://cocina.sul.stanford.edu/models/page.jsonld',
-               'http://cocina.sul.stanford.edu/models/photograph.jsonld',
-               'http://cocina.sul.stanford.edu/models/manuscript.jsonld',
-               'http://cocina.sul.stanford.edu/models/map.jsonld',
-               'http://cocina.sul.stanford.edu/models/media.jsonld',
-               'http://cocina.sul.stanford.edu/models/track.jsonld',
-               'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
-               'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/object.jsonld',
+        'http://cocina.sul.stanford.edu/models/3d.jsonld',
+        'http://cocina.sul.stanford.edu/models/agreement.jsonld',
+        'http://cocina.sul.stanford.edu/models/book.jsonld',
+        'http://cocina.sul.stanford.edu/models/document.jsonld',
+        'http://cocina.sul.stanford.edu/models/geo.jsonld',
+        'http://cocina.sul.stanford.edu/models/image.jsonld',
+        'http://cocina.sul.stanford.edu/models/page.jsonld',
+        'http://cocina.sul.stanford.edu/models/photograph.jsonld',
+        'http://cocina.sul.stanford.edu/models/manuscript.jsonld',
+        'http://cocina.sul.stanford.edu/models/map.jsonld',
+        'http://cocina.sul.stanford.edu/models/media.jsonld',
+        'http://cocina.sul.stanford.edu/models/track.jsonld',
+        'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
+        'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'
+      ].freeze
 
       # example: item
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -5,7 +5,9 @@ module Cocina
     class RequestFile < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/file.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/file.jsonld'
+      ].freeze
 
       attribute :type, Types::Strict::String.enum(*RequestFile::TYPES)
       attribute :label, Types::Strict::String

--- a/lib/cocina/models/request_file_set.rb
+++ b/lib/cocina/models/request_file_set.rb
@@ -5,7 +5,9 @@ module Cocina
     class RequestFileSet < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/fileset.jsonld'].freeze
+      TYPES = [
+        'http://cocina.sul.stanford.edu/models/fileset.jsonld'
+      ].freeze
 
       attribute :type, Types::Strict::String.enum(*RequestFileSet::TYPES)
       attribute :label, Types::Strict::String


### PR DESCRIPTION
## Why was this change made?

Less noise in the output

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

