### PR TITLE
pr-template gets note about propagating openapi.yml changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**NOTE:  Changes to openapi.yml require generating models - see README.**
+**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**
 
 ## Why was this change made?
 


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require generating models - see README.**

## Why was this change made?

For the clueless among us, having the pr template ALSO say that we need to update openapi.yml in other apps is helpful.

## How was this change tested?



## Which documentation and/or configurations were updated?
