### PR TITLE
Fix valueLanguage in event models

### DIFF
--- a/lib/cocina/models/descriptive_parallel_event.rb
+++ b/lib/cocina/models/descriptive_parallel_event.rb
@@ -3,17 +3,6 @@
 module Cocina
   module Models
     class DescriptiveParallelEvent < Struct
-      # Code representing the standard or encoding.
-      attribute :code, Types::Strict::String.meta(omittable: true)
-      # URI for the standard or encoding.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      # String describing the standard or encoding.
-      attribute :value, Types::Strict::String.meta(omittable: true)
-      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # The version of the standard or encoding.
-      attribute :version, Types::Strict::String.meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
-      attribute :valueScript, Standard.optional.meta(omittable: true)
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       # Description of the event (creation, publication, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
@@ -23,6 +12,8 @@ module Cocina
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/event.rb
+++ b/lib/cocina/models/event.rb
@@ -4,17 +4,6 @@ module Cocina
   module Models
     class Event < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # Code representing the standard or encoding.
-      attribute :code, Types::Strict::String.meta(omittable: true)
-      # URI for the standard or encoding.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      # String describing the standard or encoding.
-      attribute :value, Types::Strict::String.meta(omittable: true)
-      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # The version of the standard or encoding.
-      attribute :version, Types::Strict::String.meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
-      attribute :valueScript, Standard.optional.meta(omittable: true)
       # Description of the event (creation, publication, etc.).
       attribute :type, Types::Strict::String.meta(omittable: true)
       # The preferred display label to use for the event in access systems.
@@ -23,6 +12,8 @@ module Cocina
       attribute :contributor, Types::Strict::Array.of(Contributor).meta(omittable: true)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
+      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
       attribute :parallelEvent, Types::Strict::Array.of(DescriptiveParallelEvent).meta(omittable: true)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -656,27 +656,6 @@ components:
               $ref: '#/components/schemas/Standard'
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
-    Title:
-      type: object
-      additionalProperties: false
-      allOf:
-        - $ref: "#/components/schemas/DescriptiveValue"
-        - anyOf:
-            - type: object
-              required:
-                - value
-            - type: object
-              required:
-                - structuredValue
-            - type: object
-              required:
-                - parallelValue
-            - type: object
-              required:
-                - groupedValue
-            - type: object
-              required:
-                - valueAt
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
@@ -1521,3 +1500,24 @@ components:
           type: string
         source:
           $ref: "#/components/schemas/Source"
+    Title:
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/DescriptiveValue"
+        - anyOf:
+            - type: object
+              required:
+                - value
+            - type: object
+              required:
+                - structuredValue
+            - type: object
+              required:
+                - parallelValue
+            - type: object
+              required:
+                - groupedValue
+            - type: object
+              required:
+                - valueAt

--- a/openapi.yml
+++ b/openapi.yml
@@ -581,7 +581,6 @@ components:
       type: object
       additionalProperties: false
       allOf:
-        - $ref: "#/components/schemas/DescriptiveValueLanguage"
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
         - type: object
           additionalProperties: false
@@ -617,6 +616,9 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
+            valueLanguage:
+              # description: Language of the descriptive element value
+              $ref: "#/components/schemas/DescriptiveValueLanguage"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object
@@ -839,7 +841,6 @@ components:
       additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
-        - $ref: "#/components/schemas/DescriptiveValueLanguage"
         - type: object
           additionalProperties: false
           properties:
@@ -874,6 +875,9 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
+            valueLanguage:
+              # description: Language of the descriptive element value
+              $ref: "#/components/schemas/DescriptiveValueLanguage"
             parallelEvent:
               description: For multiple representations of information about the same event (e.g. in different languages)
               type: array


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
- Add missing valueLanguage
- move Title to the correct place alphabetically in openapi.yml

## How was this change tested?
CircleCI


## Which documentation and/or configurations were updated?
n/a