### PR TITLE
Add digitalLocation property to DescriptiveAccessMetadata for born di…

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -365,6 +365,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+        digitalLocation:
+          description: Location of a digital version of the resource, such as a file path for a born digital resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
         accessContact:
           description: The library, organization, or person responsible for access to the resource.
           type: array


### PR DESCRIPTION
…gital use case

## Why was this change made?
To allow indicating location for born-digital resources


## How was this change tested?
swagger.io


## Which documentation and/or configurations were updated?
cocina-descriptive-metadata


