### PR TITLE
Separate language to its own model

### DIFF
--- a/lib/cocina/models/descriptive_value_language.rb
+++ b/lib/cocina/models/descriptive_value_language.rb
@@ -10,7 +10,7 @@ module Cocina
       # String describing the standard or encoding.
       attribute :value, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # The version of the value standard.
+      # The version of the standard or encoding.
       attribute :version, Types::Strict::String.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
       attribute :valueScript, Standard.optional.meta(omittable: true)

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -3,30 +3,27 @@
 module Cocina
   module Models
     class Language < Struct
-      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # String or integer value of the descriptive element.
-      attribute :value, Types::Nominal::Any.meta(omittable: true)
-      # Type of value provided by the descriptive element.
-      attribute :type, Types::Strict::String.meta(omittable: true)
-      # Status of the descriptive element value relative to other instances of the element.
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
       # Code value of the descriptive element.
       attribute :code, Types::Strict::String.meta(omittable: true)
-      # URI value of the descriptive element.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
-      attribute :encoding, Standard.optional.meta(omittable: true)
-      attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
       # The preferred display label to use for the descriptive element in access systems.
       attribute :displayLabel, Types::Strict::String.meta(omittable: true)
-      # A term providing information about the circumstances of the statement (e.g., approximate dates).
-      attribute :qualifier, Types::Strict::String.meta(omittable: true)
+      attribute :encoding, Standard.optional.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).meta(omittable: true)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      # present for mapping to additional schemas in the future and for consistency but not otherwise used
+      attribute :qualifier, Types::Strict::String.meta(omittable: true)
       attribute :script, DescriptiveValue.optional.meta(omittable: true)
+      attribute :source, Source.optional.meta(omittable: true)
+      # Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
+      attribute :status, Types::Strict::String.enum('primary').meta(omittable: true)
+      attribute :standard, Standard.optional.meta(omittable: true)
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      # URI value of the descriptive element.
+      attribute :uri, Types::Strict::String.meta(omittable: true)
+      # Value of the descriptive element.
+      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -10,7 +10,7 @@ module Cocina
       # String describing the standard or encoding.
       attribute :value, Types::Strict::String.meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # The version of the value standard.
+      # The version of the standard or encoding.
       attribute :version, Types::Strict::String.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -880,17 +880,63 @@ components:
         or part of a resource or its descriptive metadata.
       type: object
       additionalProperties: false
-      allOf:
-        - $ref: '#/components/schemas/DescriptiveValue'
-        - type: object
-          # additionalProperties breaks the validator, presumably because it can't
-          # conform to other schemas (allOf) and not have additionalProperties
-          # additionalProperties: false
-          properties:
-            script:
-              $ref: '#/components/schemas/DescriptiveValue'
-              # description: An alphabet or other notation used to represent a
-              #   language or other symbolic system associated with the resource.
+      properties:
+        appliesTo:
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveBasicValue"
+        code:
+          description: Code value of the descriptive element.
+          type: string
+        displayLabel:
+          description: The preferred display label to use for the descriptive element in access systems.
+          type: string
+        encoding:
+          # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          $ref: "#/components/schemas/Standard"
+        note:
+          description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        parallelValue:
+          description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        qualifier:
+          type: string
+          description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+        script:
+          $ref: '#/components/schemas/DescriptiveValue'
+          # description: An alphabet or other notation used to represent a
+          #   language or other symbolic system associated with the resource.
+        source:
+          $ref: "#/components/schemas/Source"
+        status:
+          description: Status of the contributor relative to other parallel contributors
+            (e.g. the primary author among a group of contributors).
+          type: string
+          enum:
+            - primary
+        standard:
+          # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          $ref: "#/components/schemas/Standard"
+        structuredValue:
+          description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        uri:
+          description: URI value of the descriptive element.
+          type: string
+          format: uri
+        value:
+          description: Value of the descriptive element.
+          type: string
+        valueLanguage:
+          # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
+          $ref: "#/components/schemas/DescriptiveValueLanguage"
     MessageDigest:
       description: The output of the message digest algorithm.
       type: object


### PR DESCRIPTION


## Why was this change made?
Previously it was not accepting script as a valid property. Possibly becase it was doing allOf with members that specified additionalProperties: false

Ref https://github.com/sul-dlss/dor-services-app/issues/1157


## How was this change tested?



## Which documentation and/or configurations were updated?



