### PR TITLE
Allow admin policies to have multiple registration workflows

### DIFF
--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class AdminPolicyAdministrative < Struct
       attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
-      attribute :registrationWorkflow, Types::Strict::String.meta(omittable: true)
+      attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
       attribute :collectionsForRegistration, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
       attribute :hasAdminPolicy, Types::Strict::String
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -168,7 +168,10 @@ components:
           type: string
           default: <?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>
         registrationWorkflow:
-          type: string
+          description: When you register an item with this admin policy, these are the workflows that are available.
+          type: array
+          items:
+            type: string
         collectionsForRegistration:
           description: When you register an item with this admin policy, these are the collections that are available.
           type: array


### PR DESCRIPTION


## Why was this change made?
Here is an example of one that does: https://argo.stanford.edu/view/druid:nz660xv7125


## How was this change tested?



## Which documentation and/or configurations were updated?
