### PR TITLE
Define the dry-struct so as to avoid metadata

### DIFF
--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -23,14 +23,6 @@ module Cocina
         key || schema_doc.name
       end
 
-      # Allows non-required values to not be provided. This allows smaller
-      # requests as not every field needs to be present.
-      def omittable
-        return '' if required && !relaxed
-
-        '.meta(omittable: true)'
-      end
-
       # Allows nillable values to be set to nil. This is useful when doing
       # an update and you want to clear out a value.
       def optional

--- a/lib/cocina/generator/schema_ref.rb
+++ b/lib/cocina/generator/schema_ref.rb
@@ -8,7 +8,7 @@ module Cocina
         if required && !relaxed
           "attribute(:#{name.camelize(:lower)}, #{schema_doc.name}.default { #{schema_doc.name}.new })"
         else
-          "attribute :#{name.camelize(:lower)}, #{schema_doc.name}.optional.meta(omittable: true)"
+          "attribute? :#{name.camelize(:lower)}, #{schema_doc.name}.optional"
         end
       end
     end

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -4,14 +4,24 @@ module Cocina
   module Generator
     # Class for generating from an openapi value
     class SchemaValue < SchemaBase
-      # rubocop:disable Layout/LineLength
       def generate
         # optional has to come before default or the default value that gets set will be nil.
-        "#{description}#{example}#{relaxed_comment}attribute :#{name.camelize(:lower)}, Types::#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}#{omittable}"
+        if required && !relaxed
+          "#{preamble}attribute :#{name.camelize(:lower)}, #{type}"
+        else
+          "#{preamble}attribute? :#{name.camelize(:lower)}, #{type}"
+        end
       end
-      # rubocop:enable Layout/LineLength
 
       private
+
+      def type
+        "Types::#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}"
+      end
+
+      def preamble
+        "#{description}#{example}#{relaxed_comment}"
+      end
 
       def enum
         return '' if !schema_doc.enum || relaxed

--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -5,15 +5,15 @@ module Cocina
     class Access < Struct
       # Access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :view, Types::Strict::String.optional.default('dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.optional.default('dark')
       # Download access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :download, Types::Strict::String.optional.default('none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.optional.default('none')
       # Not used for this access type, must be null.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :location, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :controlledDigitalLending, Types::Strict::Bool.optional.meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
     end
   end
 end

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -18,7 +18,7 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
-      attribute :description, Description.optional.meta(omittable: true)
+      attribute? :description, Description.optional
     end
   end
 end

--- a/lib/cocina/models/admin_policy_access_template.rb
+++ b/lib/cocina/models/admin_policy_access_template.rb
@@ -3,23 +3,23 @@
 module Cocina
   module Models
     class AdminPolicyAccessTemplate < Struct
-      attribute :view, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
       # Available for controlled digital lending.
-      attribute :controlledDigitalLending, Types::Strict::Bool.meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :copyright, Types::Strict::String.optional
       # Download access level. This is used in the transition from Fedora as a way to set a default download level at registration that is copied down to all the files.
 
-      attribute :download, Types::Strict::String.enum('world', 'stanford', 'location-based', 'none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.enum('world', 'stanford', 'location-based', 'none')
       # If access or download is "location-based", this indicates which location should have access. This is used in the transition from Fedora as a way to set a default location at registration that is copied down to all the files.
 
-      attribute :location, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m').meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m')
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
-      attribute :useAndReproductionStatement, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :useAndReproductionStatement, Types::Strict::String.optional
       # The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
-      attribute :license, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :license, Types::Strict::String.optional
     end
   end
 end

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -7,7 +7,7 @@ module Cocina
       attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # An additional workflow to start for objects managed by this admin policy once the end-accession workflow step is complete
       # example: wasCrawlPreassemblyWF
-      attribute :disseminationWorkflow, Types::Strict::String.meta(omittable: true)
+      attribute? :disseminationWorkflow, Types::Strict::String
       attribute :collectionsForRegistration, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # example: druid:bc123df4567
       attribute :hasAdminPolicy, Types::Strict::String

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -18,11 +18,11 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
-      attribute :description, Description.optional.meta(omittable: true)
+      attribute? :description, Description.optional
       # When the object was created.
