### PR TITLE
Updated DVL, source, and standard models with version attribute

### DIFF
--- a/lib/cocina/models/descriptive_value_language.rb
+++ b/lib/cocina/models/descriptive_value_language.rb
@@ -11,6 +11,8 @@ module Cocina
       attribute :value, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The version of the standard or encoding.
+      attribute :version, Types::Strict::String.meta(omittable: true)
       attribute :valueScript, Standard.optional.meta(omittable: true)
     end
   end

--- a/lib/cocina/models/source.rb
+++ b/lib/cocina/models/source.rb
@@ -10,6 +10,8 @@ module Cocina
       # String describing the value source.
       attribute :value, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      # The version of the value source.
+      attribute :version, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -11,6 +11,8 @@ module Cocina
       attribute :value, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # The version of the standard or encoding.
+      attribute :version, Types::Strict::String.meta(omittable: true)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

To bring the Ruby models in alignment with the specification.

## How was this change tested?

By running through generation, per the README.

## Which documentation and/or configurations were updated?

None.

