### PR TITLE
Add a field for DOI in the Identification schema

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -7,7 +7,6 @@ module Cocina
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
 
-      # example: item
       attribute :type, Types::Strict::String.enum(*AdminPolicy::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Types::Strict::String

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -12,7 +12,6 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
 
       # The content type of the Collection. Selected from an established set of values.
-      # example: item
       attribute :type, Types::Strict::String.enum(*Collection::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Types::Strict::String

--- a/lib/cocina/models/collection_identification.rb
+++ b/lib/cocina/models/collection_identification.rb
@@ -3,11 +3,11 @@
 module Cocina
   module Models
     class CollectionIdentification < Struct
+      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
       attribute :sourceId, Types::Strict::String.meta(omittable: true)
-      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -12,7 +12,7 @@ module Cocina
       attribute :note, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # Stanford persistent URL associated with the resource.
+      # Stanford persistent URL associated with the related resource. Note this is http, not https.
       attribute :purl, Types::Strict::String.meta(omittable: true)
       attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).meta(omittable: true)

--- a/lib/cocina/models/doi.rb
+++ b/lib/cocina/models/doi.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    DOI = Types::String.constrained(
+      format: %r{^10\.25740/druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}i
+    )
+  end
+end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -22,7 +22,6 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
 
       # The content type of the DRO. Selected from an established set of values.
-      # example: item
       attribute :type, Types::Strict::String.enum(*DRO::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Types::Strict::String

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -3,13 +3,16 @@
 module Cocina
   module Models
     class Identification < Struct
+      # A barcode
+      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
+      # Digital Object Identifier (https://www.doi.org)
+      # example: 10.25740/druid:bc123df4567
+      attribute :doi, Types::Strict::String.meta(omittable: true)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
       attribute :sourceId, Types::Strict::String.meta(omittable: true)
-      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
-      # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/purl.rb
+++ b/lib/cocina/models/purl.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    Purl = Types::String.constrained(
+      format: %r{^http://}i
+    )
+  end
+end

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -18,7 +18,7 @@ module Cocina
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
       attribute :standard, Standard.optional.meta(omittable: true)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).meta(omittable: true)
-      # Stanford persistent URL associated with the related resource.
+      # Stanford persistent URL associated with the related resource. Note this is http, not https.
       attribute :purl, Types::Strict::String.meta(omittable: true)
       attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).meta(omittable: true)

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -7,7 +7,6 @@ module Cocina
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
 
-      # example: item
       attribute :type, Types::Strict::String.enum(*RequestAdminPolicy::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -11,7 +11,6 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
                'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
 
-      # example: item
       attribute :type, Types::Strict::String.enum(*RequestCollection::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -21,7 +21,6 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
                'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
 
-      # example: item
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -3,13 +3,16 @@
 module Cocina
   module Models
     class RequestIdentification < Struct
+      # A barcode
+      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
+      # Digital Object Identifier (https://www.doi.org)
+      # example: 10.25740/druid:bc123df4567
+      attribute :doi, Types::Strict::String.meta(omittable: true)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
       attribute :sourceId, Types::Strict::String
-      attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
-      # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -424,12 +424,12 @@ components:
       type: object
       additionalProperties: false
       properties:
-        sourceId:
-          $ref: '#/components/schemas/SourceId'
         catalogLinks:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
     Contributor:
       description: Property model for describing agents contributing in some way to
         the creation and history of the resource.
@@ -875,6 +875,11 @@ components:
               $ref: '#/components/schemas/Standard'
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
+    DOI:
+      type: string
+      description: Digital Object Identifier (https://www.doi.org)
+      pattern: '^10\.25740\/druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
+      example: '10.25740/druid:bc123df4567'
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
@@ -1213,14 +1218,16 @@ components:
       type: object
       additionalProperties: false
       properties:
-        sourceId:
-          $ref: '#/components/schemas/SourceId'
+        barcode:
+          $ref: '#/components/schemas/Barcode'
         catalogLinks:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-        barcode:
-          $ref: '#/components/schemas/Barcode'
+        doi:
+          $ref: '#/components/schemas/DOI'
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
     Language:
       description: Languages, scripts, symbolic systems, and notations used in all
         or part of a resource or its descriptive metadata.
@@ -1389,7 +1396,7 @@ components:
       type: string
       format: uri
       # Canonical URI is http, even though this redirects to https.
-      pattern: '^http://'
+      pattern: '^http:\/\/'
     RelatedResource:
       description: Other resource associated with the described resource.
       type: object
@@ -1701,14 +1708,16 @@ components:
       type: object
       additionalProperties: false
       properties:
-        sourceId:
-          $ref: '#/components/schemas/SourceId'
+        barcode:
+          $ref: '#/components/schemas/Barcode'
         catalogLinks:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-        barcode:
-          $ref: '#/components/schemas/Barcode'
+        doi:
+          $ref: '#/components/schemas/DOI'
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
       required:
         - sourceId
     Sequence:

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -113,7 +113,10 @@ RSpec.describe Cocina::Models do
           'type' => 'http://cocina.sul.stanford.edu/models/image.jsonld',
           'label' => 'bar',
           'version' => 5,
-          'identification' => { 'sourceId' => 'sul:123' },
+          'identification' => {
+            'sourceId' => 'sul:123',
+            'doi' => '10.25740/druid:bc123df4567'
+          },
           'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' }
         }
       end


### PR DESCRIPTION
## Why was this change made?

Fixes #269 
Needed so that h2 can transfer the object and it's associated DOI to DSA.

## How was this change tested?



## Which documentation and/or configurations were updated?