-      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      attribute? :created, Types::Params::DateTime
       # When the object was modified.
-      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      attribute? :modified, Types::Params::DateTime
       # Key for optimistic locking. The contents of the key is not specified.
       attribute :lock, Types::Strict::String
     end

--- a/lib/cocina/models/citation_only_access.rb
+++ b/lib/cocina/models/citation_only_access.rb
@@ -8,8 +8,8 @@ module Cocina
       # Download access level.
       attribute :download, Types::Strict::String.enum('none')
       # Not used for this access type, must be null.
-      attribute :location, Types::Strict::String.optional.enum('').meta(omittable: true)
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('')
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/lib/cocina/models/collection_access.rb
+++ b/lib/cocina/models/collection_access.rb
@@ -4,15 +4,15 @@ module Cocina
   module Models
     class CollectionAccess < Struct
       # Access level
-      attribute :view, Types::Strict::String.default('dark').enum('world', 'dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.default('dark').enum('world', 'dark')
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :copyright, Types::Strict::String.optional
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
-      attribute :useAndReproductionStatement, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :useAndReproductionStatement, Types::Strict::String.optional
       # The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
-      attribute :license, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :license, Types::Strict::String.optional
     end
   end
 end

--- a/lib/cocina/models/collection_identification.rb
+++ b/lib/cocina/models/collection_identification.rb
@@ -7,7 +7,7 @@ module Cocina
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
-      attribute :sourceId, Types::Strict::String.meta(omittable: true)
+      attribute? :sourceId, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -29,9 +29,9 @@ module Cocina
       attribute(:description, Description.default { Description.new })
       attribute(:identification, CollectionIdentification.default { CollectionIdentification.new })
       # When the object was created.
-      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      attribute? :created, Types::Params::DateTime
       # When the object was modified.
-      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      attribute? :modified, Types::Params::DateTime
       # Key for optimistic locking. The contents of the key is not specified.
       attribute :lock, Types::Strict::String
     end

--- a/lib/cocina/models/contributor.rb
+++ b/lib/cocina/models/contributor.rb
@@ -4,15 +4,15 @@ module Cocina
   module Models
     class Contributor < Struct
       attribute :name, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      # Entity type of the contributor (person, organization, etc.).
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      # Entity type of the contributor (person, organization, etc.). See https://sul-dlss.github.io/cocina-models/description_types.html for valid types.
+      attribute? :type, Types::Strict::String
       # Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       attribute :role, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # URL or other pointer to the location of the contributor information.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
       attribute :parallelContributor, Types::Strict::Array.of(DescriptiveParallelContributor).default([].freeze)
     end
   end

--- a/lib/cocina/models/controlled_digital_lending_access.rb
+++ b/lib/cocina/models/controlled_digital_lending_access.rb
@@ -8,7 +8,7 @@ module Cocina
       # Download access level.
       attribute :download, Types::Strict::String.enum('none')
       # Not used for this access type, must be null.
-      attribute :location, Types::Strict::String.optional.enum('').meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('')
       # Available for controlled digital lending.
       attribute :controlledDigitalLending, Types::Strict::Bool.default(false)
     end

--- a/lib/cocina/models/dark_access.rb
+++ b/lib/cocina/models/dark_access.rb
@@ -4,12 +4,12 @@ module Cocina
   module Models
     class DarkAccess < Struct
       # Access level.
-      attribute :view, Types::Strict::String.default('dark').enum('dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.default('dark').enum('dark')
       # Download access level.
-      attribute :download, Types::Strict::String.default('none').enum('none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.default('none').enum('none')
       # Not used for this access type, must be null.
-      attribute :location, Types::Strict::String.optional.enum('').meta(omittable: true)
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('')
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -14,12 +14,12 @@ module Cocina
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
+      attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)
       attribute :marcEncodedData, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :adminMetadata, DescriptiveAdminMetadata.optional.meta(omittable: true)
+      attribute? :adminMetadata, DescriptiveAdminMetadata.optional
       # URL or other pointer to the location of the resource description.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
       # Stanford persistent URL associated with the related resource. Note this is http, not https.
       attribute :purl, Types::Strict::String
     end

--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -7,27 +7,27 @@ module Cocina
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # String or integer value of the descriptive element.
-      attribute :value, Types::Nominal::Any.meta(omittable: true)
-      # Type of value provided by the descriptive element.
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Nominal::Any
+      # Type of value provided by the descriptive element. See https://sul-dlss.github.io/cocina-models/description_types.html for valid types.
+      attribute? :type, Types::Strict::String
       # Status of the descriptive element value relative to other instances of the element.
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       # Code value of the descriptive element.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI value of the descriptive element.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
-      attribute :encoding, Standard.optional.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
+      attribute? :standard, Standard.optional
+      attribute? :encoding, Standard.optional
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :source, Source.optional.meta(omittable: true)
+      attribute? :source, Source.optional
       # The preferred display label to use for the descriptive element in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
-      attribute :qualifier, Types::Strict::String.meta(omittable: true)
+      attribute? :qualifier, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/descriptive_parallel_contributor.rb
+++ b/lib/cocina/models/descriptive_parallel_contributor.rb
@@ -4,16 +4,16 @@ module Cocina
   module Models
     class DescriptiveParallelContributor < Struct
       attribute :name, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      # Entity type of the contributor (person, organization, etc.).
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      # Entity type of the contributor (person, organization, etc.). See https://sul-dlss.github.io/cocina-models/description_types.html for valid types.
+      attribute? :type, Types::Strict::String
       # Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       attribute :role, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # URL or other pointer to the location of the contributor information.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
     end
   end
 end

--- a/lib/cocina/models/descriptive_parallel_event.rb
+++ b/lib/cocina/models/descriptive_parallel_event.rb
@@ -5,15 +5,15 @@ module Cocina
     class DescriptiveParallelEvent < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Description of the event (creation, publication, etc.).
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :type, Types::Strict::String
       # The preferred display label to use for the event in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       attribute :date, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
     end
   end
 end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -7,27 +7,27 @@ module Cocina
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # String or integer value of the descriptive element.
-      attribute :value, Types::Nominal::Any.meta(omittable: true)
-      # Type of value provided by the descriptive element.
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Nominal::Any
+      # Type of value provided by the descriptive element. See https://sul-dlss.github.io/cocina-models/description_types.html for valid types.
+      attribute? :type, Types::Strict::String
       # Status of the descriptive element value relative to other instances of the element.
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       # Code value of the descriptive element.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI value of the descriptive element.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
-      attribute :encoding, Standard.optional.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
+      attribute? :standard, Standard.optional
+      attribute? :encoding, Standard.optional
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :source, Source.optional.meta(omittable: true)
+      attribute? :source, Source.optional
       # The preferred display label to use for the descriptive element in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
-      attribute :qualifier, Types::Strict::String.meta(omittable: true)
+      attribute? :qualifier, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
     end
   end

--- a/lib/cocina/models/descriptive_value_language.rb
+++ b/lib/cocina/models/descriptive_value_language.rb
@@ -4,16 +4,16 @@ module Cocina
   module Models
     class DescriptiveValueLanguage < Struct
       # Code representing the standard or encoding.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI for the standard or encoding.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
       # String describing the standard or encoding.
-      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # The version of the standard or encoding.
-      attribute :version, Types::Strict::String.meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
-      attribute :valueScript, Standard.optional.meta(omittable: true)
+      attribute? :version, Types::Strict::String
+      attribute? :source, Source.optional
+      attribute? :valueScript, Standard.optional
     end
   end
 end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -39,7 +39,7 @@ module Cocina
       attribute(:description, Description.default { Description.new })
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, DROStructural.default { DROStructural.new })
-      attribute :geographic, Geographic.optional.meta(omittable: true)
+      attribute? :geographic, Geographic.optional
     end
   end
 end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -5,24 +5,24 @@ module Cocina
     class DROAccess < Struct
       # Access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :view, Types::Strict::String.optional.default('dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.optional.default('dark')
       # Download access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :download, Types::Strict::String.optional.default('none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.optional.default('none')
       # Not used for this access type, must be null.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :location, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :controlledDigitalLending, Types::Strict::Bool.optional.meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
-      attribute :copyright, Types::Strict::String.optional.meta(omittable: true)
-      attribute :embargo, Embargo.optional.meta(omittable: true)
+      attribute? :copyright, Types::Strict::String.optional
+      attribute? :embargo, Embargo.optional
       # The human readable use and reproduction statement that applies
       # example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
-      attribute :useAndReproductionStatement, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :useAndReproductionStatement, Types::Strict::String.optional
       # The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
-      attribute :license, Types::Strict::String.optional.enum('https://www.gnu.org/licenses/agpl.txt', 'https://www.apache.org/licenses/LICENSE-2.0', 'https://opensource.org/licenses/BSD-2-Clause', 'https://opensource.org/licenses/BSD-3-Clause', 'https://creativecommons.org/licenses/by/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode', 'https://creativecommons.org/licenses/by-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-sa/4.0/legalcode', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode', 'https://opensource.org/licenses/cddl1', 'https://www.eclipse.org/legal/epl-2.0', 'https://www.gnu.org/licenses/gpl-3.0-standalone.html', 'https://www.isc.org/downloads/software-support-policy/isc-license/', 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html', 'https://opensource.org/licenses/MIT', 'https://www.mozilla.org/MPL/2.0/', 'https://opendatacommons.org/licenses/by/1-0/', 'http://opendatacommons.org/licenses/odbl/1.0/', 'https://opendatacommons.org/licenses/odbl/1-0/', 'https://creativecommons.org/publicdomain/mark/1.0/', 'https://opendatacommons.org/licenses/pddl/1-0/', 'https://creativecommons.org/licenses/by/3.0/legalcode', 'https://creativecommons.org/licenses/by-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nd/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode', 'https://cocina.sul.stanford.edu/licenses/none').meta(omittable: true)
+      attribute? :license, Types::Strict::String.optional.enum('https://www.gnu.org/licenses/agpl.txt', 'https://www.apache.org/licenses/LICENSE-2.0', 'https://opensource.org/licenses/BSD-2-Clause', 'https://opensource.org/licenses/BSD-3-Clause', 'https://creativecommons.org/licenses/by/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode', 'https://creativecommons.org/licenses/by-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-sa/4.0/legalcode', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode', 'https://opensource.org/licenses/cddl1', 'https://www.eclipse.org/legal/epl-2.0', 'https://www.gnu.org/licenses/gpl-3.0-standalone.html', 'https://www.isc.org/downloads/software-support-policy/isc-license/', 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html', 'https://opensource.org/licenses/MIT', 'https://www.mozilla.org/MPL/2.0/', 'https://opendatacommons.org/licenses/by/1-0/', 'http://opendatacommons.org/licenses/odbl/1.0/', 'https://opendatacommons.org/licenses/odbl/1-0/', 'https://creativecommons.org/publicdomain/mark/1.0/', 'https://opendatacommons.org/licenses/pddl/1-0/', 'https://creativecommons.org/licenses/by/3.0/legalcode', 'https://creativecommons.org/licenses/by-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nd/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode', 'https://cocina.sul.stanford.edu/licenses/none')
     end
   end
 end

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -39,11 +39,11 @@ module Cocina
       attribute(:description, Description.default { Description.new })
       attribute(:identification, Identification.default { Identification.new })
       attribute(:structural, DROStructural.default { DROStructural.new })
-      attribute :geographic, Geographic.optional.meta(omittable: true)
+      attribute? :geographic, Geographic.optional
       # When the object was created.
-      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      attribute? :created, Types::Params::DateTime
       # When the object was modified.
-      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      attribute? :modified, Types::Params::DateTime
       # Key for optimistic locking. The contents of the key is not specified.
       attribute :lock, Types::Strict::String
     end

--- a/lib/cocina/models/embargo.rb
+++ b/lib/cocina/models/embargo.rb
@@ -5,21 +5,21 @@ module Cocina
     class Embargo < Struct
       # Access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :view, Types::Strict::String.optional.default('dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.optional.default('dark')
       # Download access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :download, Types::Strict::String.optional.default('none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.optional.default('none')
       # Not used for this access type, must be null.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :location, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :controlledDigitalLending, Types::Strict::Bool.optional.meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
       # Date when the Collection is released from an embargo.
       # example: 2029-06-22T07:00:00.000+00:00
       attribute :releaseDate, Types::Params::DateTime
       # The human readable use and reproduction statement that applies when the embargo expires.
       # example: These materials are in the public domain.
-      attribute :useAndReproductionStatement, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :useAndReproductionStatement, Types::Strict::String.optional
     end
   end
 end

--- a/lib/cocina/models/event.rb
+++ b/lib/cocina/models/event.rb
@@ -5,15 +5,15 @@ module Cocina
     class Event < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Description of the event (creation, publication, etc.).
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :type, Types::Strict::String
       # The preferred display label to use for the event in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       attribute :date, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :location, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
       attribute :parallelEvent, Types::Strict::Array.of(DescriptiveParallelEvent).default([].freeze)
     end
   end

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -16,17 +16,17 @@ module Cocina
       # Filename for a file. Can be same as label.
       attribute :filename, Types::Strict::String
       # Size of the File (binary) in bytes.
-      attribute :size, Types::Strict::Integer.meta(omittable: true)
+      attribute? :size, Types::Strict::Integer
       # Version for the File within SDR.
       attribute :version, Types::Strict::Integer
       # MIME Type of the File.
-      attribute :hasMimeType, Types::Strict::String.meta(omittable: true)
+      attribute? :hasMimeType, Types::Strict::String
       # Use for the File.
-      attribute :use, Types::Strict::String.meta(omittable: true)
+      attribute? :use, Types::Strict::String
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, FileAccess.default { FileAccess.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })
-      attribute :presentation, Presentation.optional.meta(omittable: true)
+      attribute? :presentation, Presentation.optional
     end
   end
 end

--- a/lib/cocina/models/file_access.rb
+++ b/lib/cocina/models/file_access.rb
@@ -5,15 +5,15 @@ module Cocina
     class FileAccess < Struct
       # Access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :view, Types::Strict::String.optional.default('dark').meta(omittable: true)
+      attribute? :view, Types::Strict::String.optional.default('dark')
       # Download access level.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :download, Types::Strict::String.optional.default('none').meta(omittable: true)
+      attribute? :download, Types::Strict::String.optional.default('none')
       # Not used for this access type, must be null.
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :location, Types::Strict::String.optional.meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute :controlledDigitalLending, Types::Strict::Bool.optional.meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
     end
   end
 end

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -4,11 +4,11 @@ module Cocina
   module Models
     class Identification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute? :barcode, Types::Nominal::Any
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
       # example: 10.25740/bc123df4567
-      attribute :doi, Types::Strict::String.meta(omittable: true)
+      attribute? :doi, Types::Strict::String
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -5,28 +5,28 @@ module Cocina
     class Language < Struct
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
       # Code value of the descriptive element.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # The preferred display label to use for the descriptive element in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
-      attribute :encoding, Standard.optional.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
+      attribute? :encoding, Standard.optional
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # present for mapping to additional schemas in the future and for consistency but not otherwise used
-      attribute :qualifier, Types::Strict::String.meta(omittable: true)
-      attribute :script, DescriptiveValue.optional.meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
+      attribute? :qualifier, Types::Strict::String
+      attribute? :script, DescriptiveValue.optional
+      attribute? :source, Source.optional
       # Status of the language relative to other parallel language elements (e.g. the primary language)
-      attribute :status, Types::Strict::String.enum('primary').meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
+      attribute? :status, Types::Strict::String.enum('primary')
+      attribute? :standard, Standard.optional
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # URI value of the descriptive element.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
       # Value of the descriptive element.
-      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Strict::String
       # URL or other pointer to the location of the language information.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
     end
   end
 end

--- a/lib/cocina/models/location_based_access.rb
+++ b/lib/cocina/models/location_based_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('location-based', 'none')
       # If access or download is "location-based", which location should have access.
       attribute :location, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m')
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/lib/cocina/models/location_based_download_access.rb
+++ b/lib/cocina/models/location_based_download_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('location-based')
       # Which location should have download access.
       attribute :location, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m')
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/lib/cocina/models/object_metadata.rb
+++ b/lib/cocina/models/object_metadata.rb
@@ -4,9 +4,9 @@ module Cocina
   module Models
     class ObjectMetadata < Struct
       # When the object was created.
-      attribute :created, Types::Params::DateTime.meta(omittable: true)
+      attribute? :created, Types::Params::DateTime
       # When the object was modified.
-      attribute :modified, Types::Params::DateTime.meta(omittable: true)
+      attribute? :modified, Types::Params::DateTime
       # Key for optimistic locking. The contents of the key is not specified.
       attribute :lock, Types::Strict::String
     end

--- a/lib/cocina/models/presentation.rb
+++ b/lib/cocina/models/presentation.rb
@@ -4,9 +4,9 @@ module Cocina
   module Models
     class Presentation < Struct
       # Height in pixels
-      attribute :height, Types::Strict::Integer.meta(omittable: true)
+      attribute? :height, Types::Strict::Integer
       # Width in pixels
-      attribute :width, Types::Strict::Integer.meta(omittable: true)
+      attribute? :width, Types::Strict::Integer
     end
   end
 end

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -4,11 +4,11 @@ module Cocina
   module Models
     class RelatedResource < Struct
       # The relationship of the related resource to the described resource.
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :type, Types::Strict::String
       # Status of the related resource relative to other related resources.
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       # The preferred display label to use for the related resource in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       attribute :title, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :event, Types::Strict::Array.of(Event).default([].freeze)
@@ -16,17 +16,17 @@ module Cocina
       attribute :language, Types::Strict::Array.of(Language).default([].freeze)
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :standard, Standard.optional.meta(omittable: true)
+      attribute? :standard, Standard.optional
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Stanford persistent URL associated with the related resource. Note this is http, not https.
-      attribute :purl, Types::Strict::String.meta(omittable: true)
-      attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
+      attribute? :purl, Types::Strict::String
+      attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)
-      attribute :adminMetadata, DescriptiveAdminMetadata.optional.meta(omittable: true)
+      attribute? :adminMetadata, DescriptiveAdminMetadata.optional
       # The version of the related resource.
-      attribute :version, Types::Strict::String.meta(omittable: true)
+      attribute? :version, Types::Strict::String
       # URL or other pointer to the location of the related resource information.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/release_tag.rb
+++ b/lib/cocina/models/release_tag.rb
@@ -5,15 +5,15 @@ module Cocina
     class ReleaseTag < Struct
       # Who did this release
       # example: petucket
-      attribute :who, Types::Strict::String.meta(omittable: true)
+      attribute? :who, Types::Strict::String
       # What is being released. This item or the whole collection.
       # example: self
-      attribute :what, Types::Strict::String.enum('self', 'collection').meta(omittable: true)
+      attribute? :what, Types::Strict::String.enum('self', 'collection')
       # When did this action happen
-      attribute :date, Types::Params::DateTime.meta(omittable: true)
+      attribute? :date, Types::Params::DateTime
       # What platform is it released to
       # example: Searchworks
-      attribute :to, Types::Strict::String.meta(omittable: true)
+      attribute? :to, Types::Strict::String
       attribute :release, Types::Strict::Bool.default(false)
     end
   end

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -16,7 +16,7 @@ module Cocina
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })
-      attribute :description, RequestDescription.optional.meta(omittable: true)
+      attribute? :description, RequestDescription.optional
     end
   end
 end

