### PR TITLE
README: add a naming convention for DROs that are agreements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If for some reason the above method does not work, the sul-dlss/access-update-sc
 The following are the recommended naming conventions for code using Cocina models:
 
 * `cocina_item`: `Cocina::Models::DRO` instance
+* `cocina_agreement`: `Cocina::Models::DRO` with type of Cocina::Models::ObjectType.agreement
 * `cocina_admin_policy`: `Cocina::Models::AdminPolicy` instance
 * `cocina_collection`: `Cocina::Models::Collection` instance
 * `cocina_object`: `Cocina::Models::DRO` or `Cocina::Models::AdminPolicy` or `Cocina::Models::Collection` instance


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

agreement objects are a thing

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

README changes only.

