### PR TITLE
Set some additionalProperties to true.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -137,7 +137,8 @@ components:
         - hasAdminPolicy
     AdminPolicy:
       type: object
-      additionalProperties: false
+      # This is set to true to avoid committee errors.
+      additionalProperties: true
       properties:
         type:
           type: string
@@ -201,7 +202,8 @@ components:
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
-      additionalProperties: false
+      # This is set to true to avoid committee errors.
+      additionalProperties: true
       properties:
         type:
           description: The content type of the Collection. Selected from an established set of values.
@@ -525,7 +527,8 @@ components:
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
-      additionalProperties: false
+      # This is set to true to avoid committee errors.
+      additionalProperties: true
       properties:
         type:
           description: The content type of the DRO. Selected from an established set of values.
@@ -1038,7 +1041,8 @@ components:
     ReleaseTag:
       description: A tag that indicates the item or collection should be released.
       type: object
-      additionalProperties: false
+      # This is set to true to avoid committee errors.
+      additionalProperties: true
       required:
         - release
       properties:


### PR DESCRIPTION
## Why was this change made?
There are some cases where setting additionalProperties to false causes committee problems. When the openapi is copied from cocina models to dor services app or SDR API, it is REAL easy to forget to make those changes (and the errors come out sideways). By placing these changes directly in this openapi it will avoid this problem.

## How was this change tested?
NA


## Which documentation and/or configurations were updated?
openapi


