### PR TITLE
Add RSpec matchers for cocina comparisons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,7 @@ Metrics/BlockLength:
   Exclude:
     - cocina-models.gemspec
     - spec/cocina/**/*
+    - lib/cocina/rspec/matchers.rb
 
 Metrics/MethodLength:
   Max: 14

--- a/README.md
+++ b/README.md
@@ -103,3 +103,17 @@ The following are the recommended naming conventions for code using Cocina model
 * `cocina_admin_policy`: `Cocina::Models::AdminPolicy` instance
 * `cocina_collection`: `Cocina::Models::Collection` instance
 * `cocina_object`: `Cocina::Models::DRO` or `Cocina::Models::AdminPolicy` or `Cocina::Models::Collection` instance
+
+## RSpec matchers
+
+As of the 0.69.0 release, the `cocina-models` gem provides RSpec matchers for downstream apps to make it easier to compare Cocina data structures. The matchers provided include:
+
+* `equal_cocina_model`: Compare a Cocina JSON string with a model instance. This matcher is especially valuable coupled with the `super_diff` gem (a dependency of `cocina-models` since the 0.69.0 release). Example usage:
+  * `expect(http_response_body_with_cocina_json).to equal_cocina_model(cocina_instance)`
+* `cocina_object_with` (AKA `match_cocina_object_with`): Compare a Cocina model instance with a hash containining part of the structure of a Cocina object. Example usage:
+  * `expect(CocinaObjectStore).to have_received(:save).with(cocina_object_with(access: { view: 'world' }, structural: { contains: [...] }))`
+  * expect(updated_cocina_item).to match_cocina_object_with(structural: { hasMemberOrders: [] })
+* `cocina_object_with_types`: Check a Cocina object's type information. Example usage:
+  * `expect(object_client).to have_received(:update).with(params: cocina_object_with_types(content_type: Cocina::Models::ObjectType.book, viewing_direction: 'left-to-right'))`
+* `cocina_admin_policy_with_registration_collections`: Check a Cocina admin policy's collections. Example usage:
+  * `expect(object_client).to have_received(:update).with(params: cocina_admin_policy_with_registration_collections([collection_id]))`

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   # Match these version requirements to what committee wants,
   # so that our client (non-committee) users have the same dependencies.
   spec.add_dependency 'openapi_parser', '>= 0.11.1', '< 1.0'
+  spec.add_dependency 'super_diff'
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 

--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -22,6 +22,7 @@ class CocinaModelsInflector < Zeitwerk::Inflector
     'dro_access' => 'DROAccess',
     'dro_structural' => 'DROStructural',
     'request_dro_structural' => 'RequestDROStructural',
+    'rspec' => 'RSpec',
     'version' => 'VERSION'
   }.freeze
 

--- a/lib/cocina/rspec.rb
+++ b/lib/cocina/rspec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+require 'rspec/matchers'
+if defined?(Rails)
+  require 'super_diff/rspec-rails'
+else
+  require 'super_diff/rspec'
+end
+require 'cocina/rspec/matchers'
+
+RSpec.configure do |config|
+  config.include Cocina::RSpec::Matchers
+end

--- a/lib/cocina/rspec/matchers.rb
+++ b/lib/cocina/rspec/matchers.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Provides RSpec matchers for Cocina models
+module Cocina
+  module RSpec
+    # Cocina-related RSpec matchers
+    module Matchers
+      extend ::RSpec::Matchers::DSL
+
+      # NOTE: each k/v pair in the hash passed to this matcher will need to be present in actual
+      matcher :cocina_object_with do |**kwargs|
+        kwargs.each do |cocina_section, expected|
+          match do |actual|
+            expected.all? do |expected_key, expected_value|
+              # NOTE: there's no better method on Hash that I could find for this.
+              #        #include? and #member? only check keys, not k/v pairs
+              actual.public_send(cocina_section).to_h.any? do |actual_key, actual_value|
+                if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
+                  expected_value.all? { |pair| actual_value.to_a.include?(pair) }
+                else
+                  actual_key == expected_key && actual_value == expected_value
+                end
+              end
+            end
+          end
+        end
+      end
+
+      alias_matcher :match_cocina_object_with, :cocina_object_with
+
+      # The `equal_cocina_model` matcher compares a JSON string as actual value
+      # against a Cocina model coerced to JSON as expected value. We want to compare
+      # these as JSON rather than as hashes, else we'll have to start
+      # deep-converting some values within the hashes, thinking of date/time values
+      # in particular. This matching behavior continues what dor-services-app was
+      # already doing before this custom matcher was written.
+      #
+      # Note, though, that when actual and expected values do *not* match, we coerce
+      # both values to hashes to allow the `super_diff` gem to highlight the areas
+      # that differ. This is easier to scan than two giant JSON strings.
+      matcher :equal_cocina_model do |expected|
+        match do |actual|
+          Cocina::Models.build(JSON.parse(actual)).to_json == expected.to_json
+        rescue NoMethodError
+          warn "Could not match cocina models because expected is not a valid JSON string: #{expected}"
+          false
+        end
+
+        failure_message do |actual|
+          SuperDiff::EqualityMatchers::Hash.new(
+            expected: expected.to_h.deep_symbolize_keys,
+            actual: JSON.parse(actual, symbolize_names: true)
+          ).fail
+        rescue StandardError => e
+          "ERROR in CocinaMatchers: #{e}"
+        end
+      end
+
+      matcher :cocina_object_with_types do |expected|
+        match do |actual|
+          return false if expected[:without_order] && !match_no_orders?
+
+          if expected[:content_type] && expected[:resource_types]
+            match_cocina_type?(actual, expected) && match_contained_cocina_types?(actual, expected)
+          elsif expected[:content_type] && expected[:viewing_direction]
+            match_cocina_type?(actual, expected) && match_cocina_viewing_direction?(actual, expected)
+          elsif expected[:content_type]
+            match_cocina_type?(actual, expected)
+          elsif expected[:resource_types]
+            match_contained_cocina_types?(actual, expected)
+          else
+            raise ArgumentError, 'must provide content_type and/or resource_types keyword args'
+          end
+        end
+
+        def match_no_orders?
+          actual.structural.hasMemberOrders.blank?
+        end
+
+        def match_cocina_type?(actual, expected)
+          actual.type == expected[:content_type]
+        end
+
+        def match_cocina_viewing_direction?(actual, expected)
+          actual.structural.hasMemberOrders.map(&:viewingDirection).all? do |viewing_direction|
+            viewing_direction == expected[:viewing_direction]
+          end
+        end
+
+        def match_contained_cocina_types?(actual, expected)
+          Array(actual.structural.contains).map(&:type).all? { |type| type.in?(expected[:resource_types]) }
+        end
+      end
+
+      matcher :cocina_admin_policy_with_registration_collections do |expected|
+        match do |actual|
+          actual.type == Cocina::Models::ObjectType.admin_policy &&
+            expected.all? { |collection_id| collection_id.in?(actual.administrative.collectionsForRegistration) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #319

## Why was this change made? 🤔

This commit ports Cocina matchers from other codebases (argo, dor-services-app, sdr-client) so that they are available downstream. Companion PRs in these codebases are in progress and will be ready for review once we cut the next release of cocina-models.

## How was this change tested? 🤨

CI, and this change was already tested successfully in argo, dor-services-app, and sdr-client.
