### PR TITLE
Add validator ensuring no more than one refresh catalog link is present

### DIFF
--- a/lib/cocina/models/validators/catalog_links_validator.rb
+++ b/lib/cocina/models/validators/catalog_links_validator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that only a single CatalogLink has refresh set to true
+      class CatalogLinksValidator
+        MAX_REFRESH_CATALOG_LINKS = 1
+
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+        end
+
+        def validate
+          return unless meets_preconditions?
+
+          return if refresh_catalog_links.length <= MAX_REFRESH_CATALOG_LINKS
+
+          raise ValidationError, "Multiple catalog links have 'refresh' property set to true " \
+                                 "(only one allowed) #{refresh_catalog_links}"
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def meets_preconditions?
+          (dro? || collection?) && Array(attributes.dig(:identification, :catalogLinks)).any?
+        end
+
+        def refresh_catalog_links
+          attributes.dig(:identification, :catalogLinks).select { |catalog_link| catalog_link[:refresh] }
+        end
+
+        def dro?
+          (clazz::TYPES & DRO::TYPES).any?
+        rescue NameError
+          false
+        end
+
+        def collection?
+          (clazz::TYPES & Collection::TYPES).any?
+        rescue NameError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -5,7 +5,7 @@ module Cocina
     module Validators
       # Perform validation against all other Validators
       class Validator
-        VALIDATORS = [OpenApiValidator, DarkValidator].freeze
+        VALIDATORS = [OpenApiValidator, DarkValidator, CatalogLinksValidator].freeze
 
         def self.validate(clazz, attributes)
           VALIDATORS.each { |validator| validator.validate(clazz, attributes) }

--- a/spec/cocina/models/validators/catalog_links_validator_spec.rb
+++ b/spec/cocina/models/validators/catalog_links_validator_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::CatalogLinksValidator do
+  subject(:validate) { described_class.validate(clazz, props) }
+
+  {
+    Cocina::Models::RequestDRO => Cocina::Models::ObjectType.book,
+    Cocina::Models::DRO => Cocina::Models::ObjectType.object,
+    Cocina::Models::DROWithMetadata => Cocina::Models::ObjectType.image,
+    Cocina::Models::Collection => Cocina::Models::ObjectType.collection
+  }.each do |clazz, type|
+    context "with a #{clazz}" do
+      let(:clazz) { clazz }
+      let(:props) do
+        {
+          type: type,
+          identification: {
+            catalogLinks: catalog_links
+          }
+        }
+      end
+
+      context 'with zero catalog links' do
+        let(:catalog_links) { nil }
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with one refresh catalog link' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '111',
+              refresh: true
+            }
+          ]
+        end
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with one non-refresh catalog link' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '111',
+              refresh: false
+            }
+          ]
+        end
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with multiple non-refresh catalog links' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '111',
+              refresh: false
+            },
+            {
+              catalog: 'symphony',
+              catalogRecordId: '222',
+              refresh: false
+            }
+          ]
+        end
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with multiple catalog links including one refresh' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '111',
+              refresh: false
+            },
+            {
+              catalog: 'symphony',
+              catalogRecordId: '222',
+              refresh: true
+            }
+          ]
+        end
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with multiple catalog links including multiple refresh' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '111',
+              refresh: true
+            },
+            {
+              catalog: 'symphony',
+              catalogRecordId: '222',
+              refresh: true
+            }
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { validate }.to raise_error(
+            Cocina::Models::ValidationError,
+            /Multiple catalog links have 'refresh' property set to true \(only one allowed\)/
+          )
+        end
+      end
+    end
+  end
+
+  context 'with a non-DRO/non-Collection' do
+    let(:clazz) { Cocina::Models::AdminPolicy }
+    let(:props) do
+      {
+        type: Cocina::Models::ObjectType.admin_policy
+      }
+    end
+
+    it 'validates' do
+      expect { validate }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Fixes #379

## Why was this change made? 🤔

To continue adding smarter semantic validation to cocina-models, and this is the next step. Having a single catalog link with the refresh property set to true makes it clear which catalog link ("catkey") to use for refreshing metadata.

## How was this change tested? 🤨

CI

