### PR TITLE
Validate that PURL starts with http, not https.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -582,9 +582,7 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         purl:
-          description: Stanford persistent URL associated with the resource.
-          type: string
-          format: uri
+          $ref: "#/components/schemas/Purl"
         access:
           $ref: "#/components/schemas/DescriptiveAccessMetadata"
         relatedResource:
@@ -1389,6 +1387,12 @@ components:
         width:
           description: Width in pixels
           type: integer
+    Purl:
+      description: Stanford persistent URL associated with the related resource. Note this is http, not https.
+      type: string
+      format: uri
+      # Canonical URI is http, even though this redirects to https.
+      pattern: '^http://'
     RelatedResource:
       description: Other resource associated with the described resource.
       type: object
@@ -1450,9 +1454,7 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         purl:
-          description: Stanford persistent URL associated with the related resource.
-          type: string
-          format: uri
+          $ref: "#/components/schemas/Purl"
         access:
           $ref: "#/components/schemas/DescriptiveAccessMetadata"
         relatedResource:

--- a/spec/cocina/models/description_spec.rb
+++ b/spec/cocina/models/description_spec.rb
@@ -91,4 +91,16 @@ RSpec.describe Cocina::Models::Description do
       expect(title.status).to eq('primary')
     end
   end
+
+  context 'with an invalid purl' do
+    let(:properties) do
+      JSON.parse(File.read('spec/fixtures/description/etd.json')).tap do |props|
+        props['purl'] = 'https://purl.stanford.edu/hj456dt5655'
+      end
+    end
+
+    it 'raises' do
+      expect { item }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
 end


### PR DESCRIPTION
closes #265

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
Enforce canonical PURLs.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
openapi.yml