### PR TITLE
Validates on instantiation from existing instance.

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -76,6 +76,7 @@ module Cocina
         run("rubocop -a #{filepath} > /dev/null")
       end
 
+      # rubocop:disable Metrics/AbcSize
       def clean_output
         FileUtils.mkdir_p(options[:output])
         files = Dir.glob("#{options[:output]}/*.rb")
@@ -83,8 +84,10 @@ module Cocina
         files.delete("#{options[:output]}/version.rb")
         files.delete("#{options[:output]}/checkable.rb")
         files.delete("#{options[:output]}/validator.rb")
+        files.delete("#{options[:output]}/validatable.rb")
         FileUtils.rm_f(files)
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -16,11 +16,10 @@ module Cocina
             module Models
               class #{name} < Struct
 
+                #{validate}
                 #{types}
 
                 #{model_attributes}
-
-                #{validate}
               end
             end
           end
@@ -64,10 +63,7 @@ module Cocina
         return '' unless validatable?
 
         <<~RUBY
-          def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-            Validator.validate(self, attributes.with_indifferent_access) if validate && name
-            super(attributes, safe, &block)
-                end
+          include Validatable
         RUBY
       end
 

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class AdminPolicy < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
@@ -17,11 +19,6 @@ module Cocina
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
       attribute :description, Description.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class Collection < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/collection.jsonld',
@@ -26,11 +28,6 @@ module Cocina
       attribute :administrative, Administrative.optional.meta(omittable: true)
       attribute :description, Description.optional.meta(omittable: true)
       attribute :identification, CollectionIdentification.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class Description < Struct
+      include Validatable
+
       attribute :title, Types::Strict::Array.of(Title).default([].freeze)
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :event, Types::Strict::Array.of(Event).default([].freeze)
@@ -20,11 +22,6 @@ module Cocina
       attribute :valueAt, Types::Strict::String.meta(omittable: true)
       # Stanford persistent URL associated with the related resource. Note this is http, not https.
       attribute :purl, Types::Strict::String
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class DRO < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/object.jsonld',
@@ -38,11 +40,6 @@ module Cocina
       attribute :identification, Identification.optional.meta(omittable: true)
       attribute :structural, DROStructural.optional.meta(omittable: true)
       attribute :geographic, Geographic.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class RequestAdminPolicy < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/admin_policy.jsonld'].freeze
@@ -15,11 +17,6 @@ module Cocina
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
       attribute :description, RequestDescription.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class RequestCollection < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/collection.jsonld',
@@ -21,11 +23,6 @@ module Cocina
       attribute(:administrative, Administrative.default { Administrative.new })
       attribute :description, RequestDescription.optional.meta(omittable: true)
       attribute :identification, CollectionIdentification.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/request_description.rb
+++ b/lib/cocina/models/request_description.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class RequestDescription < Struct
+      include Validatable
+
       attribute :title, Types::Strict::Array.of(Title).default([].freeze)
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :event, Types::Strict::Array.of(Event).default([].freeze)
@@ -18,11 +20,6 @@ module Cocina
       attribute :adminMetadata, DescriptiveAdminMetadata.optional.meta(omittable: true)
       # URL or other pointer to the location of the resource description.
       attribute :valueAt, Types::Strict::String.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -3,6 +3,8 @@
 module Cocina
   module Models
     class RequestDRO < Struct
+      include Validatable
+
       include Checkable
 
       TYPES = ['http://cocina.sul.stanford.edu/models/object.jsonld',
@@ -33,11 +35,6 @@ module Cocina
       attribute(:identification, RequestIdentification.default { RequestIdentification.new })
       attribute :structural, RequestDROStructural.optional.meta(omittable: true)
       attribute :geographic, Geographic.optional.meta(omittable: true)
-
-      def self.new(attributes = default_attributes, safe = false, validate = true, &block)
-        Validator.validate(self, attributes.with_indifferent_access) if validate && name
-        super(attributes, safe, &block)
-      end
     end
   end
 end

--- a/lib/cocina/models/validatable.rb
+++ b/lib/cocina/models/validatable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # Validate upon construction
+    module Validatable
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def new(attributes = default_attributes, safe = false, validate = true, &block)
+          Validator.validate(self, attributes.with_indifferent_access) if validate && name
+          super(attributes, safe, &block)
+        end
+      end
+
+      def new(*args)
+        validate = args.first.delete(:validate) if args.present?
+        new_model = super(*args)
+        Validator.validate(new_model.class, new_model.to_h) if (validate || validate.nil?) && self.class.name
+        new_model
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validator_spec.rb
+++ b/spec/cocina/models/validator_spec.rb
@@ -3,23 +3,23 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validator do
+  let(:valid_policy) do
+    Cocina::Models::AdminPolicy.new(
+      externalIdentifier: 'druid:bc123df4567',
+      label: 'My admin policy',
+      type: Cocina::Models::Vocab.admin_policy,
+      version: 1,
+      administrative: {
+        hasAdminPolicy: 'druid:bc123df4567',
+        hasAgreement: 'druid:bc123df4567'
+      }
+    )
+  end
+
   # AdminPolicy.externalIdentifier must be a valid druid
   context 'when valid' do
-    let(:policy) do
-      Cocina::Models::AdminPolicy.new(
-        externalIdentifier: 'druid:bc123df4567',
-        label: 'My admin policy',
-        type: Cocina::Models::Vocab.admin_policy,
-        version: 1,
-        administrative: {
-          hasAdminPolicy: 'druid:bc123df4567',
-          hasAgreement: 'druid:bc123df4567'
-        }
-      )
-    end
-
     it 'does not raise' do
-      expect(policy.externalIdentifier).to eq('druid:bc123df4567')
+      expect(valid_policy.externalIdentifier).to eq('druid:bc123df4567')
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe Cocina::Models::Validator do
     end
   end
 
-  describe 'when invalid' do
+  context 'when invalid' do
     let(:policy) do
       Cocina::Models::AdminPolicy.new(
         externalIdentifier: 'druid:abc123',
@@ -117,6 +117,21 @@ RSpec.describe Cocina::Models::Validator do
 
     it 'raises' do
       expect { policy }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+
+  context 'when invalid and created from existing valid object' do
+    it 'raises' do
+      expect do
+        valid_policy.new(externalIdentifier: 'druid:abc123')
+      end.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+
+  context 'when invalid and created from existing valid object but not validating' do
+    it 'does not raise' do
+      expect(valid_policy.new(externalIdentifier: 'druid:abc123',
+                              validate: false).externalIdentifier).to eq('druid:abc123')
     end
   end
 


### PR DESCRIPTION
closes #313

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Catch validation problems faster.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