--- a/lib/cocina/models/request_administrative.rb
+++ b/lib/cocina/models/request_administrative.rb
@@ -8,7 +8,7 @@ module Cocina
       attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
       # Internal project this resource is a part of. This governs routing of messages about this object.
       # example: Google Books
-      attribute :partOfProject, Types::Strict::String.meta(omittable: true)
+      attribute? :partOfProject, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -21,8 +21,8 @@ module Cocina
       attribute :version, Types::Strict::Integer.default(1).enum(1)
       attribute(:access, CollectionAccess.default { CollectionAccess.new })
       attribute(:administrative, RequestAdministrative.default { RequestAdministrative.new })
-      attribute :description, RequestDescription.optional.meta(omittable: true)
-      attribute :identification, CollectionIdentification.optional.meta(omittable: true)
+      attribute? :description, RequestDescription.optional
+      attribute? :identification, CollectionIdentification.optional
     end
   end
 end

--- a/lib/cocina/models/request_description.rb
+++ b/lib/cocina/models/request_description.rb
@@ -14,12 +14,12 @@ module Cocina
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :access, DescriptiveAccessMetadata.optional.meta(omittable: true)
+      attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)
       attribute :marcEncodedData, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :adminMetadata, DescriptiveAdminMetadata.optional.meta(omittable: true)
