### PR TITLE
Allow barcode to be nullable (really this time)

### DIFF
--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class Identification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.optional.meta(omittable: true)
+      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
       # example: 10.25740/bc123df4567

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class RequestIdentification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.optional.meta(omittable: true)
+      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -314,7 +314,6 @@ components:
             $ref: "#/components/schemas/DescriptiveBasicValue"
     Barcode:
       description: 'A barcode'
-      nullable: true
       oneOf:
         - $ref: '#/components/schemas/BusinessBarcode'
         - $ref: '#/components/schemas/LaneMedicalBarcode'
@@ -1845,6 +1844,7 @@ components:
     StandardBarcode:
       description: The standard barcode associated with a DRO object, prefixed with 36105
       type: string
+      nullable: true
       pattern: '^36105[0-9]{9}$'
       example: '36105010362304'
     Title:

--- a/spec/cocina/models/validator_spec.rb
+++ b/spec/cocina/models/validator_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Cocina::Models::Validator do
     end
   end
 
-  context 'when a nil value is passed' do
+  context 'when a nil copyright value (nullable string) is passed' do
     let(:policy) do
       Cocina::Models::AdminPolicy.new(
         externalIdentifier: 'druid:bc123df4567',
@@ -73,6 +73,28 @@ RSpec.describe Cocina::Models::Validator do
           defaultAccess: { copyright: nil },
           hasAdminPolicy: 'druid:bc123df4567',
           hasAgreement: 'druid:bc123df4567'
+        }
+      )
+    end
+
+    it 'does not raise' do
+      expect(policy.externalIdentifier).to eq('druid:bc123df4567')
+    end
+  end
+
+  context 'when a nil barcode value (nullable oneOf) is passed' do
+    let(:policy) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'My item',
+        type: Cocina::Models::Vocab.object,
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:bc123df4567'
+        },
+        access: {},
+        identification: {
+          barcode: nil
         }
       )
     end


### PR DESCRIPTION


## Why was this change made?
See https://github.com/OAI/OpenAPI-Specification/issues/1368 for why the earlier approach was unsuccessful



## How was this change tested?



## Which documentation and/or configurations were updated?
