### PR TITLE
remove AdminPolicyDefaultAccess#embargo

### DIFF
--- a/lib/cocina/models/admin_policy_default_access.rb
+++ b/lib/cocina/models/admin_policy_default_access.rb
@@ -9,7 +9,6 @@ module Cocina
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute :copyright, Types::Strict::String.meta(omittable: true)
-      attribute :embargo, Embargo.optional.meta(omittable: true)
       # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
 
       attribute :download, Types::Strict::String.enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)

--- a/openapi.yml
+++ b/openapi.yml
@@ -252,7 +252,7 @@ components:
       required:
         - hasAdminPolicy
     AdminPolicyDefaultAccess:
-      description: 'Provides the default access settings for an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults.'
+      description: 'Provides the default access settings for an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo.'
       type: object
       additionalProperties: false
       properties:
@@ -271,8 +271,6 @@ components:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
-        embargo:
-          $ref: '#/components/schemas/Embargo'
         download:
           description: >
             Download access level. This is used in the transition from Fedora as


### PR DESCRIPTION

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Since embargo comes from embargoMetadata, it can never come from defaultObjectRights, which is where the rest of these properties originate.  So this property will never be used.


## How was this change tested?



## Which documentation and/or configurations were updated?
