### PR TITLE
openapi.yml: fix description of language status property

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -501,7 +501,7 @@ components:
           description: Terms associated with the intellectual content of the related resource.
           type: array
           items:
-            $ref: "#/components/schemas/DescriptiveValue"    
+            $ref: "#/components/schemas/DescriptiveValue"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object
@@ -946,7 +946,7 @@ components:
         source:
           $ref: "#/components/schemas/Source"
         status:
-          description: Status of the contributor relative to other parallel contributors
+          description: Status of the language relative to other parallel language elements (e.g. the primary language)
             (e.g. the primary author among a group of contributors).
           type: string
           enum:


### PR DESCRIPTION
## Why was this change made?

I noticed the comment was incorrect copypasta.

## How was this change tested?

it's just the description in the openapi.yml

## Which documentation and/or configurations were updated?



