### PR TITLE
Optimistic locking

### DIFF
--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -47,10 +47,13 @@ module Cocina
       end
 
       def types
-        type_properties_doc = schema_doc.properties['type']
-        return '' if type_properties_doc.nil? || type_properties_doc.enum.nil?
+        type_schema_property = schema_properties.find { |schema_property| schema_property.key == 'type' }
+        return '' if type_schema_property.nil?
 
-        types_list = type_properties_doc.enum.map { |item| "'#{item}'" }.join(",\n ")
+        type_schema_doc = type_schema_property.schema_doc
+        return '' if type_schema_doc.enum.nil?
+
+        types_list = type_schema_doc.enum.map { |item| "'#{item}'" }.join(",\n ")
 
         <<~RUBY
           include Checkable

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AdminPolicyWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/admin_policy'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :type, Types::Strict::String.enum(*AdminPolicyWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Strict::Integer
+      attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
+      attribute :description, Description.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class CollectionWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/collection',
+               'https://cocina.sul.stanford.edu/models/curated-collection',
+               'https://cocina.sul.stanford.edu/models/user-collection',
+               'https://cocina.sul.stanford.edu/models/exhibit',
+               'https://cocina.sul.stanford.edu/models/series'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      # The content type of the Collection. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*CollectionWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      # Primary processing label (can be same as title) for a Collection.
+      attribute :label, Types::Strict::String
+      # Version for the Collection within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute(:access, CollectionAccess.default { CollectionAccess.new })
+      attribute :administrative, Administrative.optional.meta(omittable: true)
+      attribute(:description, Description.default { Description.new })
+      attribute :identification, CollectionIdentification.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class DROWithMetadata < Struct
+      include Validatable
+
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/object',
+               'https://cocina.sul.stanford.edu/models/3d',
+               'https://cocina.sul.stanford.edu/models/agreement',
+               'https://cocina.sul.stanford.edu/models/book',
+               'https://cocina.sul.stanford.edu/models/document',
+               'https://cocina.sul.stanford.edu/models/geo',
+               'https://cocina.sul.stanford.edu/models/image',
+               'https://cocina.sul.stanford.edu/models/page',
+               'https://cocina.sul.stanford.edu/models/photograph',
+               'https://cocina.sul.stanford.edu/models/manuscript',
+               'https://cocina.sul.stanford.edu/models/map',
+               'https://cocina.sul.stanford.edu/models/media',
+               'https://cocina.sul.stanford.edu/models/track',
+               'https://cocina.sul.stanford.edu/models/webarchive-binary',
+               'https://cocina.sul.stanford.edu/models/webarchive-seed'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      # The content type of the DRO. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*DROWithMetadata::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Types::Strict::String
+      # Primary processing label (can be same as title) for a DRO.
+      attribute :label, Types::Strict::String
+      # Version for the DRO within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute(:access, DROAccess.default { DROAccess.new })
+      attribute(:administrative, Administrative.default { Administrative.new })
+      attribute(:description, Description.default { Description.new })
+      attribute :identification, Identification.optional.meta(omittable: true)
+      attribute :structural, DROStructural.optional.meta(omittable: true)
+      attribute :geographic, Geographic.optional.meta(omittable: true)
+      # When the object was created.
+      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/models/object_metadata.rb
+++ b/lib/cocina/models/object_metadata.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class ObjectMetadata < Struct
+      # When the object was created.
+      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      # When the object was modified.
+      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      # Key for optimistic locking. The contents of the key is not specified.
+      attribute :lock, Types::Strict::String
+    end
+  end
+end

--- a/lib/cocina/rspec/matchers.rb
+++ b/lib/cocina/rspec/matchers.rb
@@ -11,16 +11,21 @@ module Cocina
       matcher :cocina_object_with do |**kwargs|
         kwargs.each do |cocina_section, expected|
           match do |actual|
-            expected.all? do |expected_key, expected_value|
-              # NOTE: there's no better method on Hash that I could find for this.
-              #        #include? and #member? only check keys, not k/v pairs
-              actual.public_send(cocina_section).to_h.any? do |actual_key, actual_value|
-                if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
-                  expected_value.all? { |pair| actual_value.to_a.include?(pair) }
-                else
-                  actual_key == expected_key && actual_value == expected_value
+            # created, modified, lock for *WithMetadata don't respond to all?
+            if expected.respond_to?(:all?)
+              expected.all? do |expected_key, expected_value|
+                # NOTE: there's no better method on Hash that I could find for this.
+                #        #include? and #member? only check keys, not k/v pairs
+                actual.public_send(cocina_section).to_h.any? do |actual_key, actual_value|
+                  if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
+                    expected_value.all? { |pair| actual_value.to_a.include?(pair) }
+                  else
+                    actual_key == expected_key && actual_value == expected_value
+                  end
                 end
               end
+            else
+              expected == actual.public_send(cocina_section)
             end
           end
         end

--- a/openapi.yml
+++ b/openapi.yml
@@ -31,6 +31,18 @@ paths:
       responses:
         '200':
           description: noop
