### PR TITLE
simplecov no longer needs to be pinned to 0.17

### DIFF
--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.24'
   spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.1'
-  spec.add_development_dependency 'simplecov', '~> 0.17.0'
+  spec.add_development_dependency 'simplecov'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

simplecov later versions work with codeclimate test report runner.

## How was this change tested?



## Which documentation and/or configurations were updated?
