### PR TITLE
Quiet rubocop output when generating models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,3 +143,34 @@ Style/SingleArgumentDig:
 
 Style/StringConcatenation:
   Enabled: true
+
+Layout/BeginEndAlignment: # (new in 0.91)
+  Enabled: true
+Lint/ConstantDefinitionInBlock: # (new in 0.91)
+  Enabled: true
+Lint/DuplicateRequire: # (new in 0.90)
+  Enabled: true
+Lint/EmptyFile: # (new in 0.90)
+  Enabled: true
+Lint/HashCompareByIdentity: # (new in 0.93)
+  Enabled: true
+Lint/IdentityComparison: # (new in 0.91)
+  Enabled: true
+Lint/RedundantSafeNavigation: # (new in 0.93)
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
+  Enabled: true
+Lint/UselessMethodDefinition: # (new in 0.90)
+  Enabled: true
+Lint/UselessTimes: # (new in 0.91)
+  Enabled: true
+Style/ClassEqualityComparison: # (new in 0.93)
+  Enabled: true
+Style/CombinableLoops: # (new in 0.90)
+  Enabled: true
+Style/KeywordParametersOrder: # (new in 0.90)
+  Enabled: true
+Style/RedundantSelfAssignment: # (new in 0.90)
+  Enabled: true
+Style/SoleNestedConditional: # (new in 0.89)
+  Enabled: true

--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -45,7 +45,7 @@ module Cocina
         FileUtils.rm_f(filepath)
 
         create_file filepath, vocab.generate
-        run("rubocop -a #{filepath}")
+        run("rubocop -a #{filepath} > /dev/null")
       end
 
       private
@@ -71,7 +71,7 @@ module Cocina
         FileUtils.rm_f(filepath)
 
         create_file filepath, schema.generate
-        run("rubocop -a #{filepath}")
+        run("rubocop -a #{filepath} > /dev/null")
       end
 
       def clean_output


### PR DESCRIPTION
Connects to #135 (an alternative approach)

## Why was this change made?

To reduce spammy output when generating models but without giving up on Rubocop. 

Output now looks like:

