### PR TITLE
Add dor indexing app to list of dependent services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Once the above listed gems are updated all the following services that use cocin
 * sul-dlss/hydrus
 * sul-dlss/happy-heron
 * sul-dlss/infrastructure-integration-test
+* sul-dlss/dor_indexing_app
 
 ## Using this gem
 


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
So keep list of dependent services accurate.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
