### PR TITLE
Add type to standard

### DIFF
--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -13,6 +13,8 @@ module Cocina
       # The version of the standard or encoding.
       attribute :version, Types::Strict::String.meta(omittable: true)
       attribute :source, Source.optional.meta(omittable: true)
+      # Type of value provided by the descriptive element.
+      attribute :type, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1364,3 +1364,7 @@ components:
           type: string
         source:
           $ref: "#/components/schemas/Source"
+        type:
+          description: Type of value provided by the descriptive element.
+          type: string
+  


### PR DESCRIPTION
## Why was this change made?

To address a validation error for geoExtension:

```
Error: #/components/schemas/Standard does not define properties: type (2321 errors)
Examples: druid:kc077zt9844, druid:vx722vc3405, druid:by600fq9386, druid:gp648mv8238, druid:qp493vs1757, druid:gd408vx9336, druid:kx697qh8411, druid:xz981qh7561, druid:xz353zm4455, druid:gt953mf3634
```

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A


