### PR TITLE
Do not eager load rspec matchers and bump version to 0.69.2

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -34,6 +34,8 @@ end
 loader = Zeitwerk::Loader.new
 loader.inflector = CocinaModelsInflector.new
 loader.push_dir(File.absolute_path("#{__FILE__}/../.."))
+loader.ignore("#{__dir__}/rspec.rb")
+loader.ignore("#{__dir__}/rspec/**/*.rb")
 loader.setup
 
 module Cocina

--- a/lib/cocina/models/version.rb
+++ b/lib/cocina/models/version.rb
@@ -2,6 +2,6 @@
 
 module Cocina
   module Models
-    VERSION = '0.69.1'
+    VERSION = '0.69.2'
   end
 end


### PR DESCRIPTION
Else, zeitwerk attempts to load rspec matchers in the production environment, where rspec is not a dependency.

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



