### PR TITLE
Make partOfProject a request only parameter

### DIFF
--- a/lib/cocina/models/request_administrative.rb
+++ b/lib/cocina/models/request_administrative.rb
@@ -2,10 +2,13 @@
 
 module Cocina
   module Models
-    class Administrative < Struct
+    class RequestAdministrative < Struct
       # example: druid:bc123df4567
       attribute :hasAdminPolicy, Types::Strict::String
       attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
+      # Internal project this resource is a part of. This governs routing of messages about this object.
+      # example: Google Books
+      attribute :partOfProject, Types::Strict::String.meta(omittable: true)
     end
   end
 end

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -20,7 +20,7 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)
       attribute(:access, CollectionAccess.default { CollectionAccess.new })
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:administrative, RequestAdministrative.default { RequestAdministrative.new })
       attribute :description, RequestDescription.optional.meta(omittable: true)
       attribute :identification, CollectionIdentification.optional.meta(omittable: true)
     end

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -30,7 +30,7 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)
       attribute :access, DROAccess.optional.meta(omittable: true)
-      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:administrative, RequestAdministrative.default { RequestAdministrative.new })
       attribute :description, RequestDescription.optional.meta(omittable: true)
       attribute(:identification, RequestIdentification.default { RequestIdentification.new })
       attribute :structural, RequestDROStructural.optional.meta(omittable: true)

--- a/openapi.yml
+++ b/openapi.yml
@@ -174,11 +174,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ReleaseTag'
-        partOfProject:
-          description: Administrative or Internal project this resource is a part of
-          example: Google Books
-          type: string
-          nullable: true
       required:
         - hasAdminPolicy
     AdminPolicy:
@@ -1469,6 +1464,18 @@ components:
           example: Searchworks
         release:
           type: boolean
+    RequestAdministrative:
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/Administrative"
+        - type: object
+          additionalProperties: false
+          properties:
+            partOfProject:
+              description: Internal project this resource is a part of. This governs routing of messages about this object.
+              example: Google Books
+              type: string
     RequestAdminPolicy:
       description: Same as an AdminPolicy, but doesn't have an externalIdentifier as one will be created
       type: object
@@ -1522,7 +1529,7 @@ components:
         access:
           $ref: '#/components/schemas/CollectionAccess'
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: '#/components/schemas/RequestAdministrative'
         description:
           $ref: '#/components/schemas/RequestDescription'
         identification:
@@ -1642,7 +1649,7 @@ components:
         access:
           $ref: '#/components/schemas/DROAccess'
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: '#/components/schemas/RequestAdministrative'
         description:
           $ref: '#/components/schemas/RequestDescription'
         identification:

--- a/spec/cocina/models/validator_spec.rb
+++ b/spec/cocina/models/validator_spec.rb
@@ -173,8 +173,7 @@ RSpec.describe Cocina::Models::Validator do
                 to: 'Searchworks',
                 release: true
               }
-            ],
-            partOfProject: 'School of Engineering photograph collection'
+            ]
           }
         }
       )


### PR DESCRIPTION

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
This is only for routing messages, so we don't need to persist it in the model.
Ref https://github.com/sul-dlss/common-accessioning/issues/851



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



