### PR TITLE
Adds additional access attributes for embargoes and moves some access…

### DIFF
--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -3,13 +3,13 @@
 module Cocina
   module Models
     class Access < Struct
-      # Access level
+      # Access level that applies when embargo expires.
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute :copyright, Types::Strict::String.meta(omittable: true)
       # If access is "location-based", which location should have access.
-      attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      attribute :readLocation, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)

--- a/lib/cocina/models/access_download.rb
+++ b/lib/cocina/models/access_download.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    AccessDownload = Types::String.constrained(
+      format: //i
+    )
+  end
+end

--- a/lib/cocina/models/access_level.rb
+++ b/lib/cocina/models/access_level.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    AccessLevel = Types::String.constrained(
+      format: //i
+    )
+  end
+end

--- a/lib/cocina/models/access_read_location.rb
+++ b/lib/cocina/models/access_read_location.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    AccessReadLocation = Types::String.constrained(
+      format: //i
+    )
+  end
+end

--- a/lib/cocina/models/admin_policy_default_access.rb
+++ b/lib/cocina/models/admin_policy_default_access.rb
@@ -3,7 +3,8 @@
 module Cocina
   module Models
     class AdminPolicyDefaultAccess < Struct
-      attribute :access, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
+      # Access level that applies when embargo expires.
+      attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
       # Available for controlled digital lending.
       attribute :controlledDigitalLending, Types::Strict::Bool.meta(omittable: true)
       # The human readable copyright statement that applies
@@ -11,9 +12,8 @@ module Cocina
       attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
       # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
 
-      attribute :download, Types::Strict::String.enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
-      # If access is "location-based", which location should have access. This is used in the transition from Fedora as a way to set a default readLocation at registration that is copied down to all the files.
-
+      attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
+      # If access is "location-based", which location should have access.
       attribute :readLocation, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -3,6 +3,7 @@
 module Cocina
   module Models
     class DROAccess < Struct
+      # Access level that applies when embargo expires.
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
       # Available for controlled digital lending.
       attribute :controlledDigitalLending, Types::Strict::Bool.meta(omittable: true)
@@ -13,9 +14,8 @@ module Cocina
       # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
 
       attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
-      # If access is "location-based", which location should have access. This is used in the transition from Fedora as a way to set a default readLocation at registration that is copied down to all the files.
-
-      attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      # If access is "location-based", which location should have access.
+      attribute :readLocation, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)

--- a/lib/cocina/models/embargo.rb
+++ b/lib/cocina/models/embargo.rb
@@ -7,7 +7,12 @@ module Cocina
       # example: 2029-06-22T07:00:00.000+00:00
       attribute :releaseDate, Types::Params::DateTime
       # Access level that applies when embargo expires.
-      attribute :access, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
+      attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
+      # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
+
+      attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
+      # If access is "location-based", which location should have access.
+      attribute :readLocation, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
       # The human readable use and reproduction statement that applies when the embargo expires.
       # example: These materials are in the public domain.
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)

--- a/lib/cocina/models/file_access.rb
+++ b/lib/cocina/models/file_access.rb
@@ -3,14 +3,15 @@
 module Cocina
   module Models
     class FileAccess < Struct
-      # Access level
+      # Access level that applies when embargo expires.
       attribute :access, Types::Strict::String.default('dark').enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
       # Available for controlled digital lending.
       attribute :controlledDigitalLending, Types::Strict::Bool.meta(omittable: true)
-      # Download access level for a file
+      # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
+
       attribute :download, Types::Strict::String.default('none').enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
       # If access is "location-based", which location should have access.
-      attribute :readLocation, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      attribute :readLocation, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -99,29 +99,13 @@ components:
       additionalProperties: false
       properties:
         access:
-          description: Access level
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'citation-only'
-            - 'dark'
-          default: 'dark'
+          $ref: '#/components/schemas/AccessLevel'
         copyright:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
         readLocation:
-          description: If access is "location-based", which location should have access.
-          type: string
-          enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+          $ref: '#/components/schemas/AccessReadLocation'
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
@@ -129,6 +113,40 @@ components:
         license:
           description: The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
           type: string
