### PR TITLE
Fix openApi for DescriptiveValue.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -430,7 +430,7 @@ components:
     DescriptiveBasicValue:
       description: Basic value model for descriptive elements.
       type: object
-      # additionalProperties breaks the validator, unclear as to why.
+      # additionalProperties breaks the validator for allOf, unclear as to why.
       # additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
@@ -534,7 +534,8 @@ components:
     DescriptiveValue:
       description: Default value model for descriptive elements.
       type: object
-      additionalProperties: false
+      # additionalProperties breaks the validator for allOf, unclear as to why.
+      # additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveBasicValue"
         - $ref: "#/components/schemas/AppliesTo"


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
Similar to problem encountered with DescriptiveBasicValue, DescriptiveValue incorrectly validates when additionProperties is set to false. This is causing a problem with mappings in dor-services-app.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
openapi