+  /validate/DROWithMetadata:
+    post:
+      summary: Validate a DRO with object metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DROWithMetadata'
+      responses:
+        '200':
+          description: noop
   /validate/Collection:
     post:
       summary: Validate a Collection
@@ -55,6 +67,18 @@ paths:
       responses:
         '200':
           description: noop
+  /validate/CollectionWithMetadata:
+    post:
+      summary: Validate a Collection with object metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionWithMetadata'
+      responses:
+        '200':
+          description: noop
   /validate/AdminPolicy:
     post:
       summary: Validate an AdminPolicy
@@ -76,6 +100,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RequestAdminPolicy'
+      responses:
+        '200':
+          description: noop
+  /validate/AdminPolicyWithMetadata:
+    post:
+      summary: Validate an AdminPolicy with object metadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminPolicyWithMetadata'
       responses:
         '200':
           description: noop
@@ -295,6 +331,14 @@ components:
           description: The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
           type: string
           nullable: true
+    # AdminPolicyWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    AdminPolicyWithMetadata:
+      description: Admin Policy with addition object metadata.
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/AdminPolicy"
+        - $ref: "#/components/schemas/ObjectMetadata"
     AppliesTo:
       description: Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.
@@ -450,6 +494,14 @@ components:
             $ref: '#/components/schemas/CatalogLink'
         sourceId:
           $ref: '#/components/schemas/SourceId'
+    # CollectionWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    CollectionWithMetadata:
+      description: Collection with addition object metadata.
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/Collection"
+        - $ref: "#/components/schemas/ObjectMetadata"
     Contributor:
       description: Property model for describing agents contributing in some way to
         the creation and history of the resource.
@@ -968,6 +1020,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Druid'
+    # DROWithMetadata schema should not be copied to sdr-api and dor-services-app.
+    DROWithMetadata:
+      description: DRO with addition object metadata.
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/DRO"
+        - $ref: "#/components/schemas/ObjectMetadata"
     Druid:
       type: string
       pattern: '^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
@@ -1343,6 +1403,25 @@ components:
       required:
         - type
         - digest
+    # ObjectMetadata schema should not be copied to sdr-api and dor-services-app.
+    ObjectMetadata:
+      description: Metadata for a cocina object.
+      type: object
+      additionalProperties: false
+      properties:
+        created:
+          description: When the object was created.
+          type: string
+          format: date-time
+        modified:
+          description: When the object was modified.
+          type: string
+          format: date-time
+        lock:
+          description: Key for optimistic locking. The contents of the key is not specified.
+          type: string        
+      required:
+        - lock
     Presentation:
       description: Presentation data for the File.
       type: object

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Cocina::Models do
 
     it 'returns a DROWithMetadata' do
       expect(cocina_object_with_metadata).to be_kind_of Cocina::Models::DROWithMetadata
-      expect(cocina_object_with_metadata).to cocina_object_with expected
+      expect(cocina_object_with_metadata).to match_cocina_object_with(expected.to_h)
     end
   end
 end

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -231,4 +231,62 @@ RSpec.describe Cocina::Models do
       end
     end
   end
+
+  describe '.without_metadata' do
+    subject(:cocina_object_without_metadata) { described_class.without_metadata(cocina_object) }
+
+    let(:cocina_object) do
+      Cocina::Models::DROWithMetadata.new(
+        type: 'https://cocina.sul.stanford.edu/models/image',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'bar',
+        version: 5,
+        access: {},
+        administrative: { 'hasAdminPolicy' => 'druid:bc123df4567' },
+        description: {
+          title: [{ 'value' => 'Test DRO' }],
+          purl: 'https://purl.stanford.edu/bc123df4567'
+        },
+        created: DateTime.now.iso8601,
+        modified: DateTime.now.iso8601,
+        lock: 'abc123'
+      )
+    end
+
+    it { is_expected.to be_kind_of Cocina::Models::DRO }
+  end
+
+  describe '.with_metadata' do
+    subject(:cocina_object_with_metadata) do
+      described_class.with_metadata(cocina_object, 'abc123', created: date, modified: date)
+    end
+
+    let(:date) { DateTime.now }
+
+    let(:props) do
+      {
+        type: 'https://cocina.sul.stanford.edu/models/image',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'bar',
+        version: 5,
+        access: {},
+        administrative: { 'hasAdminPolicy' => 'druid:bc123df4567' },
+        description: {
+          title: [{ 'value' => 'Test DRO' }],
+          purl: 'https://purl.stanford.edu/bc123df4567'
+        }
+      }
+    end
+
+    let(:cocina_object) { Cocina::Models::DRO.new(props) }
+
+    let(:expected) do
+      Cocina::Models::DROWithMetadata.new(props.merge({ lock: 'abc123', created: date, modified: date }))
+    end
+
+    it 'returns a DROWithMetadata' do
+      expect(cocina_object_with_metadata).to be_kind_of Cocina::Models::DROWithMetadata
+      expect(cocina_object_with_metadata).to cocina_object_with expected
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'cocina/models'
+require 'cocina/rspec'
 require 'byebug'
 
 require 'simplecov'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
This provides a mechanism for holding lock, create date, and modified date in a manner that is compatible with existing DRO, AdminPolicy, and Collection classes.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration tests

