### PR TITLE
generate models: DescriptiveAccessMetadata gets digitalLocation

### DIFF
--- a/lib/cocina/models/descriptive_access_metadata.rb
+++ b/lib/cocina/models/descriptive_access_metadata.rb
@@ -5,6 +5,7 @@ module Cocina
     class DescriptiveAccessMetadata < Struct
       attribute :url, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :physicalLocation, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :digitalLocation, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :accessContact, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :digitalRepository, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require generating models - see README.**

## Why was this change made?

PR #191 was merged without model generation.  D'oh.   It is one small additive change that only affects cocina mappings, so I'm generating the updated models now.

I need this for mapping ticket sul-dlss/dor-services-app/issues/1499

## How was this change tested?



## Which documentation and/or configurations were updated?
