### PR TITLE
Adapt the DOI pattern to omit the druid namespace

### DIFF
--- a/lib/cocina/models/doi.rb
+++ b/lib/cocina/models/doi.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     DOI = Types::String.constrained(
-      format: %r{^10\.25740/druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}i
+      format: %r{^10\.25740/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}i
     )
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -878,8 +878,8 @@ components:
     DOI:
       type: string
       description: Digital Object Identifier (https://www.doi.org)
-      pattern: '^10\.25740\/druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: '10.25740/druid:bc123df4567'
+      pattern: '^10\.25740\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
+      example: '10.25740/bc123df4567'
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Cocina::Models do
           'version' => 5,
           'identification' => {
             'sourceId' => 'sul:123',
-            'doi' => '10.25740/druid:bc123df4567'
+            'doi' => '10.25740/bc123df4567'
           },
           'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' }
         }


### PR DESCRIPTION


**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
This follows our existing dois: 10.25740/xd282zn6829 for example


## How was this change tested?



## Which documentation and/or configurations were updated?
