### PR TITLE
Do not require controlledDigitalLending for stanford/none.

### DIFF
--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'byebug'
+
 module Cocina
   module Generator
     # Class for generating from an openapi value
@@ -42,7 +44,7 @@ module Cocina
         # If type is boolean and default is false, erroneously getting a nil.
         # Assuming that if required, then default is false.
         default = schema_doc.default
-        default = false if default.nil? && schema_doc.type == 'boolean' && required
+        default = false if default.nil? && schema_doc.type == 'boolean'
 
         return '' if default.nil?
 

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'byebug'
-
 module Cocina
   module Generator
     # Class for generating from an openapi value

--- a/lib/cocina/models/access.rb
+++ b/lib/cocina/models/access.rb
@@ -13,7 +13,7 @@ module Cocina
       # Validation of this property is relaxed. See the openapi for full validation.
       attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
     end
   end
 end

--- a/lib/cocina/models/admin_policy_access_template.rb
+++ b/lib/cocina/models/admin_policy_access_template.rb
@@ -5,7 +5,7 @@ module Cocina
     class AdminPolicyAccessTemplate < Struct
       attribute? :view, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
       # Available for controlled digital lending.
-      attribute? :controlledDigitalLending, Types::Strict::Bool
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute? :copyright, Types::Strict::String.optional

--- a/lib/cocina/models/citation_only_access.rb
+++ b/lib/cocina/models/citation_only_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('none')
       # Not used for this access type, must be null.
       attribute? :location, Types::Strict::String.optional.enum('')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/lib/cocina/models/controlled_digital_lending_access.rb
+++ b/lib/cocina/models/controlled_digital_lending_access.rb
@@ -10,7 +10,7 @@ module Cocina
       # Not used for this access type, must be null.
       attribute? :location, Types::Strict::String.optional.enum('')
       # Available for controlled digital lending.
-      attribute :controlledDigitalLending, Types::Strict::Bool.default(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false)
     end
   end
 end

--- a/lib/cocina/models/dark_access.rb
+++ b/lib/cocina/models/dark_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute? :download, Types::Strict::String.default('none').enum('none')
       # Not used for this access type, must be null.
       attribute? :location, Types::Strict::String.optional.enum('')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -13,7 +13,7 @@ module Cocina
       # Validation of this property is relaxed. See the openapi for full validation.
       attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute? :copyright, Types::Strict::String.optional

--- a/lib/cocina/models/embargo.rb
+++ b/lib/cocina/models/embargo.rb
@@ -13,7 +13,7 @@ module Cocina
       # Validation of this property is relaxed. See the openapi for full validation.
       attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
       # Date when the Collection is released from an embargo.
       # example: 2029-06-22T07:00:00.000+00:00
       attribute :releaseDate, Types::Params::DateTime

--- a/lib/cocina/models/file_access.rb
+++ b/lib/cocina/models/file_access.rb
@@ -13,7 +13,7 @@ module Cocina
       # Validation of this property is relaxed. See the openapi for full validation.
       attribute? :location, Types::Strict::String.optional
       # Validation of this property is relaxed. See the openapi for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
     end
   end
 end

--- a/lib/cocina/models/location_based_access.rb
+++ b/lib/cocina/models/location_based_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('location-based', 'none')
       # If access or download is "location-based", which location should have access.
       attribute :location, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/lib/cocina/models/location_based_download_access.rb
+++ b/lib/cocina/models/location_based_download_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('location-based')
       # Which location should have download access.
       attribute :location, Types::Strict::String.enum('spec', 'music', 'ars', 'art', 'hoover', 'm&m')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/lib/cocina/models/stanford_access.rb
+++ b/lib/cocina/models/stanford_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('stanford')
       # Not used for this access type, must be null.
       attribute? :location, Types::Strict::String.optional.enum('')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/lib/cocina/models/world_access.rb
+++ b/lib/cocina/models/world_access.rb
@@ -9,7 +9,7 @@ module Cocina
       attribute :download, Types::Strict::String.enum('none', 'stanford', 'world')
       # Not used for this access type, must be null.
       attribute? :location, Types::Strict::String.optional.enum('')
-      attribute? :controlledDigitalLending, Types::Strict::Bool.enum(false)
+      attribute? :controlledDigitalLending, Types::Strict::Bool.default(false).enum(false)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -580,7 +580,6 @@ components:
       required:
         - view
         - download
-        - controlledDigitalLending
     DarkAccess:
       type: object
       properties:

--- a/spec/cocina/models/dro_access_spec.rb
+++ b/spec/cocina/models/dro_access_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Cocina::Models::DROAccess do
         download: download,
         location: location,
         controlledDigitalLending: controlled_digital_lending
-      },
+      }.compact,
       structural: {},
       identification: { sourceId: 'sul:123' }
     )
@@ -69,6 +69,7 @@ RSpec.describe Cocina::Models::DROAccess do
       expect { dro('stanford', 'stanford', nil, false) }.not_to raise_error
       expect { dro('stanford', 'none', nil, false) }.not_to raise_error
       expect { dro('stanford', 'none', nil, true) }.not_to raise_error
+      expect { dro('stanford', 'none', nil, nil) }.not_to raise_error
       expect { dro('stanford', 'location-based', 'art', false) }.not_to raise_error
       expect { dro('stanford', 'location-based', nil, false) }.to raise_error(Cocina::Models::ValidationError)
       expect { dro('stanford', 'world', nil, false) }.to raise_error(Cocina::Models::ValidationError)
@@ -87,6 +88,14 @@ RSpec.describe Cocina::Models::DROAccess do
       # Depends on https://github.com/ota42y/openapi_parser/pull/104
       # expect {dro('location-based', 'location-based', 'art', true) }
       #   .to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+
+  context 'with stanford/none' do
+    it 'handles missing controlledDigitalLending param' do
+      expect(described_class.new(view: 'stanford', download: 'none')).to eq(
+        described_class.new(view: 'stanford', download: 'none', controlledDigitalLending: false)
+      )
     end
   end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Remove the need for special handling of stanford/none access.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