+      attribute? :adminMetadata, DescriptiveAdminMetadata.optional
       # URL or other pointer to the location of the resource description.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -29,12 +29,12 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)
-      attribute :access, DROAccess.optional.meta(omittable: true)
+      attribute? :access, DROAccess.optional
       attribute(:administrative, RequestAdministrative.default { RequestAdministrative.new })
-      attribute :description, RequestDescription.optional.meta(omittable: true)
+      attribute? :description, RequestDescription.optional
       attribute(:identification, RequestIdentification.default { RequestIdentification.new })
-      attribute :structural, RequestDROStructural.optional.meta(omittable: true)
-      attribute :geographic, Geographic.optional.meta(omittable: true)
+      attribute? :structural, RequestDROStructural.optional
+      attribute? :geographic, Geographic.optional
     end
   end
 end

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -10,15 +10,15 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*RequestFile::TYPES)
       attribute :label, Types::Strict::String
       attribute :filename, Types::Strict::String
-      attribute :size, Types::Strict::Integer.meta(omittable: true)
+      attribute? :size, Types::Strict::Integer
       attribute :version, Types::Strict::Integer
-      attribute :hasMimeType, Types::Strict::String.meta(omittable: true)
-      attribute :externalIdentifier, Types::Strict::String.meta(omittable: true)
-      attribute :use, Types::Strict::String.meta(omittable: true)
+      attribute? :hasMimeType, Types::Strict::String
+      attribute? :externalIdentifier, Types::Strict::String
+      attribute? :use, Types::Strict::String
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, FileAccess.default { FileAccess.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })
-      attribute :presentation, Presentation.optional.meta(omittable: true)
+      attribute? :presentation, Presentation.optional
     end
   end
 end

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class RequestIdentification < Struct
       # A barcode
