### PR TITLE
Simplify modeling for the language property in the context of DescriptiveBasicValue

### DIFF
--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Language.optional.meta(omittable: true)
+      attribute :language, Standard.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Language.optional.meta(omittable: true)
+      attribute :language, Standard.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/descriptive_value_required.rb
+++ b/lib/cocina/models/descriptive_value_required.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Language.optional.meta(omittable: true)
+      attribute :language, Standard.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Language.optional.meta(omittable: true)
+      attribute :language, Standard.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
       attribute :script, DescriptiveValue.optional.meta(omittable: true)
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -468,7 +468,8 @@ components:
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
             language:
-              $ref: "#/components/schemas/Language"
+              # description: Language of the descriptive element value.
+              $ref: "#/components/schemas/Standard"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -854,7 +854,7 @@ components:
             $ref: '#/components/schemas/CatalogLink'
     Language:
       description: Languages, scripts, symbolic systems, and notations used in all
-        or part of a resource or metadata value.
+        or part of a resource or its descriptive metadata.
       type: object
       additionalProperties: false
       allOf:


### PR DESCRIPTION
## Why was this change made?

To simplify modeling for the language property in the context of DescriptiveBasicValue

## How was this change tested?

swagger.io

## Which documentation and/or configurations were updated?

cocina_descriptive_metadata/description_cocina_schema_v4-2.json

