### PR TITLE
Use the correct schema for AdminPolicy defaultAccess

### DIFF
--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -5,7 +5,7 @@ module Cocina
     class AdminPolicyAdministrative < Struct
       # This is an XML expression of the default access (see defaultAccess)
       attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
-      attribute :defaultAccess, DROAccess.optional.meta(omittable: true)
+      attribute :defaultAccess, AdminPolicyDefaultAccess.optional.meta(omittable: true)
       attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).meta(omittable: true)
       # An additional workflow to start for objects managed by this admin policy once the end-accession workflow step is complete
       # example: wasCrawlPreassemblyWF

--- a/openapi.yml
+++ b/openapi.yml
@@ -225,7 +225,7 @@ components:
           deprecated: true
           default: <?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>
         defaultAccess:
-          $ref: '#/components/schemas/DROAccess'
+          $ref: '#/components/schemas/AdminPolicyDefaultAccess'
         registrationWorkflow:
           description: When you register an item with this admin policy, these are the workflows that are available.
           type: array


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
It was not set to the correct schema before.


## How was this change tested?



## Which documentation and/or configurations were updated?
