### PR TITLE
fix super diff require

### DIFF
--- a/lib/cocina/models/version.rb
+++ b/lib/cocina/models/version.rb
@@ -2,6 +2,6 @@
 
 module Cocina
   module Models
-    VERSION = '0.69.0'
+    VERSION = '0.69.1'
   end
 end

--- a/lib/cocina/rspec.rb
+++ b/lib/cocina/rspec.rb
@@ -2,11 +2,7 @@
 
 require 'rspec/core'
 require 'rspec/matchers'
-if defined?(Rails)
-  require 'super_diff/rspec-rails'
-else
-  require 'super_diff/rspec'
-end
+require 'super_diff/rspec'
 require 'cocina/rspec/matchers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Do not bother trying to require super_diff Rails bindings

And bump version to 0.69.1. Discovered this at the end of rolling out 0.69.0 when dor_indexing_app barfed.
