### PR TITLE
Remove doi from request-identification

### DIFF
--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -6,9 +6,6 @@ module Cocina
       # A barcode
       attribute :barcode, Types::Nominal::Any.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).meta(omittable: true)
-      # Digital Object Identifier (https://www.doi.org)
-      # example: 10.25740/druid:bc123df4567
-      attribute :doi, Types::Strict::String.meta(omittable: true)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026

--- a/openapi.yml
+++ b/openapi.yml
@@ -1704,7 +1704,9 @@ components:
           items:
             $ref: '#/components/schemas/RequestFile'
     RequestIdentification:
-      description: Same as a Identification, but requires a sourceId.
+      # Doesn't permit a DOI because our DOIs all use the DRUID as part of the DOI.
+      # You have to register the object in order to get the DRUID before you can mint a DOI
+      description: Same as a Identification, but requires a sourceId and doesn't permit a DOI.
       type: object
       additionalProperties: false
       properties:
@@ -1714,8 +1716,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-        doi:
-          $ref: '#/components/schemas/DOI'
         sourceId:
           $ref: '#/components/schemas/SourceId'
       required:

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe Cocina::Models do
           'label' => 'bar',
           'version' => 5,
           'access' => {},
-          'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' }
+          'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' },
+          'identification' => {
+            'doi' => '10.25740/bc123df4567'
+          }
         }
       end
 
@@ -114,8 +117,7 @@ RSpec.describe Cocina::Models do
           'label' => 'bar',
           'version' => 5,
           'identification' => {
-            'sourceId' => 'sul:123',
-            'doi' => '10.25740/bc123df4567'
+            'sourceId' => 'sul:123'
           },
           'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' }
         }


### PR DESCRIPTION


**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
Since we don't have a druid yet, we couldn't have a DOI for the item becuase we use the DRUID to mint the DOI


## How was this change tested?



## Which documentation and/or configurations were updated?
