### PR TITLE
Enable new cops and auto-correct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,12 @@ Metrics/MethodLength:
 
 # ----- RSpec ------
 
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+
 RSpec/ExampleLength:
   Max: 18
   Exclude:

--- a/spec/cocina/generator/schema_array_spec.rb
+++ b/spec/cocina/generator/schema_array_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Cocina::Generator::SchemaArray do
       expect(tag.what).to eq('collection')
       expect(tag.date).to eq DateTime.parse '2018-11-23T00:44:52Z'
       expect(tag.to).to eq('Searchworks')
-      expect(tag.release).to eq true
+      expect(tag.release).to be true
     end
   end
 

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models do
   it 'has a version number' do
-    expect(Cocina::Models::VERSION).not_to be nil
+    expect(Cocina::Models::VERSION).not_to be_nil
   end
 
   describe '.build' do


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

When running `exe/generator` the output was flooded with:

```
Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable
RSpec/BeEq: # new in 2.9.0
  Enabled: true
RSpec/BeNil: # new in 2.9.0
  Enabled: true
```

This enables the new cops and auto corrects to apply.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



