### PR TITLE
Title builder should handle an array of Titles or DescriptiveValue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,7 +107,7 @@ RSpec/StubbedMock: # (new in 1.44)
   Enabled: true
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 6
+  Enabled: false
 
 # ----- Style ------
 

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'deprecation'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'
   spec.add_dependency 'openapi3_parser' # Parsing openapi doc

--- a/spec/cocina/models/title_builder_spec.rb
+++ b/spec/cocina/models/title_builder_spec.rb
@@ -3,37 +3,81 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::TitleBuilder do
-  subject(:build) { described_class.build(cocina_object, strategy: strategy, add_punctuation: add_punctuation) }
+  subject(:build) { described_class.build(cocina_titles, strategy: strategy, add_punctuation: add_punctuation) }
 
+  let(:cocina_titles) { titles.map { |hash| Cocina::Models::Title.new(hash) } }
   let(:strategy) { :first }
   let(:add_punctuation) { true }
   let(:druid) { 'druid:bc753qt7345' }
   let(:apo_druid) { 'druid:pp000pp0000' }
-  let(:cocina_object) do
-    Cocina::Models::DRO.new(externalIdentifier: druid,
-                            type: Cocina::Models::ObjectType.object,
-                            label: 'A new map of Africa',
-                            version: 1,
-                            description: description,
-                            identification: {},
-                            access: {},
-                            administrative: { hasAdminPolicy: apo_druid },
-                            structural: {})
-  end
 
-  context 'with untyped titles' do
+  context 'with a DRO (deprecated)' do
+    subject(:build) { described_class.build(cocina_object, strategy: strategy, add_punctuation: add_punctuation) }
+
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: druid,
+                              type: Cocina::Models::ObjectType.object,
+                              label: 'A new map of Africa',
+                              version: 1,
+                              description: description,
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: apo_druid },
+                              structural: {})
+    end
     let(:description) do
       {
         title: [
-          { value: 'However am I going to be' },
-          { value: 'A second title' }
+          { value: 'However am I going to be' }
         ],
         purl: 'https://purl.stanford.edu/bc753qt7345'
       }
     end
 
+    it 'returns the first title object and logs a deprecation' do
+      expect(build).to eq('However am I going to be')
+      expect(Deprecation).to have_received(:warn)
+    end
+  end
+
+  context 'with a DescriptiveValue (such as a subject with type = title)' do
+    let(:cocina_titles) { descriptive_values.map { |hash| Cocina::Models::DescriptiveValue.new(hash) } }
+    let(:strategy) { :all }
+    let(:add_punctuation) { false }
+
+    let(:descriptive_values) do
+      [{
+        parallelValue: [
+          {
+            value: 'The master and Margarita'
+          },
+          {
+            value: 'Мастер и Маргарита'
+          }
+        ],
+        type: 'title'
+      }]
+    end
+
+    it 'returns the expected title' do
+      expect(build).to eq [['The master and Margarita', 'Мастер и Маргарита']]
+    end
+  end
+
+  context 'with untyped titles' do
+    let(:titles) do
+      [
+        { value: 'However am I going to be' },
+        { value: 'A second title' }
+      ]
+    end
+
     context 'with a :first strategy' do
-      it 'returns the first tile object' do
+      it 'returns the first title object' do
         expect(build).to eq('However am I going to be')
       end
     end
@@ -41,41 +85,35 @@ RSpec.describe Cocina::Models::TitleBuilder do
     context 'with an :all strategy' do
       let(:strategy) { :all }
 
-      it 'returns an array with each tile object' do
+      it 'returns an array with each title object' do
         expect(build).to eq(['However am I going to be', 'A second title'])
       end
     end
   end
 
   context 'with a primary title' do
