### PR TITLE
Add missing AccessRole types

### DIFF
--- a/lib/cocina/models/access_role.rb
+++ b/lib/cocina/models/access_role.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class AccessRole < Struct
       # Name of role
-      attribute :name, Types::Strict::String.enum('sdr-administrator', 'sdr-viewer', 'dor-apo-manager', 'hydrus-collection-creator', 'hydrus-collection-manager', 'hydrus-collection-depositor', 'hydrus-collection-item-depositor', 'hydrus-collection-reviewer', 'hydrus-collection-viewer')
+      attribute :name, Types::Strict::String.enum('dor-apo-creator', 'dor-apo-depositor', 'dor-apo-manager', 'dor-apo-metadata', 'dor-apo-reviewer', 'dor-apo-viewer', 'sdr-administrator', 'sdr-viewer', 'hydrus-collection-creator', 'hydrus-collection-manager', 'hydrus-collection-depositor', 'hydrus-collection-item-depositor', 'hydrus-collection-reviewer', 'hydrus-collection-viewer')
       attribute :members, Types::Strict::Array.of(AccessRoleMember).default([].freeze)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -127,9 +127,14 @@ components:
           description: Name of role
           type: string
           enum:
+            - 'dor-apo-creator'
+            - 'dor-apo-depositor'
+            - 'dor-apo-manager'
+            - 'dor-apo-metadata'
+            - 'dor-apo-reviewer'
+            - 'dor-apo-viewer'
             - 'sdr-administrator'
             - 'sdr-viewer'
-            - 'dor-apo-manager'
             - 'hydrus-collection-creator'
             - 'hydrus-collection-manager'
             - 'hydrus-collection-depositor'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Supports missing types: https://app.honeybadger.io/projects/52894/faults/63360431

## How was this change tested?



## Which documentation and/or configurations were updated?
