### PR TITLE
Removes referencesAgreement from administrative.

### DIFF
--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -15,8 +15,6 @@ module Cocina
       attribute :hasAdminPolicy, Types::Strict::String
       # example: druid:bc123df4567
       attribute :hasAgreement, Types::Strict::String
-      # example: druid:bc123df4567
-      attribute :referencesAgreement, Types::Strict::String.meta(omittable: true)
       attribute :roles, Types::Strict::Array.of(AccessRole).default([].freeze)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -237,8 +237,6 @@ components:
           $ref: '#/components/schemas/Druid'
         hasAgreement:
           $ref: '#/components/schemas/Druid'
-        referencesAgreement:
-          $ref: '#/components/schemas/Druid'
         roles:
           description: The access roles conferred by this AdminPolicy (used by Argo)
           type: array


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
It is redundant.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
openapi