### PR TITLE
fix for refactor: use singular for FromMods::Title class name

### DIFF
--- a/lib/cocina/models/mapping/from_mods/descriptive/hydrus_default_title_builder.rb
+++ b/lib/cocina/models/mapping/from_mods/descriptive/hydrus_default_title_builder.rb
@@ -20,7 +20,7 @@ module Cocina
                 return []
               end
 
-              Titles.build(resource_element: resource_element, notifier: notifier)
+              Title.build(resource_element: resource_element, notifier: notifier)
             end
           end
         end

--- a/lib/cocina/models/mapping/from_mods/descriptive/title_builder_strategy.rb
+++ b/lib/cocina/models/mapping/from_mods/descriptive/title_builder_strategy.rb
@@ -11,7 +11,7 @@ module Cocina
             # @return [#build] a class that can build a title
             def self.find(label:)
               # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
-              label == 'Hydrus' ? HydrusDefaultTitleBuilder : Titles
+              label == 'Hydrus' ? HydrusDefaultTitleBuilder : Title
             end
           end
         end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

this should have been part of #441 but I missed it, and so did the specs.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



