### PR TITLE
Remove download access from Access schema

### DIFF
--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -5,8 +5,6 @@ module Cocina
     class Access < Struct
       # Access level
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
-      # Download access level for a file
-      attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
       # If access is "location-based", which location should have access.
       attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -108,15 +108,6 @@ components:
             - 'citation-only'
             - 'dark'
           default: 'dark'
-        download:
-          description: Download access level for a file
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'none'
-          default: 'none'
         readLocation:
           description: If access is "location-based", which location should have access.
           type: string


### PR DESCRIPTION

## Why was this change made?
The Access schema is used only by collections. DROs and Files have their own Access schema which supports download access



## How was this change tested?



## Which documentation and/or configurations were updated?



