### PR TITLE
Update openapi.yml for Event mapping use cases

### DIFF
--- a/lib/cocina/models/descriptive_parallel_event.rb
+++ b/lib/cocina/models/descriptive_parallel_event.rb
@@ -2,7 +2,18 @@
 
 module Cocina
   module Models
-    class Event < Struct
+    class DescriptiveParallelEvent < Struct
+      # Code representing the standard or encoding.
+      attribute :code, Types::Strict::String.meta(omittable: true)
+      # URI for the standard or encoding.
+      attribute :uri, Types::Strict::String.meta(omittable: true)
+      # String describing the standard or encoding.
+      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      # The version of the standard or encoding.
+      attribute :version, Types::Strict::String.meta(omittable: true)
+      attribute :source, Source.optional.meta(omittable: true)
+      attribute :valueScript, Standard.optional.meta(omittable: true)
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # Description of the event (creation, publication, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
@@ -12,8 +23,6 @@ module Cocina
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      attribute :parallelEvent, Types::Strict::Array.of(DescriptiveParallelEvent).meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -572,6 +572,47 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+    DescriptiveParallelEvent:
+      description: Value model for multiple representations of information about the same event (e.g. in different languages).
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/DescriptiveValueLanguage"
+        - $ref: "#/components/schemas/DescriptiveStructuredValue"
+        - type: object
+          additionalProperties: false
+          properties:
+            type:
+              description: Description of the event (creation, publication, etc.).
+              type: string
+            displayLabel:
+              description: The preferred display label to use for the event in access systems.
+              type: string
+            date:
+              description: Dates associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            contributor:
+              description: Contributors associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/Contributor"
+            location:
+              description: Locations associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            identifier:
+              description: Identifiers and URIs associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            note:
+              description: Other information about the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object
@@ -794,7 +835,6 @@ components:
       additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
-        - $ref: "#/components/schemas/DescriptiveParallelValue"
         - type: object
           additionalProperties: false
           properties:
@@ -829,6 +869,11 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
+            parallelEvent:
+              description: For multiple representations of information about the same event (e.g. in different languages)
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveParallelEvent"
     File:
       description: Binaries that are the basis of what our domain manages. Binaries here do not include metadata files generated for the domain's own management purposes.
       type: object


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

- I have branches with openapi.yml updated for both dor-services-app and sdr-api;  waiting for this the PR to be updated and for the gem release to move those forward.
- I will coordinate with FR and JCoyne re: updating dor-services-client and sdr-client gems, and the remaining PRs.  
- I believe the changes from THIS PR would only require updates to dor-services-app, as all the event handling is being done there.  🤷‍♀️ 
- I believe there are other changes since last gem release having to do with H2, which @jcoyne knows about.

## Why was this change made?

Event modeling changes to enable MODS originInfo mapping that will roundtrip cleanly.

This is a redo of Arcadia's PR #210, but rebased on main after PRs #212 and #213 were merged into main.

## How was this change tested?

circleci, mainly ... the openapi validator and rspec tests.

## Which documentation and/or configurations were updated?
