### PR TITLE
Add the license to the access metadata

### DIFF
--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -7,6 +7,11 @@ module Cocina
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
       # If access is "location-based", which location should have access.
       attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      # The human readable use and reproduction statement that applies
+      # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+      attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
+      # The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
+      attribute :license, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -19,6 +19,8 @@ module Cocina
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)
+      # The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
+      attribute :license, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -118,6 +118,13 @@ components:
             - 'art'
             - 'hoover'
             - 'm&m'
+        useAndReproductionStatement:
+          description: The human readable use and reproduction statement that applies
+          example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+          type: string
+        license:
+          description: The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
+          type: string
     AccessRole:
       description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
       type: object
@@ -820,6 +827,9 @@ components:
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
+          type: string
+        license:
+          description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
           type: string
     DROStructural:
       description: Structural metadata


### PR DESCRIPTION

## Why was this change made?

Ref #236
This is a missing property from the cocina-model that is in the access metadata. 

## How was this change tested?



## Which documentation and/or configurations were updated?
