### PR TITLE
Allow the barcode to be cleared out

### DIFF
--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class Identification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute :barcode, Types::Nominal::Any.optional.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
       # example: 10.25740/bc123df4567

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class RequestIdentification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute :barcode, Types::Nominal::Any.optional.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -314,6 +314,7 @@ components:
             $ref: "#/components/schemas/DescriptiveBasicValue"
     Barcode:
       description: 'A barcode'
+      nullable: true
       oneOf:
         - $ref: '#/components/schemas/BusinessBarcode'
         - $ref: '#/components/schemas/LaneMedicalBarcode'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?
Ref: https://github.com/sul-dlss/argo/issues/3065


## How was this change tested?



## Which documentation and/or configurations were updated?
