### PR TITLE
Remove defaultObjectRights

### DIFF
--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -3,8 +3,6 @@
 module Cocina
   module Models
     class AdminPolicyAdministrative < Struct
-      # This is an XML expression of the default access (see defaultAccess)
-      attribute :defaultObjectRights, Types::Strict::String.default('<?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>').meta(omittable: true)
       attribute :defaultAccess, AdminPolicyDefaultAccess.optional.meta(omittable: true)
       attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # An additional workflow to start for objects managed by this admin policy once the end-accession workflow step is complete

--- a/openapi.yml
+++ b/openapi.yml
@@ -212,11 +212,6 @@ components:
       type: object
       additionalProperties: false
       properties:
-        defaultObjectRights:
-          type: string
-          description: This is an XML expression of the default access (see defaultAccess)
-          deprecated: true
-          default: <?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>
         defaultAccess:
           $ref: '#/components/schemas/AdminPolicyDefaultAccess'
         registrationWorkflow:


### PR DESCRIPTION
## Why was this change made?
This was previously deprecated in favor of defaultAccess

Fixes #307

## How was this change tested?



## Which documentation and/or configurations were updated?
