### PR TITLE
Add publish attribute to file administrative metadata

### DIFF
--- a/lib/cocina/models/file_administrative.rb
+++ b/lib/cocina/models/file_administrative.rb
@@ -3,6 +3,7 @@
 module Cocina
   module Models
     class FileAdministrative < Struct
+      attribute :publish, Types::Strict::Bool.default(false)
       attribute :sdrPreserve, Types::Strict::Bool.default(true)
       attribute :shelve, Types::Strict::Bool.default(false)
     end

--- a/lib/cocina/models/version.rb
+++ b/lib/cocina/models/version.rb
@@ -2,6 +2,6 @@
 
 module Cocina
   module Models
-    VERSION = '0.54.0.beta.2'
+    VERSION = '0.54.0'
   end
 end

--- a/lib/cocina/models/version.rb
+++ b/lib/cocina/models/version.rb
@@ -2,6 +2,6 @@
 
 module Cocina
   module Models
-    VERSION = '0.54.0.beta.1'
+    VERSION = '0.54.0.beta.2'
   end
 end

--- a/lib/cocina/models/version.rb
+++ b/lib/cocina/models/version.rb
@@ -2,6 +2,6 @@
 
 module Cocina
   module Models
-    VERSION = '0.53.1'
+    VERSION = '0.54.0.beta.1'
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -959,6 +959,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        publish:
+          type: boolean
+          default: false
         sdrPreserve:
           type: boolean
           default: true
@@ -966,6 +969,7 @@ components:
           type: boolean
           default: false
       required:
+        - publish
         - sdrPreserve
         - shelve
     FileSet:


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

Fixes sul-dlss/dor-services-app#2407

## Why was this change made?

Because it is independent from the rights metadata, thus should not be derived therefrom.

## How was this change tested?

Will be tested in QA.

## Which documentation and/or configurations were updated?

OpenAPI.