### PR TITLE
Add sourceId to collections

### DIFF
--- a/lib/cocina/models/collection_identification.rb
+++ b/lib/cocina/models/collection_identification.rb
@@ -3,6 +3,10 @@
 module Cocina
   module Models
     class CollectionIdentification < Struct
+      # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
+
+      # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
+      attribute :sourceId, Types::Strict::String.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -239,6 +239,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
         catalogLinks:
           type: array
           items:


### PR DESCRIPTION


**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

This makes it possible to do asynchronous deposits, as the depositor needs to provide a sourceId and then listen for an object to come over the 'deposited' channel that has that sourceId. Then they will be able to know what the druid is for that object.  This is relevant to letting H2 use RabbitMQ for doing deposits.

## How was this change tested?



## Which documentation and/or configurations were updated?
