### PR TITLE
Add the type property to the Standard schema

### DIFF
--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -13,6 +13,8 @@ module Cocina
       # The version of the standard or encoding.
       attribute :version, Types::Strict::String.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # Type of value provided by the descriptive element.
+      attribute :type, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1361,3 +1361,6 @@ components:
           type: string
         source:
           $ref: "#/components/schemas/Source"
+        type:
+          description: Type of value provided by the descriptive element.
+          type: string


### PR DESCRIPTION
## Why was this change made?

Add `type` to `Standard` to address:

```
Error: #/components/schemas/Standard does not define properties: type (2585 errors)
Examples: druid:zw685dw6356, druid:hv751kj0082, druid:ft545jn7796, druid:pf602td9391, druid:hv022gv3986, druid:wt776rw3893, druid:tt596nz1569, druid:mn953qz8474, druid:mj707sx9198, druid:jr037zj8458
```

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A


