### PR TITLE
Add resource types to the model

### DIFF
--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -5,7 +5,22 @@ module Cocina
     class FileSet < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/fileset.jsonld'].freeze
+      TYPES = ['http://cocina.sul.stanford.edu/models/resources/audio.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/attachment.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/document.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/image.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/main-augmented.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/main-original.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/media.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/object.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/permissions.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/preview.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/supplement.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/3d.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/thumb.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/video.jsonld'].freeze
 
       # The content type of the Fileset.
       attribute :type, Types::Strict::String.enum(*FileSet::TYPES)

--- a/lib/cocina/models/request_file_set.rb
+++ b/lib/cocina/models/request_file_set.rb
@@ -5,7 +5,22 @@ module Cocina
     class RequestFileSet < Struct
       include Checkable
 
-      TYPES = ['http://cocina.sul.stanford.edu/models/fileset.jsonld'].freeze
+      TYPES = ['http://cocina.sul.stanford.edu/models/resources/audio.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/attachment.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/document.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/image.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/main-augmented.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/main-original.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/media.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/object.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/permissions.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/preview.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/supplement.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/3d.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/thumb.jsonld',
+               'http://cocina.sul.stanford.edu/models/resources/video.jsonld'].freeze
 
       attribute :type, Types::Strict::String.enum(*RequestFileSet::TYPES)
       attribute :label, Types::Strict::String

--- a/lib/cocina/models/vocab.rb
+++ b/lib/cocina/models/vocab.rb
@@ -40,10 +40,6 @@ module Cocina
         'http://cocina.sul.stanford.edu/models/file.jsonld'
       end
 
-      def self.fileset
-        'http://cocina.sul.stanford.edu/models/fileset.jsonld'
-      end
-
       def self.geo
         'http://cocina.sul.stanford.edu/models/geo.jsonld'
       end
@@ -94,6 +90,72 @@ module Cocina
 
       def self.webarchive_seed
         'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'
+      end
+
+      class Resources
+        def self.three_dimensional
+          'http://cocina.sul.stanford.edu/models/resources/3d.jsonld'
+        end
+
+        def self.attachment
+          'http://cocina.sul.stanford.edu/models/resources/attachment.jsonld'
+        end
+
+        def self.audio
+          'http://cocina.sul.stanford.edu/models/resources/audio.jsonld'
+        end
+
+        def self.document
+          'http://cocina.sul.stanford.edu/models/resources/document.jsonld'
+        end
+
+        def self.file
+          'http://cocina.sul.stanford.edu/models/resources/file.jsonld'
+        end
+
+        def self.image
+          'http://cocina.sul.stanford.edu/models/resources/image.jsonld'
+        end
+
+        def self.main_augmented
+          'http://cocina.sul.stanford.edu/models/resources/main-augmented.jsonld'
+        end
+
+        def self.main_original
+          'http://cocina.sul.stanford.edu/models/resources/main-original.jsonld'
+        end
+
+        def self.media
+          'http://cocina.sul.stanford.edu/models/resources/media.jsonld'
+        end
+
+        def self.object
+          'http://cocina.sul.stanford.edu/models/resources/object.jsonld'
+        end
+
+        def self.page
+          'http://cocina.sul.stanford.edu/models/resources/page.jsonld'
+        end
+
+        def self.permissions
+          'http://cocina.sul.stanford.edu/models/resources/permissions.jsonld'
+        end
+
+        def self.preview
+          'http://cocina.sul.stanford.edu/models/resources/preview.jsonld'
+        end
+
+        def self.supplement
+          'http://cocina.sul.stanford.edu/models/resources/supplement.jsonld'
+        end
+
+        def self.thumb
+          'http://cocina.sul.stanford.edu/models/resources/thumb.jsonld'
+        end
+
+        def self.video
+          'http://cocina.sul.stanford.edu/models/resources/video.jsonld'
+        end
       end
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -977,7 +977,22 @@ components:
           description: The content type of the Fileset.
           type: string
           enum:
-            - 'http://cocina.sul.stanford.edu/models/fileset.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/audio.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/attachment.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/document.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/file.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/image.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/main-augmented.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/main-original.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/media.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/object.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/page.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/permissions.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/preview.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/supplement.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/3d.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/thumb.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/video.jsonld'
         externalIdentifier:
           type: string
         label:
@@ -1394,7 +1409,22 @@ components:
         type:
           type: string
           enum:
-            - 'http://cocina.sul.stanford.edu/models/fileset.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/audio.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/attachment.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/document.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/file.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/image.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/main-augmented.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/main-original.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/media.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/object.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/page.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/permissions.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/preview.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/supplement.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/3d.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/thumb.jsonld'
+            - 'http://cocina.sul.stanford.edu/models/resources/video.jsonld'
         label:
           type: string
         version:

--- a/spec/cocina/generator/schema_value_spec.rb
+++ b/spec/cocina/generator/schema_value_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Cocina::Generator::SchemaValue do
 
     context 'when a type enum' do
       it 'has a TYPES constant' do
-        expect(Cocina::Models::FileSet::TYPES).to eq(['http://cocina.sul.stanford.edu/models/fileset.jsonld'])
+        expect(Cocina::Models::FileSet::TYPES).to include 'http://cocina.sul.stanford.edu/models/resources/page.jsonld'
       end
     end
   end


### PR DESCRIPTION
Some of the resource types currently in use overlap with the content types, so I made a separate namespace for these.

Fixes #226 