### PR TITLE
Adds purl validation.

### DIFF
--- a/lib/cocina/models/validators/purl_validator.rb
+++ b/lib/cocina/models/validators/purl_validator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that Purl matches the external identifier (druid)
+      class PurlValidator
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+        end
+
+        def validate
+          return unless meets_preconditions?
+
+          return if identifier_from_druid == identifier_from_purl
+
+          raise ValidationError, "Purl mismatch: #{druid} purl does not match object druid."
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def meets_preconditions?
+          purl
+        end
+
+        def druid
+          @druid ||= attributes[:externalIdentifier]
+        end
+
+        def purl
+          @purl ||= attributes.dig(:description, :purl)
+        end
+
+        def identifier_from_druid
+          druid.delete_prefix('druid:')
+        end
+
+        def identifier_from_purl
+          purl.split('/').last
+        end
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -8,6 +8,7 @@ module Cocina
         VALIDATORS = [
           OpenApiValidator,
           DarkValidator,
+          PurlValidator,
           CatalogLinksValidator,
           DescriptionTypesValidator
         ].freeze

--- a/spec/cocina/models/validators/purl_validator_spec.rb
+++ b/spec/cocina/models/validators/purl_validator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::PurlValidator do
+  subject(:validate) { described_class.validate(clazz, props) }
+
+  let(:clazz) { Cocina::Models::DRO }
+
+  context 'when valid' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:jq000jd3530',
+        description: {
+          purl: 'https://purl.stanford.edu/jq000jd3530'
+        }
+      }
+    end
+
+    it 'does not raise' do
+      validate
+    end
+  end
+
+  context 'when mismatch' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:xq000jd3530',
+        description: {
+          purl: 'https://purl.stanford.edu/jq000jd3530'
+        }
+      }
+    end
+
+    it 'raises' do
+      expect do
+        validate
+      end.to raise_error(Cocina::Models::ValidationError,
+                         'Purl mismatch: druid:xq000jd3530 purl does not match object druid.')
+    end
+  end
+
+  context 'when a request (no externalIdentifier)' do
+    let(:props) { {} }
+
+    let(:clazz) { Cocina::Models::RequestDRO }
+
+    it 'does not raise' do
+      validate
+    end
+  end
+
+  context 'when an AdminPolicy (description not required)' do
+    let(:clazz) { Cocina::Models::AdminPolicy }
+
+    let(:props) do
+      {
+        externalIdentifier: 'druid:jq000jd3530'
+      }
+    end
+
+    it 'does not raise' do
+      validate
+    end
+  end
+end


### PR DESCRIPTION
closes #397

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Valid data > invalid data


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



