### PR TITLE
Latest version of ruby requires this require fileutils

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module Cocina
   module Generator
     # Class for generating Cocina models from openapi.


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Without the require I get:

```
Traceback (most recent call last):
	6: from exe/generator:9:in `<main>'
	5: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	4: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	3: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	2: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	1: from /Users/amcollie/github/sul-dlss/cocina-models/lib/cocina/generator/generator.rb:18:in `generate'
/Users/amcollie/github/sul-dlss/cocina-models/lib/cocina/generator/generator.rb:78:in `clean_output': uninitialized constant Cocina::Generator::Generator::FileUtils (NameError)
Did you mean?  FileTest
```

when running the generated

## How was this change tested?

Validated that the generator ran, cc: @mjgiarlo 

## Which documentation and/or configurations were updated?
