### PR TITLE
No delete vocab

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -71,18 +71,23 @@ module Cocina
         run("rubocop -a #{filepath} > /dev/null")
       end
 
-      # rubocop:disable Metrics/AbcSize
+      NO_CLEAN = [
+        'version.rb',
+        'checkable.rb',
+        'validator.rb',
+        'validatable.rb',
+        'vocabulary.rb',
+        'license.rb'
+      ].freeze
+
       def clean_output
         FileUtils.mkdir_p(options[:output])
         files = Dir.glob("#{options[:output]}/*.rb")
         # Leave alone
-        files.delete("#{options[:output]}/version.rb")
-        files.delete("#{options[:output]}/checkable.rb")
-        files.delete("#{options[:output]}/validator.rb")
-        files.delete("#{options[:output]}/validatable.rb")
+        NO_CLEAN.each { |filename| files.delete("#{options[:output]}/#{filename}") }
+
         FileUtils.rm_f(files)
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -47,7 +47,7 @@ module Cocina
       end
 
       def types
-        type_properties_doc = schema_doc.properties['type']
+        type_properties_doc = schema_properties.find { |property| property.key == 'type' }&.schema_doc
         return '' if type_properties_doc.nil? || type_properties_doc.enum.nil?
 
         types_list = type_properties_doc.enum.map { |item| "'#{item}'" }.join(",\n ")

--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -22,7 +22,8 @@ class CocinaModelsInflector < Zeitwerk::Inflector
     'dro_access' => 'DROAccess',
     'dro_structural' => 'DROStructural',
     'request_dro_structural' => 'RequestDROStructural',
-    'version' => 'VERSION'
+    'version' => 'VERSION',
+    'dro_with_metadata' => 'DROWithMetadata'
   }.freeze
 
   def camelize(basename, _abspath)

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AdminPolicyWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/admin_policy'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :type, Types::Strict::String.enum(*AdminPolicyWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Strict::Integer
+      attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
+      attribute :description, Description.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class CollectionWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/collection',
+               'https://cocina.sul.stanford.edu/models/curated-collection',
+               'https://cocina.sul.stanford.edu/models/user-collection',
+               'https://cocina.sul.stanford.edu/models/exhibit',
+               'https://cocina.sul.stanford.edu/models/series'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      # The content type of the Collection. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*CollectionWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      # Primary processing label (can be same as title) for a Collection.
+      attribute :label, Types::Strict::String
+      # Version for the Collection within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute(:access, CollectionAccess.default { CollectionAccess.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
+      attribute(:description, Description.default { Description.new })
+      attribute :identification, CollectionIdentification.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class DROWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/object',
+               'https://cocina.sul.stanford.edu/models/3d',
+               'https://cocina.sul.stanford.edu/models/agreement',
+               'https://cocina.sul.stanford.edu/models/book',
+               'https://cocina.sul.stanford.edu/models/document',
+               'https://cocina.sul.stanford.edu/models/geo',
+               'https://cocina.sul.stanford.edu/models/image',
+               'https://cocina.sul.stanford.edu/models/page',
+               'https://cocina.sul.stanford.edu/models/photograph',
+               'https://cocina.sul.stanford.edu/models/manuscript',
+               'https://cocina.sul.stanford.edu/models/map',
+               'https://cocina.sul.stanford.edu/models/media',
+               'https://cocina.sul.stanford.edu/models/track',
+               'https://cocina.sul.stanford.edu/models/webarchive-binary',
+               'https://cocina.sul.stanford.edu/models/webarchive-seed'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      # The content type of the DRO. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*DROWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      # Primary processing label (can be same as title) for a DRO.
+      attribute :label, Types::Strict::String
+      # Version for the DRO within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute(:access, DROAccess.default { DROAccess.new })
+      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:description, Description.default { Description.new })
+      attribute :identification, Identification.optional.meta(omittable: true)
+      attribute :structural, DROStructural.optional.meta(omittable: true)
+      attribute :geographic, Geographic.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/object_metadata.rb
+++ b/lib/cocina/models/object_metadata.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class ObjectMetadata < Struct
+      # When the object was created.
+      attribute :created, Types::Params::DateTime
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/openapi.yml
+++ b/openapi.yml
@@ -31,6 +31,18 @@ paths:
       responses:
         '200':
           description: noop
