### PR TITLE
Add missing subject.structuredValue types

### DIFF
--- a/description_types.yml
+++ b/description_types.yml
@@ -485,11 +485,14 @@ subject.note:
 subject.structuredValue:
   - value: activity dates
   - value: city
+  - value: conference
   - value: continent
   - value: country
   - value: end
   - value: east
+  - value: event
   - value: display
+  - value: family
   - value: forename
   - value: genre
   - value: latitude
@@ -500,6 +503,7 @@ subject.structuredValue:
   - value: north
   - value: occupation
   - value: ordinal
+  - value: organization
   - value: part name
   - value: person
   - value: place

--- a/docs/description_types.md
+++ b/docs/description_types.md
@@ -393,11 +393,14 @@ _Path: subject.note_
 _Path: subject.structuredValue_
   * activity dates
   * city
+  * conference
   * continent
   * country
   * end
   * east
+  * event
   * display
+  * family
   * forename
   * genre
   * latitude
@@ -408,6 +411,7 @@ _Path: subject.structuredValue_
   * north
   * occupation
   * ordinal
+  * organization
   * part name
   * person
   * place


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Add subject.structuredValue types found in data.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