-      attribute :barcode, Types::Nominal::Any.meta(omittable: true)
+      attribute? :barcode, Types::Nominal::Any
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 

--- a/lib/cocina/models/sequence.rb
+++ b/lib/cocina/models/sequence.rb
@@ -5,7 +5,7 @@ module Cocina
     class Sequence < Struct
       attribute :members, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # The direction that a sequence of canvases should be displayed to the user
-      attribute :viewingDirection, Types::Strict::String.enum('right-to-left', 'left-to-right').meta(omittable: true)
+      attribute? :viewingDirection, Types::Strict::String.enum('right-to-left', 'left-to-right')
     end
   end
 end

--- a/lib/cocina/models/source.rb
+++ b/lib/cocina/models/source.rb
@@ -4,14 +4,14 @@ module Cocina
   module Models
     class Source < Struct
       # Code representing the value source.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI for the value source.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
       # String describing the value source.
-      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # The version of the value source.
-      attribute :version, Types::Strict::String.meta(omittable: true)
+      attribute? :version, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -4,15 +4,15 @@ module Cocina
   module Models
     class Standard < Struct
       # Code representing the standard or encoding.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI for the standard or encoding.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
       # String describing the standard or encoding.
-      attribute :value, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # The version of the standard or encoding.
-      attribute :version, Types::Strict::String.meta(omittable: true)
-      attribute :source, Source.optional.meta(omittable: true)
+      attribute? :version, Types::Strict::String
+      attribute? :source, Source.optional
     end
   end
 end

