### PR TITLE
Handle mixed hashes when validating.

### DIFF
--- a/lib/cocina/models/validatable.rb
+++ b/lib/cocina/models/validatable.rb
@@ -8,7 +8,7 @@ module Cocina
 
       class_methods do
         def new(attributes = default_attributes, safe = false, validate = true, &block)
-          Validators::Validator.validate(self, attributes.with_indifferent_access) if validate
+          Validators::Validator.validate(self, attributes) if validate
           super(attributes, safe, &block)
         end
       end
@@ -16,7 +16,7 @@ module Cocina
       def new(*args)
         validate = args.first.delete(:validate) if args.present?
         new_model = super(*args)
-        Validators::Validator.validate(new_model.class, new_model.to_h) if validate || validate.nil?
+        Validators::Validator.validate(new_model.class, new_model) if validate || validate.nil?
         new_model
       end
     end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -14,8 +14,32 @@ module Cocina
         ].freeze
 
         def self.validate(clazz, attributes)
-          VALIDATORS.each { |validator| validator.validate(clazz, attributes) }
+          # This gets rid of nested model objects.
+          # Once DSA is on Rails 6, this can be:
+          # attributes_hash = attributes.to_h.deep_transform_values do |value|
+          #   value.class.name.starts_with?('Cocina::Models') ? value.to_h : value
+          # end.with_indifferent_access
+          # And add require 'active_support/core_ext/hash/deep_transform_values' to models file.
+
+          # In the meantime, copying code.
+          attributes_hash = deep_transform_values(attributes.to_h) do |value|
+            value.class.name.starts_with?('Cocina::Models') ? value.to_h : value
+          end.with_indifferent_access
+
+          VALIDATORS.each { |validator| validator.validate(clazz, attributes_hash) }
         end
+
+        def self.deep_transform_values(object, &block)
+          case object
+          when Hash
+            object.transform_values { |value| deep_transform_values(value, &block) }
+          when Array
+            object.map { |e| deep_transform_values(e, &block) }
+          else
+            yield(object)
+          end
+        end
+        private_class_method :deep_transform_values
       end
     end
   end

--- a/spec/cocina/models/validators/validator_spec.rb
+++ b/spec/cocina/models/validators/validator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::Validator do
+  subject(:validate) { described_class.validate(clazz, dro_props) }
+
+  let(:clazz) { Cocina::Models::DRO }
+
+  let(:dro_props) { props }
+
+  let(:props) do
+    {
+      externalIdentifier: 'druid:jq000jd3530',
+      description: {
+        title: [{
+          value: 'Rockhounding Utah',
+          appliesTo: [],
+          groupedValue: [],
+          identifier: [],
+          note: [],
+          parallelValue: [],
+          structuredValue: []
+        }],
+        purl: 'https://purl.stanford.edu/jq000jd3530'
+      }
+    }.with_indifferent_access
+  end
+
+  before do
+    Cocina::Models::Validators::Validator::VALIDATORS.each do |validator_clazz|
+      allow(validator_clazz).to receive(:validate)
+    end
+  end
+
+  context 'with a props hash' do
+    it 'invokes validators' do
+      validate
+
+      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(clazz,
+                                                                                                     props))
+    end
+  end
+
+  # Yes, this can happen.
+  context 'with a mixed hash' do
+    let(:dro_props) do
+      {
+        externalIdentifier: 'druid:jq000jd3530',
+        description: {
+          title: [Cocina::Models::Title.new(value: 'Rockhounding Utah')],
+          purl: 'https://purl.stanford.edu/jq000jd3530'
+        }
+      }
+    end
+
+    it 'invokes validators' do
+      validate
+
+      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(clazz,
+                                                                                                     props))
+    end
+  end
+end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Mixed hashes were causing tests to valid in DSA.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, DSA

