### PR TITLE
Do not clean description builders when generating

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -72,12 +72,15 @@ module Cocina
       end
 
       NO_CLEAN = [
-        'version.rb',
         'checkable.rb',
-        'validator.rb',
+        'dro_rights_description_builder.rb',
+        'license.rb',
+        'rights_description_builder.rb',
+        'title_builder.rb',
         'validatable.rb',
-        'vocabulary.rb',
-        'license.rb'
+        'validator.rb',
+        'version.rb',
+        'vocabulary.rb'
       ].freeze
 
       def clean_output


### PR DESCRIPTION
## Why was this change made? 🤔

Because we do not want the generate to delete Aaron's good work.

## How was this change tested? 🤨

CI, and I ran the generator locally