+    AccessDownload:
+      description: >
+        Download access level. This is used in the transition from Fedora as
+        a way to set a default download level at registration that is copied
+        down to all the files.
+
+      type: string
+      enum:
+        - 'world'
+        - 'stanford'
+        - 'location-based'
+        - 'none'
+      default: 'none'
+    AccessLevel:
+      description: Access level that applies when embargo expires.
+      type: string
+      enum:
+        - world
+        - stanford
+        - location-based
+        - citation-only
+        - dark
+      default: 'dark'
+    AccessReadLocation:
+      description: If access is "location-based", which location should have access.
+      type: string
+      nullable: true
+      enum:
+        - 'spec'
+        - 'music'
+        - 'ars'
+        - 'art'
+        - 'hoover'
+        - 'm&m'
     AccessRole:
       description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
       type: object
@@ -261,13 +279,7 @@ components:
       additionalProperties: false
       properties:
         access:
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'citation-only'
-            - 'dark'
+          $ref: '#/components/schemas/AccessLevel'
         controlledDigitalLending:
           description: Available for controlled digital lending.
           type: boolean
@@ -277,32 +289,9 @@ components:
           type: string
           nullable: true
         download:
-          description: >
-            Download access level. This is used in the transition from Fedora as
-            a way to set a default download level at registration that is copied
-            down to all the files.
-
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'none'
+          $ref: '#/components/schemas/AccessDownload'
         readLocation:
-          description: >
-            If access is "location-based", which location should have access.
-            This is used in the transition from Fedora as a way to set a default
-            readLocation at registration that is copied down to all the files.
-
-          type: string
-          nullable: true
-          enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+          $ref: '#/components/schemas/AccessReadLocation'
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
@@ -850,14 +839,7 @@ components:
       additionalProperties: false
       properties:
         access:
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'citation-only'
-            - 'dark'
-          default: 'dark'
+          $ref: '#/components/schemas/AccessLevel'
         controlledDigitalLending:
           description: Available for controlled digital lending.
           type: boolean
@@ -869,32 +851,9 @@ components:
         embargo:
           $ref: '#/components/schemas/Embargo'
         download:
-          description: >
-            Download access level. This is used in the transition from Fedora as
-            a way to set a default download level at registration that is copied
-            down to all the files.
-
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'none'
-          default: 'none'
+          $ref: '#/components/schemas/AccessDownload'
         readLocation:
-          description: >
-            If access is "location-based", which location should have access.
-            This is used in the transition from Fedora as a way to set a default
-            readLocation at registration that is copied down to all the files.
-
-          type: string
-          enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+          $ref: '#/components/schemas/AccessReadLocation'
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
@@ -939,14 +898,11 @@ components:
           format: date-time
           example: '2029-06-22T07:00:00.000+00:00'
         access:
-          description: Access level that applies when embargo expires.
-          type: string
-          enum:
-            - world
-            - stanford
-            - location-based
-            - citation-only
-            - dark
+          $ref: '#/components/schemas/AccessLevel'
+        download:
+          $ref: '#/components/schemas/AccessDownload'
+        readLocation:
+          $ref: '#/components/schemas/AccessReadLocation'
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies when the embargo expires.
           example: These materials are in the public domain.
@@ -1058,38 +1014,15 @@ components:
       additionalProperties: false
       properties:
         access:
-          description: Access level
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'citation-only'
-            - 'dark'
-          default: 'dark'
+          $ref: '#/components/schemas/AccessLevel'
         controlledDigitalLending:
           description: Available for controlled digital lending.
           type: boolean
           default: false
         download:
-          description: Download access level for a file
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'none'
-          default: 'none'
+          $ref: '#/components/schemas/AccessDownload'
         readLocation:
-          description: If access is "location-based", which location should have access.
-          type: string
-          enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+          $ref: '#/components/schemas/AccessReadLocation'
     FileAdministrative:
       type: object
       additionalProperties: false


### PR DESCRIPTION
… attributes into own schema.

closes #253

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
* So that the access rights for an embargo can be correctly modeled.
* Reduce duplication of access-related attributes.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
openapi