--- a/lib/cocina/models/stanford_access.rb
+++ b/lib/cocina/models/stanford_access.rb
@@ -8,8 +8,8 @@ module Cocina
       # Download access level.
       attribute :download, Types::Strict::String.enum('stanford')
       # Not used for this access type, must be null.
-      attribute :location, Types::Strict::String.optional.enum('').meta(omittable: true)
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('')
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/lib/cocina/models/title.rb
+++ b/lib/cocina/models/title.rb
@@ -7,27 +7,27 @@ module Cocina
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # String or integer value of the descriptive element.
-      attribute :value, Types::Nominal::Any.meta(omittable: true)
-      # Type of value provided by the descriptive element.
-      attribute :type, Types::Strict::String.meta(omittable: true)
+      attribute? :value, Types::Nominal::Any
+      # Type of value provided by the descriptive element. See https://sul-dlss.github.io/cocina-models/description_types.html for valid types.
+      attribute? :type, Types::Strict::String
       # Status of the descriptive element value relative to other instances of the element.
-      attribute :status, Types::Strict::String.meta(omittable: true)
+      attribute? :status, Types::Strict::String
       # Code value of the descriptive element.
-      attribute :code, Types::Strict::String.meta(omittable: true)
+      attribute? :code, Types::Strict::String
       # URI value of the descriptive element.
