### PR TITLE
Add access roles to AdminSetAdministrative

### DIFF
--- a/lib/cocina/models/access_role.rb
+++ b/lib/cocina/models/access_role.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AccessRole < Struct
+      # Name of role
+      attribute :name, Types::Strict::String.enum('sdr-administrator', 'sdr-viewer', 'dor-apo-manager', 'hydrus-collection-creator', 'hydrus-collection-manager', 'hydrus-collection-depositor', 'hydrus-collection-item-depositor', 'hydrus-collection-reviewer', 'hydrus-collection-viewer')
+      attribute :members, Types::Strict::Array.of(AccessRoleMember).default([].freeze)
+    end
+  end
+end

--- a/lib/cocina/models/access_role_member.rb
+++ b/lib/cocina/models/access_role_member.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AccessRoleMember < Struct
+      include Checkable
+
+      TYPES = %w[sunetid
+                 workgroup].freeze
+
+      # Name of role
+      attribute :type, Types::Strict::String.enum(*AccessRoleMember::TYPES)
+      attribute :identifier, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -6,6 +6,7 @@ module Cocina
       attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
       attribute :registrationWorkflow, Types::Strict::String.meta(omittable: true)
       attribute :collectionsForRegistration, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
+      attribute :roles, Types::Strict::Array.of(AccessRole).meta(omittable: true)
       attribute :hasAdminPolicy, Types::Strict::String
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -118,6 +118,48 @@ components:
             - 'art'
             - 'hoover'
             - 'm&m'
+    AccessRole:
+      description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of role
+          type: string
+          enum:
+            - 'sdr-administrator'
+            - 'sdr-viewer'
+            - 'dor-apo-manager'
+            - 'hydrus-collection-creator'
+            - 'hydrus-collection-manager'
+            - 'hydrus-collection-depositor'
+            - 'hydrus-collection-item-depositor'
+            - 'hydrus-collection-reviewer'
+            - 'hydrus-collection-viewer'
+        members:
+          description: The users and groups that are members of the role
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessRoleMember'
+      required:
+        - members
+        - name
+    AccessRoleMember:
+      description: Represents a user or group that is a member of an AccessRole
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          description: Name of role
+          type: string
+          enum:
+            - 'sunetid'
+            - 'workgroup'
+        identifier:
+          type: string
+      required:
+        - identifier
+        - type
     Administrative:
       type: object
       additionalProperties: false
@@ -161,6 +203,7 @@ components:
         - type
         - version
     AdminPolicyAdministrative:
+      description: Administrative properties for an AdminPolicy
       type: object
       additionalProperties: false
       properties:
@@ -174,6 +217,11 @@ components:
           type: array
           items:
             type: string
+        roles:
+          description: The access roles conferred by this AdminPolicy (used by Argo)
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessRole'
         hasAdminPolicy:
           type: string
       required:


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
To support decoupling Argo/dor_indexing_app from Fedora


## How was this change tested?



## Which documentation and/or configurations were updated?
