### PR TITLE
Change adminMetadata.standard to adminMetadata.metadataStandard to ac…

### DIFF
--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'committee'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.87'
-  spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'rubocop', '~> 0.93'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.44'
   spec.add_development_dependency 'simplecov', '~> 0.17.0'
 end

--- a/lib/cocina/models/descriptive_admin_metadata.rb
+++ b/lib/cocina/models/descriptive_admin_metadata.rb
@@ -3,17 +3,12 @@
 module Cocina
   module Models
     class DescriptiveAdminMetadata < Struct
-
-      
-
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
-attribute :event, Types::Strict::Array.of(Event).meta(omittable: true)
-attribute :language, Types::Strict::Array.of(Language).meta(omittable: true)
-attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-attribute :metadataStandard, Types::Strict::Array.of(Standard).meta(omittable: true)
-attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-
-      
+      attribute :event, Types::Strict::Array.of(Event).meta(omittable: true)
+      attribute :language, Types::Strict::Array.of(Language).meta(omittable: true)
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :metadataStandard, Types::Strict::Array.of(Standard).meta(omittable: true)
+      attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/descriptive_admin_metadata.rb
+++ b/lib/cocina/models/descriptive_admin_metadata.rb
@@ -3,12 +3,17 @@
 module Cocina
   module Models
     class DescriptiveAdminMetadata < Struct
+
+      
+
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
-      attribute :event, Types::Strict::Array.of(Event).meta(omittable: true)
-      attribute :language, Types::Strict::Array.of(Language).meta(omittable: true)
-      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
-      attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+attribute :event, Types::Strict::Array.of(Event).meta(omittable: true)
+attribute :language, Types::Strict::Array.of(Language).meta(omittable: true)
+attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+attribute :metadataStandard, Types::Strict::Array.of(Standard).meta(omittable: true)
+attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+
+      
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -411,9 +411,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
-        standard:
-          # description: Descriptive or content standard to which this resource description conforms.
-          $ref: "#/components/schemas/Standard"
+        metadataStandard:
+          description: Descriptive or content standard(s) to which this resource description conforms.
+          type: array
+          items:
+            $ref: "#/components/schemas/Standard"
         identifier:
           description: Identifiers associated with this resource description.
           type: array


### PR DESCRIPTION
…commodate records with multiple standards

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
To address https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/232


## How was this change tested?
Swagger.io


## Which documentation and/or configurations were updated?
cocina-descriptive-metadata, stanford-library-metadata