### PR TITLE
pr-template gets note about generating models for openapi.yml changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+**NOTE:  Changes to openapi.yml require generating models - see README.**
+
 ## Why was this change made?
 
 
@@ -7,6 +9,3 @@
 
 
 ## Which documentation and/or configurations were updated?
-
-
-


### PR DESCRIPTION
## Why was this change made?

Because I forgot to do this, and I may not be the only one.

## How was this change tested?



## Which documentation and/or configurations were updated?



