### PR TITLE
Extract a DescriptiveValueLanguage schema

### DIFF
--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Standard.optional.meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Standard.optional.meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/descriptive_value_language.rb
+++ b/lib/cocina/models/descriptive_value_language.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class DescriptiveValueLanguage < Struct
+      # Code representing the standard or encoding.
+      attribute :code, Types::Strict::String.meta(omittable: true)
+      # URI for the standard or encoding.
+      attribute :uri, Types::Strict::String.meta(omittable: true)
+      # String describing the standard or encoding.
+      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :source, Source.optional.meta(omittable: true)
+      attribute :valueScript, Standard.optional.meta(omittable: true)
+    end
+  end
+end

--- a/lib/cocina/models/descriptive_value_required.rb
+++ b/lib/cocina/models/descriptive_value_required.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Standard.optional.meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
     end
   end

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -23,7 +23,7 @@ module Cocina
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
       attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :language, Standard.optional.meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
       attribute :script, DescriptiveValue.optional.meta(omittable: true)
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -468,15 +468,7 @@ components:
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
             valueLanguage:
-              # description: Language of the descriptive element value.
-              allOf:
-                - $ref: "#/components/schemas/Standard"
-                - type: object
-                  properties:
-                    valueScript:
-                      $ref: '#/components/schemas/Standard'
-                      # description: An alphabet or other notation used to represent a
-                      #   language or other symbolic system of the descriptive element value.
+              $ref: "#/components/schemas/DescriptiveValueLanguage"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object
@@ -502,6 +494,18 @@ components:
       allOf:
         - $ref: "#/components/schemas/DescriptiveBasicValue"
         - $ref: "#/components/schemas/AppliesTo"
+    DescriptiveValueLanguage:
+      description: Language of the descriptive element value
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/Standard"
+        - type: object
+          properties:
+            valueScript:
+              $ref: '#/components/schemas/Standard'
+              # description: An alphabet or other notation used to represent a
+              #   language or other symbolic system of the descriptive element value.
     DescriptiveValueRequired:
       type: object
       additionalProperties: false


### PR DESCRIPTION


## Why was this change made?
The generator can't cope with allOf for an attribute


## How was this change tested?



## Which documentation and/or configurations were updated?



