### PR TITLE
Allow validation to handle model that includes DateTime.

### DIFF
--- a/lib/cocina/models/validator.rb
+++ b/lib/cocina/models/validator.rb
@@ -7,7 +7,8 @@ module Cocina
       def self.validate(clazz, attributes)
         method_name = clazz.name.split('::').last
         request_operation = root.request_operation(:post, "/validate/#{method_name}")
-        request_operation.validate_request_body('application/json', attributes)
+        # JSON.parse forces serialization of objects like DateTime.
+        request_operation.validate_request_body('application/json', JSON.parse(attributes.to_json))
       rescue OpenAPIParser::OpenAPIError => e
         raise ValidationError, e.message
       end

--- a/spec/cocina/models/validator_spec.rb
+++ b/spec/cocina/models/validator_spec.rb
@@ -36,6 +36,45 @@ RSpec.describe Cocina::Models::Validator do
     end
   end
 
+  context 'when has a DateTime' do
+    # This makes sure that something like following does not raise a validation error due to DateTime:
+    # dro_hash = dro.to_h
+    # Change the hash.
+    # Cocina::Models::DRO.new(dro_hash)
+    let(:dro) do
+      Cocina::Models::DRO.new(
+        {
+          "type": 'http://cocina.sul.stanford.edu/models/image.jsonld',
+          "externalIdentifier": 'druid:bb000kg4251',
+          "label": 'Roger Howe Professorship',
+          "version": 3,
+          "access": {
+            "access": 'world',
+            "download": 'world',
+            "useAndReproductionStatement": 'Property rights reside with the repository.'
+          },
+          "administrative": {
+            "hasAdminPolicy": 'druid:ww057vk7675',
+            "releaseTags": [
+              {
+                "who": 'cspitzer',
+                "what": 'self',
+                "date": DateTime.new,
+                "to": 'Searchworks',
+                "release": true
+              }
+            ],
+            "partOfProject": 'School of Engineering photograph collection'
+          }
+        }
+      )
+    end
+
+    it 'does not raise' do
+      dro
+    end
+  end
+
   describe 'when validate=false' do
     let(:policy) do
       Cocina::Models::AdminPolicy.new({


### PR DESCRIPTION
closes #217

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
To allow the following when a DateTime is involved:
1. Convert a model to hash.
2. Edit the hash.
3. Create a model from the hash.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA