### PR TITLE
Add DOI to the zeitwerk inflector

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -14,27 +14,19 @@ require 'thor'
 
 # Help Zeitwerk find some of our classes
 class CocinaModelsInflector < Zeitwerk::Inflector
-  # rubocop:disable Metrics/MethodLength
-  def camelize(basename, _abspath)
-    case basename
-    when 'dro'
-      'DRO'
-    when 'request_dro'
-      'RequestDRO'
-    when 'dro_access'
-      'DROAccess'
-    when 'dro_structural'
-      'DROStructural'
-    when 'request_dro_structural'
-      'RequestDROStructural'
-    when 'version'
-      'VERSION'
-    else
-      super
-    end
-  end
+  INFLECTIONS = {
+    'doi' => 'DOI',
+    'dro' => 'DRO',
+    'request_dro' => 'RequestDRO',
+    'dro_access' => 'DROAccess',
+    'dro_structural' => 'DROStructural',
+    'request_dro_structural' => 'RequestDROStructural',
+    'version' => 'VERSION'
+  }.freeze
 
-  # rubocop:enable Metrics/MethodLength
+  def camelize(basename, _abspath)
+    INFLECTIONS.fetch(basename) { super }
+  end
 end
 
 loader = Zeitwerk::Loader.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,9 @@ SimpleCov.start do
   add_filter 'spec'
 end
 
+# This will find any constants that Zeitwerk has trouble inflecting
+Zeitwerk::Loader.eager_load_all
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

otherwise, when an application eager loads (in production mode), we get this error:
```
Could not spawn process for application /opt/app/sdr/sdr-api/current: The application encountered the following error: expected file /opt/app/sdr/sdr-api/shared/bundle/ruby/2.6.0/gems/cocina-models-0.61.0/lib/cocina/models/doi.rb to define constant Cocina::Models::Doi, but didn’t (Zeitwerk::NameError)
```

## How was this change tested?



## Which documentation and/or configurations were updated?