+  /validate/DROWithMetadata:
+    post:
+      summary: Validate a DRO with metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DROWithMetadata'
+      responses:
+        '200':
+          description: noop
   /validate/Collection:
     post:
       summary: Validate a Collection
@@ -55,6 +67,18 @@ paths:
       responses:
         '200':
           description: noop
+  /validate/CollectionWithMetadata:
+    post:
+      summary: Validate a Collection with metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionWithMetadata'
+      responses:
+        '200':
+          description: noop
   /validate/AdminPolicy:
     post:
       summary: Validate an AdminPolicy
@@ -76,6 +100,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RequestAdminPolicy'
+      responses:
+        '200':
+          description: noop
+  /validate/AdminPolicyWithMetadata:
+    post:
+      summary: Validate an Admin Policy with metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminPolicyWithMetadata'
       responses:
         '200':
           description: noop
@@ -203,6 +239,13 @@ components:
         - label
         - type
         - version
+    # AdminPolicyWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    AdminPolicyWithMetadata:
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/AdminPolicy"
+        - $ref: "#/components/schemas/ObjectMetadata"
     AdminPolicyAdministrative:
       description: Administrative properties for an AdminPolicy
       type: object
@@ -450,6 +493,13 @@ components:
             $ref: '#/components/schemas/CatalogLink'
         sourceId:
           $ref: '#/components/schemas/SourceId'
+    # CollectionWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    CollectionWithMetadata:
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/Collection"
+        - $ref: "#/components/schemas/ObjectMetadata"
     Contributor:
       description: Property model for describing agents contributing in some way to
         the creation and history of the resource.
@@ -968,6 +1018,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Druid'
+    # DROWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    DROWithMetadata:
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/DRO"
+        - $ref: "#/components/schemas/ObjectMetadata"
     Druid:
       type: string
       pattern: '^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
@@ -1343,6 +1400,27 @@ components:
       required:
         - type
         - digest
+    # ObjectMetadata schema should not be copied to sdr-api and dor-services-app.
+    ObjectMetadata:
+      description: Metadata for a cocina object.
+      type: object
+      additionalProperties: false
+      properties:
+        created:
+          description: When the object was created.
+          type: string
+          format: date-time
+        modified:
+          description: When the object was modified.
+          type: string
+          format: date-time
+        lock:
+          description: Key for optimistic locking. The contents of the key is not specified.
+          type: string        
+      required:
+        - created
+        - modified
+        - lock
     Presentation:
       description: Presentation data for the File.
       type: object

--- a/spec/cocina/generator/schema_spec.rb
+++ b/spec/cocina/generator/schema_spec.rb
@@ -83,6 +83,30 @@ RSpec.describe Cocina::Generator::Schema do
     end
   end
 
+  context 'when schema has types via allOf' do
+    let(:policy) do
+      Cocina::Models::AdminPolicyWithMetadata.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'My admin policy',
+        type: Cocina::Models::ObjectType.admin_policy,
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:bc123df4567',
+          hasAgreement: 'druid:bc123df4567',
+          accessTemplate: {}
+        },
+        created: DateTime.now,
+        modified: DateTime.now,
+        lock: 'abc123'
+      )
+    end
+
+    it 'is checkable' do
+      expect(policy.admin_policy?).to be true
+      expect(policy.dro?).to be false
+    end
+  end
+
   context 'when validatable' do
     # A model is validatable when there is a validation path in the openapi. For example, /validate/AdminPolicy
     # Its initializer then accepts a third argument which indicates whether to validate.


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Vocab-related files were being deleted when regenerating all files.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Local


