### PR TITLE
Allow integer data type in DescriptiveBasicValue

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -430,8 +430,10 @@ components:
           additionalProperties: false
           properties:
             value:
-              description: String value of the descriptive element.
-              type: string
+              description: String or integer value of the descriptive element.
+              oneOf:
+              - type: string
+              - type: integer
             type:
               description: Type of value provided by the descriptive element.
               type: string


### PR DESCRIPTION
## Why was this change made?

To allow integer value for nonsorting character count

## How was this change tested?

Swagger editor validation

## Which documentation and/or configurations were updated?

cocina_descriptive_metadata/description_v4.json updated to description_v4-1.json


