### PR TITLE
fix description_types for identifier 'West Mat #'

### DIFF
--- a/description_types.yml
+++ b/description_types.yml
@@ -356,7 +356,7 @@ identifier:
     code: urn
   - value: videorecording identifier
     code: videorecording-identifier
-  - value: West Mat \#
+  - value: 'West Mat #'
   - value: Wikidata
     code: wikidata
 note:

--- a/spec/cocina/models/validators/description_types_validator_spec.rb
+++ b/spec/cocina/models/validators/description_types_validator_spec.rb
@@ -466,4 +466,23 @@ RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
       expect { validate }.to raise_error(Cocina::Models::ValidationError)
     end
   end
+
+  context 'when description_types.yml has value with special character' do
+    let(:desc_props) do
+      {
+        title: [{ value: 'Testing West Mat #' }],
+        purl: 'https://purl.stanford.edu/bc123df4567',
+        identifier: [
+          {
+            value: '123',
+            type: 'West Mat #'
+          }
+        ]
+      }
+    end
+
+    it 'does not raise' do
+      validate
+    end
+  end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

Fix descriptive_types.yml for a type with a special character.

Fixes #412

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