-    let(:description) do
-      {
-        title: [
-          { value: 'A very silly primary title', status: 'primary' },
-          { value: 'A very silly secondary title' }
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      [
+        { value: 'A very silly primary title', status: 'primary' },
+        { value: 'A very silly secondary title' }
+      ]
     end
 
-    it 'returns the first tile object' do
+    it 'returns the first title object' do
       expect(build).to eq('A very silly primary title')
     end
   end
 
   context 'with a main title' do
-    let(:description) do
-      {
-        title: [
-          { value: 'A very silly main title', type: 'main title' },
-          { value: 'A very silly sub title', type: 'subtitle' }
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      [
+        { value: 'A very silly main title', type: 'main title' },
+        { value: 'A very silly sub title', type: 'subtitle' }
+      ]
     end
 
     context 'with a :first strategy' do
-      it 'returns the main tile object' do
+      it 'returns the main title object' do
         expect(build).to eq('A very silly main title')
       end
     end
@@ -83,7 +121,7 @@ RSpec.describe Cocina::Models::TitleBuilder do
     context 'with an :all strategy' do
       let(:strategy) { :all }
 
-      it 'returns the main tile object' do
+      it 'returns the main title object' do
         expect(build).to eq(['A very silly main title', 'A very silly sub title'])
       end
     end
@@ -92,36 +130,33 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when the titles are in a structuredValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          structuredValue: [
-            {
-              value: 'ti1:nonSort',
-              type: 'nonsorting characters'
-            },
-            {
-              value: 'brisk junket',
-              type: 'main title'
-            },
-            {
-              value: 'ti1:subTitle',
-              type: 'subtitle'
-            },
-            {
-              value: 'ti1:partNumber',
-              type: 'part number'
-            },
-            {
-              value: 'ti1:partName',
-              type: 'part name'
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        structuredValue: [
+          {
+            value: 'ti1:nonSort',
+            type: 'nonsorting characters'
+          },
+          {
+            value: 'brisk junket',
+            type: 'main title'
+          },
+          {
+            value: 'ti1:subTitle',
+            type: 'subtitle'
+          },
+          {
+            value: 'ti1:partNumber',
+            type: 'part number'
+          },
+          {
+            value: 'ti1:partName',
+            type: 'part name'
+          }
+        ]
+      ]
     end
 
     it 'returns the structured title' do
@@ -132,28 +167,25 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when the titles are in nested structuredValues' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          structuredValue: [
-            {
-              structuredValue: [
-                {
-                  value: 'brisk junket',
-                  type: 'main title'
-                },
-                {
-                  value: 'ti1:nonSort',
-                  type: 'nonsorting characters'
-                }
-              ]
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        structuredValue: [
+          {
+            structuredValue: [
+              {
+                value: 'brisk junket',
+                type: 'main title'
+              },
+              {
+                value: 'ti1:nonSort',
+                type: 'nonsorting characters'
+              }
+            ]
+          }
+        ]
+      ]
     end
 
     it 'returns the first structured title' do
@@ -164,24 +196,21 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when the title parts are in a structuredValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          structuredValue: [
-            {
-              value: 'ti1:partNumber',
-              type: 'part number'
-            },
-            {
-              value: 'ti1:partName',
-              type: 'part name'
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        structuredValue: [
+          {
+            value: 'ti1:partNumber',
+            type: 'part number'
+          },
+          {
+            value: 'ti1:partName',
+            type: 'part name'
+          }
+        ]
+      ]
     end
 
     context 'when add punctuation is default true' do
@@ -202,24 +231,21 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when a subtitle is in a structuredValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          structuredValue: [
-            {
-              value: 'A random subtitle',
-              type: 'subtitle'
-            },
-            {
-              value: 'A random title',
-              type: 'title'
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        structuredValue: [
+          {
+            value: 'A random subtitle',
+            type: 'subtitle'
+          },
+          {
+            value: 'A random title',
+            type: 'title'
+          }
+        ]
+      ]
     end
 
     context 'when add punctuation is default true' do
@@ -240,28 +266,25 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when multiple subtitles are in a structuredValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          structuredValue: [
-            {
-              value: 'The first subtitle',
-              type: 'subtitle'
-            },
-            {
-              value: 'The second subtitle',
-              type: 'subtitle'
-            },
-            {
-              value: 'A Title',
-              type: 'title'
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        structuredValue: [
+          {
+            value: 'The first subtitle',
+            type: 'subtitle'
+          },
+          {
+            value: 'The second subtitle',
+            type: 'subtitle'
+          },
+          {
+            value: 'A Title',
+            type: 'title'
+          }
+        ]
+      ]
     end
 
     context 'when add punctuation is default true' do
@@ -282,52 +305,46 @@ RSpec.describe Cocina::Models::TitleBuilder do
   context 'when the titles are in a parallelValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
-    let(:description) do
-      {
-        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-        # a uniform title where both the name and the title have internal StructuredValue
-        title: [
-          parallelValue: [
-            {
-              value: 'A Random sub title',
-              type: 'subtitle'
-            },
-            {
-              value: 'A Random Title'
-            }
-          ]
-        ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+    let(:titles) do
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      [
+        parallelValue: [
+          {
+            value: 'A Random sub title',
+            type: 'subtitle'
+          },
+          {
+            value: 'A Random Title'
+          }
+        ]
+      ]
     end
 
     it 'returns the correct title' do
-      expect(build).to eq('A Random sub title')
+      expect(build).to eq('A Random Title')
     end
   end
 
   context 'when multiple nonsorting characters' do
-    let(:description) do
-      {
-        title: [
-          structuredValue: [
-            {
-              value: 'The',
-              type: 'nonsorting characters'
-            }, {
-              value: 'means to prosperity',
-              type: 'main title'
-            }
-          ],
-          note: [
-            {
-              value: '5',
-              type: 'nonsorting character count'
-            }
-          ]
+    let(:titles) do
+      [
+        structuredValue: [
+          {
+            value: 'The',
+            type: 'nonsorting characters'
+          }, {
+            value: 'means to prosperity',
+            type: 'main title'
+          }
         ],
-        purl: 'https://purl.stanford.edu/bc753qt7345'
-      }
+        note: [
+          {
+            value: '5',
+            type: 'nonsorting character count'
+          }
+        ]
+      ]
     end
 
     it 'returns the title with non sorting characters included' do


### PR DESCRIPTION

## Why was this change made? 🤔
This is required in dor-indexing-app for https://github.com/sul-dlss/dor_indexing_app/issues/796
Because it is used by the TopicBuilder here: https://github.com/sul-dlss/dor_indexing_app/blob/main/app/services/topic_builder.rb#L78


## How was this change tested? 🤨
test suite