### PR TITLE
Add geographic to cocina description

### DIFF
--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -7,6 +7,7 @@ module Cocina
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
       attribute :event, Types::Strict::Array.of(Event).meta(omittable: true)
       attribute :form, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :geographic, Types::Strict::Array.of(Geographic).meta(ommittable: true)
       attribute :language, Types::Strict::Array.of(Language).meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)

--- a/openapi.yml
+++ b/openapi.yml
@@ -304,6 +304,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+        geographic:
+          description: Something soemthing geographic
+          type: array
+          items:
+            $ref: "#/components/schemas/Geographic"
         language:
           description: Languages, scripts, symbolic systems, and notations used in all or
             part of a resource.


### PR DESCRIPTION
## Why was this change made?

Requires to complete the cocina mapping to and from fedora.

