### PR TITLE
Fix the description for message digest

### DIFF
--- a/lib/cocina/models/message_digest.rb
+++ b/lib/cocina/models/message_digest.rb
@@ -10,7 +10,7 @@ module Cocina
 
       # The algorithm that was used
       attribute :type, Types::Strict::String.enum(*MessageDigest::TYPES)
-      # The digest value Base64 encoded
+      # The digest value hexidecimal encoded
       attribute :digest, Types::Strict::String
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -968,7 +968,7 @@ components:
             - md5
             - sha1
         digest:
-          description: The digest value Base64 encoded
+          description: The digest value hexidecimal encoded
           type: string
       required:
         - type


### PR DESCRIPTION


## Why was this change made?

Previously it indicated Base64 encoding, but we always use hex encoding

## How was this change tested?



## Which documentation and/or configurations were updated?



