### PR TITLE
Fix so that note can have an appliesTo attribute.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -437,7 +437,8 @@ components:
         - $ref: "#/components/schemas/DescriptiveParallelValue"
         - $ref: "#/components/schemas/DescriptiveGroupedValue"
         - type: object
-          additionalProperties: false
+          # additionalProperties breaks the validator for DescriptiveValue, unclear as to why.
+          # additionalProperties: false
           properties:
             value:
               description: String or integer value of the descriptive element.
@@ -534,8 +535,7 @@ components:
     DescriptiveValue:
       description: Default value model for descriptive elements.
       type: object
-      # additionalProperties breaks the validator for allOf, unclear as to why.
-      # additionalProperties: false
+      additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveBasicValue"
         - $ref: "#/components/schemas/AppliesTo"


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
Creating a note with an appliesTo attribute was creating an error (in dor-services-app).


## How was this change tested?
Linked to branch in dor-services-app and tested.


## Which documentation and/or configurations were updated?
openapi