-      attribute :uri, Types::Strict::String.meta(omittable: true)
-      attribute :standard, Standard.optional.meta(omittable: true)
-      attribute :encoding, Standard.optional.meta(omittable: true)
+      attribute? :uri, Types::Strict::String
+      attribute? :standard, Standard.optional
+      attribute? :encoding, Standard.optional
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :source, Source.optional.meta(omittable: true)
+      attribute? :source, Source.optional
       # The preferred display label to use for the descriptive element in access systems.
-      attribute :displayLabel, Types::Strict::String.meta(omittable: true)
+      attribute? :displayLabel, Types::Strict::String
       # A term providing information about the circumstances of the statement (e.g., approximate dates).
-      attribute :qualifier, Types::Strict::String.meta(omittable: true)
+      attribute? :qualifier, Types::Strict::String
       attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      attribute :valueLanguage, DescriptiveValueLanguage.optional.meta(omittable: true)
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
-      attribute :valueAt, Types::Strict::String.meta(omittable: true)
+      attribute? :valueAt, Types::Strict::String
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
     end
   end

--- a/lib/cocina/models/world_access.rb
+++ b/lib/cocina/models/world_access.rb
@@ -8,8 +8,8 @@ module Cocina
       # Download access level.
       attribute :download, Types::Strict::String.enum('none', 'stanford', 'world')
       # Not used for this access type, must be null.
-      attribute :location, Types::Strict::String.optional.enum('').meta(omittable: true)
-      attribute :controlledDigitalLending, Types::Strict::Bool.enum(false).meta(omittable: true)
+      attribute? :location, Types::Strict::String.optional.enum('')
+      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
     end
   end
 end

--- a/spec/cocina/models/description_spec.rb
+++ b/spec/cocina/models/description_spec.rb
@@ -93,4 +93,12 @@ RSpec.describe Cocina::Models::Description do
       expect { item }.to raise_error(Cocina::Models::ValidationError)
     end
   end
+
+  describe 'introspecting' do
+    it 'is possible to get the nodes from the schema' do
+      # We use this to determine whether the paths in the descriptive spreadsheet are valid
+      node = Cocina::Models::DescriptiveValue.schema.find { |key| key.name == :source }
+      expect(node.type.right).to eq Cocina::Models::Source
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

The old way made introspection impossible:

```
node = Cocina::Models::DescriptiveValue.schema.find { |key| key.name == :source }
node.type
node.type.right
#<Class:0x000000010ae7f710>
```


## How was this change tested? 🤨
Added a unit test.