### PR TITLE
Add a vocabulary for the 'none' license

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -80,6 +80,8 @@ module Cocina
         files.delete("#{options[:output]}/checkable.rb")
         files.delete("#{options[:output]}/validator.rb")
         files.delete("#{options[:output]}/validatable.rb")
+        files.delete("#{options[:output]}/license.rb")
+
         FileUtils.rm_f(files)
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/cocina/models/license.rb
+++ b/lib/cocina/models/license.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # This vocabulary defines some of the supported licenses
+    class License
+      def self.none
+        'https://cocina.sul.stanford.edu/licenses/none'
+      end
+    end
+  end
+end


### PR DESCRIPTION


**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

Fixes #344

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



