### PR TITLE
Model virtual object relationship on the constituent side

### DIFF
--- a/lib/cocina/models/dro_structural.rb
+++ b/lib/cocina/models/dro_structural.rb
@@ -5,6 +5,7 @@ module Cocina
     class DROStructural < Struct
       attribute :contains, Types::Strict::Array.of(FileSet).default([].freeze)
       attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).default([].freeze)
+      attribute :isConstituentOf, Types::Strict::Array.of(Druid).default([].freeze)
       attribute :isMemberOf, Types::Strict::Array.of(Druid).default([].freeze)
     end
   end

--- a/lib/cocina/models/request_dro_structural.rb
+++ b/lib/cocina/models/request_dro_structural.rb
@@ -5,6 +5,7 @@ module Cocina
     class RequestDROStructural < Struct
       attribute :contains, Types::Strict::Array.of(RequestFileSet).default([].freeze)
       attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).default([].freeze)
+      attribute :isConstituentOf, Types::Strict::Array.of(Druid).default([].freeze)
       attribute :isMemberOf, Types::Strict::Array.of(Druid).default([].freeze)
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -965,6 +965,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Sequence'
+        isConstituentOf:
+          description: Virtual object DROs that this DRO is a constituent of
+          type: array
+          items:
+            $ref: '#/components/schemas/Druid'
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array
@@ -1659,6 +1664,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Sequence'
+        isConstituentOf:
+          description: Virtual object DROs that this DRO is a constituent of
+          type: array
+          items:
+            $ref: '#/components/schemas/Druid'
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made?

This lets us generate public XML relating constituents back to their virtual objects.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None
