### PR TITLE
Allow copyright statement to be nullable

### DIFF
--- a/lib/cocina/models/collection_access.rb
+++ b/lib/cocina/models/collection_access.rb
@@ -7,7 +7,7 @@ module Cocina
       attribute :access, Types::Strict::String.default('dark').enum('world', 'dark').meta(omittable: true)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.meta(omittable: true)
+      attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
       attribute :useAndReproductionStatement, Types::Strict::String.meta(omittable: true)

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -16,7 +16,7 @@ module Cocina
       attribute :controlledDigitalLending, Types::Strict::Bool.optional.meta(omittable: true)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.meta(omittable: true)
+      attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
       attribute :embargo, Embargo.optional.meta(omittable: true)
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).

--- a/openapi.yml
+++ b/openapi.yml
@@ -408,6 +408,7 @@ components:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
+          nullable: true
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
@@ -935,6 +936,7 @@ components:
               description: The human readable copyright statement that applies
               example: Copyright World Trade Organization
               type: string
+              nullable: true
             embargo:
               $ref: '#/components/schemas/Embargo'
             useAndReproductionStatement:


### PR DESCRIPTION


**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
So that it can be cleared out if it is not desired


## How was this change tested?



## Which documentation and/or configurations were updated?
