### PR TITLE
Revert to using https for purl links

### DIFF
--- a/docs/sampleETD/foxml.xml
+++ b/docs/sampleETD/foxml.xml
@@ -944,7 +944,7 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <note>Submitted to the Graduate School of Education.</note>
   <note type="thesis">Thesis (Ph.D.)--Stanford University, 2015.</note>
   <location>
-  <url displayLabel="electronic resource" usage="primary display">http://purl.stanford.edu/xn109qc9773</url>
+  <url displayLabel="electronic resource" usage="primary display">https://purl.stanford.edu/xn109qc9773</url>
   </location>
   <recordInfo>
   <recordContentSource authority="marcorg">CSt</recordContentSource>

--- a/docs/sampleETD/xn109qc9773_bibframe.ttl
+++ b/docs/sampleETD/xn109qc9773_bibframe.ttl
@@ -86,7 +86,7 @@
 
 :xn109qc9773_item [ a bf:Item ;
     bf:electronicLocator [ a rdf:Resource ;
-        rdf:value <http://purl.stanford.edu/xn109qc9773> ;
+        rdf:value <https://purl.stanford.edu/xn109qc9773> ;
         bf:note [ a bf:Note ;
             rdfs:label "primary display" ;
             bf:noteType "URL usage"

--- a/docs/sampleETD/xn109qc9773_taco.json
+++ b/docs/sampleETD/xn109qc9773_taco.json
@@ -151,7 +151,7 @@
         ],
         "accessURL": [{
             "type": "purl",
-            "url": "http://purl.stanford.edu/xn109qc9773",
+            "url": "https://purl.stanford.edu/xn109qc9773",
             "primary": "TRUE"
         }]
     }

--- a/lib/cocina/models/purl.rb
+++ b/lib/cocina/models/purl.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     Purl = Types::String.constrained(
-      format: %r{^http://}i
+      format: %r{^https://}i
     )
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1396,8 +1396,8 @@ components:
       description: Stanford persistent URL associated with the related resource. Note this is http, not https.
       type: string
       format: uri
-      # Canonical URI is http, even though this redirects to https.
-      pattern: '^http:\/\/'
+      # Canonical URI is https
+      pattern: '^https:\/\/'
     RelatedResource:
       description: Other resource associated with the described resource.
       type: object

--- a/spec/cocina/models/description_spec.rb
+++ b/spec/cocina/models/description_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Cocina::Models::Description do
       expect(identifier.value).to eq('0000005406')
       expect(identifier.type).to eq('ETD ID')
 
-      expect(item.purl).to eq('http://purl.stanford.edu/hj456dt5655')
+      expect(item.purl).to eq('https://purl.stanford.edu/hj456dt5655')
 
       url = item.access.url.first
       expect(url.value).to eq('https://etd.stanford.edu/view/0000005406')
@@ -95,7 +95,7 @@ RSpec.describe Cocina::Models::Description do
   context 'with an invalid purl' do
     let(:properties) do
       JSON.parse(File.read('spec/fixtures/description/etd.json')).tap do |props|
-        props['purl'] = 'https://purl.stanford.edu/hj456dt5655'
+        props['purl'] = 'http://purl.stanford.edu/hj456dt5655'
       end
     end
 

--- a/spec/fixtures/description/etd.json
+++ b/spec/fixtures/description/etd.json
@@ -470,7 +470,7 @@
       "type": "ETD ID"
     }
   ],
-  "purl": "http://purl.stanford.edu/hj456dt5655",
+  "purl": "https://purl.stanford.edu/hj456dt5655",
   "access": {
     "url": [
       {

--- a/spec/fixtures/description/etd2.json
+++ b/spec/fixtures/description/etd2.json
@@ -458,7 +458,7 @@
       "type": "ETD ID"
     }
   ],
-  "purl": "http://purl.stanford.edu/qk672zk2803",
+  "purl": "https://purl.stanford.edu/qk672zk2803",
   "access": {
     "url": [
       {


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

Ref #276

## How was this change tested?



## Which documentation and/or configurations were updated?
