### PR TITLE
Adds cocinaVersion attribute.

### DIFF
--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -26,10 +26,14 @@ module Cocina
       end
 
       def default
+        # Provide version as default for cocinaVersion
+        return '.default(Cocina::Models::VERSION)' if name == 'cocinaVersion'
+
         # If type is boolean and default is false, erroneously getting a nil.
         # Assuming that if required, then default is false.
         default = schema_doc.default
         default = false if default.nil? && schema_doc.type == 'boolean' && required
+
         return '' if default.nil?
 
         ".default(#{quote(default)})"

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -7,6 +7,9 @@ module Cocina
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       attribute :type, Types::Strict::String.enum(*AdminPolicy::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Types::Strict::String

--- a/lib/cocina/models/cocina_version.rb
+++ b/lib/cocina/models/cocina_version.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    CocinaVersion = Types::String.constrained(
+      format: /^\d+\.\d+\.\d+$/i
+    )
+  end
+end

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -11,6 +11,9 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
                'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       # The content type of the Collection. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*Collection::TYPES)
       # example: druid:bc123df4567

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -21,6 +21,9 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
                'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       # The content type of the DRO. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*DRO::TYPES)
       # example: druid:bc123df4567

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -7,6 +7,9 @@ module Cocina
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       attribute :type, Types::Strict::String.enum(*RequestAdminPolicy::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -11,6 +11,9 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/exhibit.jsonld',
                'http://cocina.sul.stanford.edu/models/series.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       attribute :type, Types::Strict::String.enum(*RequestCollection::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -21,6 +21,9 @@ module Cocina
                'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
                'http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld'].freeze
 
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer

--- a/lib/cocina/models/validator.rb
+++ b/lib/cocina/models/validator.rb
@@ -7,11 +7,23 @@ module Cocina
       def self.validate(clazz, attributes)
         method_name = clazz.name.split('::').last
         request_operation = root.request_operation(:post, "/validate/#{method_name}")
+
         # JSON.parse forces serialization of objects like DateTime.
-        request_operation.validate_request_body('application/json', JSON.parse(attributes.to_json))
+        json_attributes = JSON.parse(attributes.to_json)
+        # Inject cocinaVersion if needed and not present.
+        if operation_has_cocina_version?(request_operation) && !json_attributes.include?('cocinaVersion')
+          json_attributes['cocinaVersion'] = Cocina::Models::VERSION
+        end
+
+        request_operation.validate_request_body('application/json', json_attributes)
       rescue OpenAPIParser::OpenAPIError => e
         raise ValidationError, e.message
       end
+
+      def self.operation_has_cocina_version?(request_operation)
+        request_operation.operation_object.request_body.content['application/json'].schema.properties.include?('cocinaVersion')
+      end
+      private_class_method :operation_has_cocina_version?
 
       # rubocop:disable Style/ClassVars
       def self.root

--- a/openapi.yml
+++ b/openapi.yml
@@ -172,6 +172,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -187,6 +189,7 @@ components:
         description:
           $ref: '#/components/schemas/Description'
       required:
+        - cocinaVersion
         - administrative
         - externalIdentifier
         - label
@@ -363,11 +366,18 @@ components:
       required:
         - access
         - download
+    CocinaVersion:
+      description: The version of Cocina with which this object conforms.
+      type: string
+      pattern: '^\d+\.\d+\.\d+$'
+      example: '1.2.3'
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+            $ref: '#/components/schemas/CocinaVersion'
         type:
           description: The content type of the Collection. Selected from an established set of values.
           type: string
@@ -394,6 +404,7 @@ components:
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
       required:
+        - cocinaVersion
         - externalIdentifier
         - label
         - type
@@ -889,6 +900,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           description: The content type of the DRO. Selected from an established set of values.
           type: string
@@ -929,6 +942,7 @@ components:
         geographic:
           $ref: '#/components/schemas/Geographic'
       required:
+        - cocinaVersion
         - access
         - administrative
         - externalIdentifier
@@ -1508,6 +1522,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -1521,6 +1537,7 @@ components:
         description:
           $ref: '#/components/schemas/Description'
       required:
+        - cocinaVersion
         - administrative
         - label
         - type
@@ -1530,6 +1547,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -1551,6 +1570,7 @@ components:
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
       required:
+        - cocinaVersion
         - access
         - administrative
         - label
@@ -1561,6 +1581,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -1596,6 +1618,7 @@ components:
         geographic:
           $ref: '#/components/schemas/Geographic'
       required:
+        - cocinaVersion
         - administrative
         - identification
         - label

--- a/spec/cocina/generator/schema_value_spec.rb
+++ b/spec/cocina/generator/schema_value_spec.rb
@@ -174,4 +174,20 @@ RSpec.describe Cocina::Generator::SchemaValue do
       expect(access.readLocation).to eq('my office')
     end
   end
+
+  context 'when property is cocinaVersion' do
+    let(:dro) do
+      Cocina::Models::RequestDRO.new({
+                                       label: 'The Prince',
+                                       type: Cocina::Models::Vocab.book,
+                                       version: 5,
+                                       identification: { sourceId: 'sul:123' },
+                                       administrative: { hasAdminPolicy: 'druid:bc123df4567' }
+                                     }, false, false)
+    end
+
+    it 'default is provided' do
+      expect(dro.cocinaVersion).to eq(Cocina::Models::VERSION)
+    end
+  end
 end

--- a/spec/cocina/models/validator_spec.rb
+++ b/spec/cocina/models/validator_spec.rb
@@ -23,6 +23,45 @@ RSpec.describe Cocina::Models::Validator do
     end
   end
 
+  context 'when cocina version is omitted' do
+    let(:policy) do
+      Cocina::Models::AdminPolicy.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'My admin policy',
+        type: Cocina::Models::Vocab.admin_policy,
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:bc123df4567',
+          hasAgreement: 'druid:bc123df4567'
+        }
+      )
+    end
+
+    it 'injects cocina version' do
+      expect(policy.cocinaVersion).to eq(Cocina::Models::VERSION)
+    end
+  end
+
+  context 'when cocina version is present' do
+    let(:policy) do
+      Cocina::Models::AdminPolicy.new(
+        cocinaVersion: '1.0.0',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'My admin policy',
+        type: Cocina::Models::Vocab.admin_policy,
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:bc123df4567',
+          hasAgreement: 'druid:bc123df4567'
+        }
+      )
+    end
+
+    it 'does not inject cocina version' do
+      expect(policy.cocinaVersion).to eq('1.0.0')
+    end
+  end
+
   context 'when a nil value is passed' do
     let(:policy) do
       Cocina::Models::AdminPolicy.new(


### PR DESCRIPTION
closes #285

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
To keep track of the cocina version of an object to allow for long-term maintenance.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
openapi