### PR TITLE
[WIP] validate that cdl for specific conditions

### DIFF
--- a/lib/cocina/models/validators/cdl_validator.rb
+++ b/lib/cocina/models/validators/cdl_validator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that the controlledDigitalLending attribute is set when view: 'stanford', download: 'none'
+      # though it will set a default of "false" if not found instead of throwing a validation error
+      class CdlValidator
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+        end
+
+        def validate
+          return unless meets_preconditions?
+
+          raise ValidationError, 'controlledDigitalLending must be set when "view: stanford, download: none"'
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def meets_preconditions?
+          dro? && attributes.dig(:access,
+                                 :view) == 'stanford' && attributes.dig(:access,
+                                                                        :download) == 'none' && attributes.dig(
+                                                                          :access, :controlledDigitalLending
+                                                                        ).nil?
+        end
+
+        def dro?
+          (clazz::TYPES & DRO::TYPES).any?
+        rescue NameError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -8,6 +8,7 @@ module Cocina
         VALIDATORS = [
           OpenApiValidator,
           DarkValidator,
+          CdlValidator,
           PurlValidator,
           CatalogLinksValidator,
           AssociatedNameValidator,

--- a/spec/cocina/models/validators/cdl_validator_spec.rb
+++ b/spec/cocina/models/validators/cdl_validator_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::CdlValidator do
+  let(:validate) { described_class.validate(clazz, props) }
+
+  let(:clazz) { Cocina::Models::DRO }
+
+  let(:props) { dro_props }
+  let(:cdl) { true }
+
+  let(:dro_props) do
+    {
+      type: Cocina::Models::ObjectType.book,
+      access: { view: view, download: download, controlledDigitalLending: cdl },
+      structural: {
+        contains: [
+          {
+            externalIdentifier: 'bc123df4567_1',
+            label: 'Fileset 1',
+            type: Cocina::Models::FileSetType.file,
+            version: 1,
+            structural: {
+              contains: [
+                { externalIdentifier: 'bc123df4567_1',
+                  label: 'Page 1',
+                  type: Cocina::Models::ObjectType.file,
+                  version: 1,
+                  access: { view: 'stanford', download: 'none' },
+                  administrative: {
+                    publish: true,
+                    shelve: true,
+                    sdrPreserve: true
+                  },
+                  hasMessageDigests: [],
+                  hasMimeType: 'text/plain',
+                  filename: 'page1.txt' }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  describe 'when access is stanford and download is none' do
+    let(:view) { 'stanford' }
+    let(:download) { 'none' }
+
+    describe 'when controlledDigitalLending is missing' do
+      let(:missing_cdl_props) do
+        dro_props.dup.tap do |props|
+          props[:access].delete(:controlledDigitalLending)
+        end
+      end
+
+      let(:props) { missing_cdl_props }
+
+      it 'is not valid' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+
+    describe 'when controlledDigitalLending is set to true' do
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    describe 'when controlledDigitalLending is set to false' do
+      let(:cdl) { false }
+
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    describe 'when controlledDigitalLending exists but is set to nil' do
+      let(:cdl) { nil }
+
+      it 'is not valid' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+  end
+
+  describe 'when access is not stanford' do
+    let(:view) { 'world' }
+    let(:download) { 'none' }
+
+    describe 'when controlledDigitalLending is missing' do
+      let(:missing_cdl_props) do
+        dro_props.dup.tap do |props|
+          props[:access].delete(:controlledDigitalLending)
+        end
+      end
+
+      let(:props) { missing_cdl_props }
+
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    describe 'when controlledDigitalLending is set to true' do
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    describe 'when controlledDigitalLending is set to false' do
+      let(:cdl) { false }
+
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    describe 'when controlledDigitalLending exists but is set to nil' do
+      let(:cdl) { nil }
+
+      it 'does not raise' do
+        validate
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Ref #405 - validate the CDL attribute is present when access="stanford" and view="one"

TODO: can we set a default of false instead of throwing a validation error instead?  I'm not sure of the best way of doing this.

## How was this change tested? 🤨

new tests