### PR TITLE
openapi.yml: tweaks to silence validator warnings

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -176,7 +176,6 @@ components:
           type: string
           enum:
             - 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
-          example: item
         externalIdentifier:
           $ref: '#/components/schemas/Druid'
         label:
@@ -375,7 +374,6 @@ components:
             - 'http://cocina.sul.stanford.edu/models/user-collection.jsonld'
             - 'http://cocina.sul.stanford.edu/models/exhibit.jsonld'
             - 'http://cocina.sul.stanford.edu/models/series.jsonld'
-          example: item
         externalIdentifier:
           $ref: '#/components/schemas/Druid'
         label:
@@ -901,7 +899,6 @@ components:
             - 'http://cocina.sul.stanford.edu/models/track.jsonld'
             - 'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld'
             - 'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'
-          example: item
         externalIdentifier:
           $ref: '#/components/schemas/Druid'
         label:
@@ -1507,7 +1504,6 @@ components:
           type: string
           enum:
             - 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
-          example: item
         label:
           type: string
         version:
@@ -1534,7 +1530,6 @@ components:
             - 'http://cocina.sul.stanford.edu/models/user-collection.jsonld'
             - 'http://cocina.sul.stanford.edu/models/exhibit.jsonld'
             - 'http://cocina.sul.stanford.edu/models/series.jsonld'
-          example: item
         label:
           type: string
         version:
@@ -1576,7 +1571,6 @@ components:
             - 'http://cocina.sul.stanford.edu/models/track.jsonld'
             - 'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld'
             - 'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'
-          example: item
         label:
           type: string
         version:

--- a/openapi.yml
+++ b/openapi.yml
@@ -308,12 +308,12 @@ components:
       description: The barcode associated with a business library DRO object, prefixed with 2050
       type: string
       pattern: '^2050[0-9]{7}$'
-      example: 20503740296
+      example: '20503740296'
     LaneMedicalBarcode:
       description: The barcode associated with a Lane Medical Library DRO object, prefixed with 245
       type: string
       pattern: '^245[0-9]{8}$'
-      example: 24503259768
+      example: '24503259768'
     CatalogLink:
       type: object
       additionalProperties: false
@@ -328,12 +328,12 @@ components:
         catalogRecordId:
           description: Record identifier that is unique within the context of the linked record's catalog.
           type: string
-          example: 11403803
+          example: '11403803'
     CatkeyBarcode:
       description: The barcode associated with a DRO object based on catkey, prefixed with 36105
       type: string
       pattern: '^[0-9]+-[0-9]+$'
-      example: 6772719-1001
+      example: '6772719-1001'
     CitationOnlyAccess:
       type: object
       properties:
@@ -1798,7 +1798,7 @@ components:
       description: The standard barcode associated with a DRO object, prefixed with 36105
       type: string
       pattern: '^36105[0-9]{9}$'
-      example: 36105010362304
+      example: '36105010362304'
     Title:
       type: object
       additionalProperties: false

--- a/openapi.yml
+++ b/openapi.yml
@@ -948,36 +948,36 @@ components:
               description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
               type: string
               enum:
-                - https://www.gnu.org/licenses/agpl.txt
-                - https://www.apache.org/licenses/LICENSE-2.0
-                - https://opensource.org/licenses/BSD-2-Clause
-                - https://opensource.org/licenses/BSD-3-Clause
-                - https://creativecommons.org/licenses/by/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-                - https://creativecommons.org/licenses/by-nd/4.0/legalcode
-                - https://creativecommons.org/licenses/by-sa/4.0/legalcode
-                - https://creativecommons.org/publicdomain/zero/1.0/legalcode
-                - https://opensource.org/licenses/cddl1
-                - https://www.eclipse.org/legal/epl-2.0
-                - https://www.gnu.org/licenses/gpl-3.0-standalone.html
-                - https://www.isc.org/downloads/software-support-policy/isc-license/
-                - https://www.gnu.org/licenses/lgpl-3.0-standalone.html
-                - https://opensource.org/licenses/MIT
-                - https://www.mozilla.org/MPL/2.0/
-                - https://opendatacommons.org/licenses/by/1-0/
-                - http://opendatacommons.org/licenses/odbl/1.0/ # Non cannonical, but in some of our data
-                - https://opendatacommons.org/licenses/odbl/1-0/
-                - https://creativecommons.org/publicdomain/mark/1.0/
-                - https://opendatacommons.org/licenses/pddl/1-0/
-                - https://creativecommons.org/licenses/by/3.0/legalcode
-                - https://creativecommons.org/licenses/by-sa/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nd/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode
-                - https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode
-                - http://cocina.sul.stanford.edu/licenses/none # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
+                - 'https://www.gnu.org/licenses/agpl.txt'
+                - 'https://www.apache.org/licenses/LICENSE-2.0'
+                - 'https://opensource.org/licenses/BSD-2-Clause'
+                - 'https://opensource.org/licenses/BSD-3-Clause'
+                - 'https://creativecommons.org/licenses/by/4.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc/4.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nd/4.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-sa/4.0/legalcode'
+                - 'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
+                - 'https://opensource.org/licenses/cddl1'
+                - 'https://www.eclipse.org/legal/epl-2.0'
+                - 'https://www.gnu.org/licenses/gpl-3.0-standalone.html'
+                - 'https://www.isc.org/downloads/software-support-policy/isc-license/'
+                - 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html'
+                - 'https://opensource.org/licenses/MIT'
+                - 'https://www.mozilla.org/MPL/2.0/'
+                - 'https://opendatacommons.org/licenses/by/1-0/'
+                - 'http://opendatacommons.org/licenses/odbl/1.0/' # Non cannonical, but in some of our data
+                - 'https://opendatacommons.org/licenses/odbl/1-0/'
+                - 'https://creativecommons.org/publicdomain/mark/1.0/'
+                - 'https://opendatacommons.org/licenses/pddl/1-0/'
+                - 'https://creativecommons.org/licenses/by/3.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-sa/3.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nd/3.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode'
+                - 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
+                - 'http://cocina.sul.stanford.edu/licenses/none' # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
     DROStructural:
       description: Structural metadata
       type: object


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

to silence some warnings from running `openapi-enforcer validate openapi.yml`

I will put in separate PRs for sdr-api and dor-services-app `openapi.yml` files.

## How was this change tested?

unit tests, openapi.yml validation still works.

## Which documentation and/or configurations were updated?
