### PR TITLE
openapi.yml: remove vestigial desc phrase

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -935,7 +935,6 @@ components:
           $ref: "#/components/schemas/Source"
         status:
           description: Status of the language relative to other parallel language elements (e.g. the primary language)
-            (e.g. the primary author among a group of contributors).
           type: string
           enum:
             - primary


### PR DESCRIPTION
## Why was this change made?

Correcting some description text (effectively, a typo)

## How was this change tested?



## Which documentation and/or configurations were updated?



