### PR TITLE
Add properties for modeling the admin policy defaults

### DIFF
--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -3,7 +3,9 @@
 module Cocina
   module Models
     class AdminPolicyAdministrative < Struct
+      # This is an XML expression of the default access (see defaultAccess)
       attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
+      attribute :defaultAccess, DROAccess.optional.meta(omittable: true)
       attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
       # An additional workflow to start for objects managed by this admin policy once the end-accession workflow step is complete
       # example: wasCrawlPreassemblyWF

--- a/lib/cocina/models/admin_policy_default_access.rb
+++ b/lib/cocina/models/admin_policy_default_access.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AdminPolicyDefaultAccess < Struct
+      attribute :access, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
+      # Available for controlled digital lending.
+      attribute :controlledDigitalLending, Types::Strict::Bool.meta(omittable: true)
+      # The human readable copyright statement that applies
+      # example: Copyright World Trade Organization
+      attribute :copyright, Types::Strict::String.meta(omittable: true)
+      attribute :embargo, Embargo.optional.meta(omittable: true)
+      # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
+
+      attribute :download, Types::Strict::String.enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
+      # If access is "location-based", which location should have access. This is used in the transition from Fedora as a way to set a default readLocation at registration that is copied down to all the files.
+
+      attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      # The human readable use and reproduction statement that applies
+      # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+      attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
+      # The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
+      attribute :license, Types::Strict::String.meta(omittable: true)
+    end
+  end
+end

--- a/openapi.yml
+++ b/openapi.yml
@@ -221,7 +221,11 @@ components:
       properties:
         defaultObjectRights:
           type: string
+          description: This is an XML expression of the default access (see defaultAccess)
+          deprecated: true
           default: <?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>
+        defaultAccess:
+          $ref: '#/components/schemas/DROAccess'
         registrationWorkflow:
           description: When you register an item with this admin policy, these are the workflows that are available.
           type: array
@@ -247,6 +251,61 @@ components:
             $ref: '#/components/schemas/AccessRole'
       required:
         - hasAdminPolicy
+    AdminPolicyDefaultAccess:
+      description: 'Provides the default access settings for an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults.'
+      type: object
+      additionalProperties: false
+      properties:
+        access:
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'citation-only'
+            - 'dark'
+        controlledDigitalLending:
+          description: Available for controlled digital lending.
+          type: boolean
+        copyright:
+          description: The human readable copyright statement that applies
+          example: Copyright World Trade Organization
+          type: string
+        embargo:
+          $ref: '#/components/schemas/Embargo'
+        download:
+          description: >
+            Download access level. This is used in the transition from Fedora as
+            a way to set a default download level at registration that is copied
+            down to all the files.
+
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'none'
+        readLocation:
+          description: >
+            If access is "location-based", which location should have access.
+            This is used in the transition from Fedora as a way to set a default
+            readLocation at registration that is copied down to all the files.
+
+          type: string
+          enum:
+            - 'spec'
+            - 'music'
+            - 'ars'
+            - 'art'
+            - 'hoover'
+            - 'm&m'
+        useAndReproductionStatement:
+          description: The human readable use and reproduction statement that applies
+          example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+          type: string
+        license:
+          description: The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
+          type: string
     AppliesTo:
       description: Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Currently we're just using an unvalidated chunk of XML to convey these values, but we should migrated to explicit values.

## How was this change tested?



## Which documentation and/or configurations were updated?