```shell
$ exe/generator generate                                        
      create  lib/cocina/models/access.rb                                                                                                             
         run  rubocop -a lib/cocina/models/access.rb > /dev/null from "."                                                                             
      create  lib/cocina/models/administrative.rb                                                                                                     
         run  rubocop -a lib/cocina/models/administrative.rb > /dev/null from "."                                                                     
      create  lib/cocina/models/admin_policy.rb                                                                                                       
         run  rubocop -a lib/cocina/models/admin_policy.rb > /dev/null from "."                                                                       
      create  lib/cocina/models/admin_policy_administrative.rb                                                                                        
         run  rubocop -a lib/cocina/models/admin_policy_administrative.rb > /dev/null from "."                                                        
      create  lib/cocina/models/applies_to.rb                                                                                                         
         run  rubocop -a lib/cocina/models/applies_to.rb > /dev/null from "."                                                                         
      create  lib/cocina/models/catalog_link.rb                                                                                                       
         run  rubocop -a lib/cocina/models/catalog_link.rb > /dev/null from "."                                                                       
      create  lib/cocina/models/collection.rb                                                                                                         
         run  rubocop -a lib/cocina/models/collection.rb > /dev/null from "."                                                                         
      create  lib/cocina/models/collection_identification.rb                                                                                          
         run  rubocop -a lib/cocina/models/collection_identification.rb > /dev/null from "."                                                          
      create  lib/cocina/models/contributor.rb                                                                                                        
         run  rubocop -a lib/cocina/models/contributor.rb > /dev/null from "."                                                                        
      create  lib/cocina/models/description.rb                                                                                                        
         run  rubocop -a lib/cocina/models/description.rb > /dev/null from "."                                                                        
      create  lib/cocina/models/descriptive_access_metadata.rb                                                                                        
         run  rubocop -a lib/cocina/models/descriptive_access_metadata.rb > /dev/null from "."                                                        
      create  lib/cocina/models/descriptive_admin_metadata.rb                                                                                         
         run  rubocop -a lib/cocina/models/descriptive_admin_metadata.rb > /dev/null from "."                                                         
      create  lib/cocina/models/descriptive_basic_value.rb                                                                                            
         run  rubocop -a lib/cocina/models/descriptive_basic_value.rb > /dev/null from "."                                                            
      create  lib/cocina/models/descriptive_parallel_value.rb                                                                                         
         run  rubocop -a lib/cocina/models/descriptive_parallel_value.rb > /dev/null from "."              
      create  lib/cocina/models/descriptive_structured_value.rb
         run  rubocop -a lib/cocina/models/descriptive_structured_value.rb > /dev/null from "."
      create  lib/cocina/models/descriptive_value.rb
         run  rubocop -a lib/cocina/models/descriptive_value.rb > /dev/null from "."
      create  lib/cocina/models/descriptive_value_language.rb
         run  rubocop -a lib/cocina/models/descriptive_value_language.rb > /dev/null from "."
      create  lib/cocina/models/title.rb
         run  rubocop -a lib/cocina/models/title.rb > /dev/null from "."
      create  lib/cocina/models/dro.rb
         run  rubocop -a lib/cocina/models/dro.rb > /dev/null from "."
      create  lib/cocina/models/dro_access.rb
         run  rubocop -a lib/cocina/models/dro_access.rb > /dev/null from "."
      create  lib/cocina/models/dro_structural.rb
         run  rubocop -a lib/cocina/models/dro_structural.rb > /dev/null from "."
      create  lib/cocina/models/druid.rb
         run  rubocop -a lib/cocina/models/druid.rb > /dev/null from "."
      create  lib/cocina/models/embargo.rb
         run  rubocop -a lib/cocina/models/embargo.rb > /dev/null from "."
      create  lib/cocina/models/event.rb
         run  rubocop -a lib/cocina/models/event.rb > /dev/null from "."
      create  lib/cocina/models/file.rb
         run  rubocop -a lib/cocina/models/file.rb > /dev/null from "."
      create  lib/cocina/models/file_access.rb
         run  rubocop -a lib/cocina/models/file_access.rb > /dev/null from "."
      create  lib/cocina/models/file_administrative.rb
         run  rubocop -a lib/cocina/models/file_administrative.rb > /dev/null from "."
      create  lib/cocina/models/file_set.rb
         run  rubocop -a lib/cocina/models/file_set.rb > /dev/null from "."
      create  lib/cocina/models/file_set_structural.rb
         run  rubocop -a lib/cocina/models/file_set_structural.rb > /dev/null from "."
      create  lib/cocina/models/geographic.rb
         run  rubocop -a lib/cocina/models/geographic.rb > /dev/null from "."
      create  lib/cocina/models/identification.rb
         run  rubocop -a lib/cocina/models/identification.rb > /dev/null from "."
      create  lib/cocina/models/language.rb
         run  rubocop -a lib/cocina/models/language.rb > /dev/null from "."
      create  lib/cocina/models/message_digest.rb
         run  rubocop -a lib/cocina/models/message_digest.rb > /dev/null from "."
      create  lib/cocina/models/presentation.rb
         run  rubocop -a lib/cocina/models/presentation.rb > /dev/null from "."
      create  lib/cocina/models/related_resource.rb
         run  rubocop -a lib/cocina/models/related_resource.rb > /dev/null from "."
      create  lib/cocina/models/release_tag.rb
         run  rubocop -a lib/cocina/models/release_tag.rb > /dev/null from "."
      create  lib/cocina/models/request_admin_policy.rb
         run  rubocop -a lib/cocina/models/request_admin_policy.rb > /dev/null from "."
      create  lib/cocina/models/request_collection.rb
         run  rubocop -a lib/cocina/models/request_collection.rb > /dev/null from "."
      create  lib/cocina/models/request_dro.rb
         run  rubocop -a lib/cocina/models/request_dro.rb > /dev/null from "."
      create  lib/cocina/models/request_dro_structural.rb
         run  rubocop -a lib/cocina/models/request_dro_structural.rb > /dev/null from "."
      create  lib/cocina/models/request_file.rb
         run  rubocop -a lib/cocina/models/request_file.rb > /dev/null from "."
      create  lib/cocina/models/request_file_set.rb
         run  rubocop -a lib/cocina/models/request_file_set.rb > /dev/null from "."
      create  lib/cocina/models/request_file_set_structural.rb
         run  rubocop -a lib/cocina/models/request_file_set_structural.rb > /dev/null from "."
      create  lib/cocina/models/request_identification.rb
         run  rubocop -a lib/cocina/models/request_identification.rb > /dev/null from "."
      create  lib/cocina/models/sequence.rb
         run  rubocop -a lib/cocina/models/sequence.rb > /dev/null from "."
      create  lib/cocina/models/source.rb
         run  rubocop -a lib/cocina/models/source.rb > /dev/null from "."
      create  lib/cocina/models/source_id.rb
         run  rubocop -a lib/cocina/models/source_id.rb > /dev/null from "."
      create  lib/cocina/models/standard.rb
         run  rubocop -a lib/cocina/models/standard.rb > /dev/null from "."
      create  lib/cocina/models/vocab.rb
         run  rubocop -a lib/cocina/models/vocab.rb > /dev/null from "."
```

## How was this change tested?

Ran the generator.

## Which documentation and/or configurations were updated?

None.

