### PR TITLE
Add a hash accessor for properties

### DIFF
--- a/lib/cocina/models/vocabulary.rb
+++ b/lib/cocina/models/vocabulary.rb
@@ -25,6 +25,15 @@ module Cocina
       def self.properties
         @properties ||= {}
       end
+
+      ##
+      # Returns the URI for the term `property` in this vocabulary.
+      #
+      # @param  [#to_sym] property
+      # @return [String]
+      def self.[](property)
+        properties[property.to_sym]
+      end
     end
   end
 end

--- a/spec/cocina/models/file_set_type_spec.rb
+++ b/spec/cocina/models/file_set_type_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::FileSetType do
+  it 'provides vocab methods' do
+    expect(described_class.file).to eq 'https://cocina.sul.stanford.edu/models/resources/file'
+    expect(described_class.image).to eq 'https://cocina.sul.stanford.edu/models/resources/image'
+  end
+
+  it 'handles special main-original case' do
+    expect(described_class.main_original).to eq 'https://cocina.sul.stanford.edu/models/resources/main-original'
+  end
+
+  it 'has a hash accessor' do
+    expect(described_class['image']).to eq 'https://cocina.sul.stanford.edu/models/resources/image'
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Argo often needs to get the URI by the short name, (e.g. from a spreadsheet upload).

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



