### PR TITLE
[SPIKE] Create an interface for effectively mutating model instances

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -49,6 +49,18 @@ module Cocina
     class Struct < Dry::Struct
       transform_keys(&:to_sym)
       schema schema.strict
+
+      def self.attribute(name, type = nil, &block)
+        super
+
+        define_method("#{name}=") do |value|
+          self.attributes = attributes.merge(name => value)
+        end
+      end
+
+      def attributes=(new_attributes)
+        @attributes = self.class.schema[new_attributes]
+      end
     end
 
     # DRY Types

--- a/spec/cocina/models/administrative_spec.rb
+++ b/spec/cocina/models/administrative_spec.rb
@@ -23,4 +23,19 @@ RSpec.describe Cocina::Models::Administrative do
       expect(administrative1.to_h).to eq(administrative2.to_h)
     end
   end
+
+  describe 'mutation' do
+    let(:administrative) do
+      described_class.new(
+        {
+          hasAdminPolicy: 'druid:bc123df4567'
+        }
+      )
+    end
+
+    it 'provides a setter as a mutation facade' do
+      administrative.hasAdminPolicy = 'druid:cb321fd7654'
+      expect(administrative.hasAdminPolicy).to eq('druid:cb321fd7654')
+    end
+  end
 end

--- a/spec/cocina/models/file_access_spec.rb
+++ b/spec/cocina/models/file_access_spec.rb
@@ -4,49 +4,51 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::FileAccess do
   # Verifying that correctly validate access, download, readLocation, and controlledDigitalLending.
-
   def dro(access, download, read_location, controlled_digital_lending)
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
-                            label: 'My DRO',
-                            type: Cocina::Models::Vocab.book,
-                            version: 1,
-                            administrative: { hasAdminPolicy: 'druid:bc123df4567' },
-                            access: {},
-                            structural: {
-                              contains: [
-                                {
-                                  version: 1,
-                                  type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-                                  label: 'Page 1',
-                                  externalIdentifier: 'abc123',
-                                  structural: {
-                                    contains: [
-                                      {
-                                        version: 1,
-                                        type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                                        filename: '00002.jp2',
-                                        label: '00002.jp2',
-                                        hasMimeType: 'image/jp2',
-                                        externalIdentifier: 'abc123',
-                                        size: 111_467,
-                                        administrative: {
-                                          publish: true,
-                                          sdrPreserve: true,
-                                          shelve: true
-                                        },
-                                        access: {
-                                          access: access,
-                                          download: download,
-                                          readLocation: read_location,
-                                          controlledDigitalLending: controlled_digital_lending
-                                        },
-                                        hasMessageDigests: []
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            })
+    dro_template = Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                           label: 'My DRO',
+                                           type: Cocina::Models::Vocab.book,
+                                           version: 1,
+                                           administrative: { hasAdminPolicy: 'druid:bc123df4567' },
+                                           access: {},
+                                           structural: {
+                                             contains: [
+                                               {
+                                                 version: 1,
+                                                 type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                                                 label: 'Page 1',
+                                                 externalIdentifier: 'abc123',
+                                                 structural: {
+                                                   contains: [
+                                                     {
+                                                       version: 1,
+                                                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                                                       filename: '00002.jp2',
+                                                       label: '00002.jp2',
+                                                       hasMimeType: 'image/jp2',
+                                                       externalIdentifier: 'abc123',
+                                                       size: 111_467,
+                                                       administrative: {
+                                                         publish: true,
+                                                         sdrPreserve: true,
+                                                         shelve: true
+                                                       },
+                                                       access: {},
+                                                       hasMessageDigests: []
+                                                     }
+                                                   ]
+                                                 }
+                                               }
+                                             ]
+                                           })
+
+    dro_template.structural.contains.first.structural.contains.first.access = {
+      access: access,
+      download: download,
+      readLocation: read_location,
+      controlledDigitalLending: controlled_digital_lending
+    }
+    dro_template
   end
 
   context 'with dark access' do


### PR DESCRIPTION
Working with our cocina-models can be jarring because, unlike most of the rest of the code we write, dry-structs are immutable which can lead to surprising results when leaning on the usual assignment interactions. So, try something different. What is in this commit (which is partly copypasta from a dry-struct issue) works fine in the simplest use cases (see administrative spec), but currently fails in the gnarlier use cases (file access spec) particularly when reaching into a structure (like a DRO) to modify another structure (like a File). Why? Because File instances are not self-validating. Files are validated in the context of the DRO, and when you reach into the DRO and mutate the File, I have so far not found a way to force a validation in the surrounding context. This feels a lot like working against dry-struct/-types, too, so I am ending the spike and pushing this up for comments.
