### PR TITLE
Add referenceAgreement to AdminPolicyAdministrative

### DIFF
--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -96,7 +96,7 @@ module Cocina
         doc.properties.map do |key, properties_doc|
           property_class_for(properties_doc).new(properties_doc,
                                                  key: key,
-                                                 required: doc.requires?(properties_doc),
+                                                 required: doc.requires?(key),
                                                  parent: self)
         end
       end

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -9,8 +9,11 @@ module Cocina
       # example: wasCrawlPreassemblyWF
       attribute :disseminationWorkflow, Types::Strict::String.meta(omittable: true)
       attribute :collectionsForRegistration, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
-      attribute :roles, Types::Strict::Array.of(AccessRole).meta(omittable: true)
+      # example: druid:bc123df4567
       attribute :hasAdminPolicy, Types::Strict::String
+      # example: druid:bc123df4567
+      attribute :referencesAgreement, Types::Strict::String.meta(omittable: true)
+      attribute :roles, Types::Strict::Array.of(AccessRole).meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -229,13 +229,15 @@ components:
           type: array
           items:
             type: string
+        hasAdminPolicy:
+          $ref: '#/components/schemas/Druid'
+        referencesAgreement:
+          $ref: '#/components/schemas/Druid'
         roles:
           description: The access roles conferred by this AdminPolicy (used by Argo)
           type: array
           items:
             $ref: '#/components/schemas/AccessRole'
-        hasAdminPolicy:
-          type: string
       required:
         - hasAdminPolicy
     AppliesTo:


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Because APOs reference agreements.

## How was this change tested?



## Which documentation and/or configurations were updated?
