### PR TITLE
Port cocina factory.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,12 +83,15 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 100
+  Exclude:
+    - 'lib/cocina/rspec/factories.rb'
 
 Metrics/MethodLength:
   Max: 14
   Exclude:
     - 'spec/cocina/models/file_access_spec.rb'
     - 'spec/cocina/models/dro_access_spec.rb'
+    - 'lib/cocina/rspec/factories.rb'
     - 'lib/cocina/models/mapping/to_mods/descriptive/*'
     - 'lib/cocina/models/mapping/from_mods/descriptive/*'
     - 'lib/cocina/models/mapping/normalizers/mods/origin_info_normalizer.rb'

--- a/lib/cocina/rspec.rb
+++ b/lib/cocina/rspec.rb
@@ -4,7 +4,9 @@ require 'rspec/core'
 require 'rspec/matchers'
 require 'super_diff/rspec'
 require 'cocina/rspec/matchers'
+require 'cocina/rspec/factories'
 
 RSpec.configure do |config|
   config.include Cocina::RSpec::Matchers
+  config.include Cocina::RSpec::Factories::Methods
 end

--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Cocina
+  module RSpec
+    # Factories for Cocina model objects.
+    class Factories
+      # Provides the build method.
+      module Methods
+        def build(type, ...)
+          # If we don't support this factory, maybe factory_bot does.
+          Factories.supported_type?(type) ? Factories.build(type, ...) : super
+        end
+      end
+
+      def self.supported_type?(type)
+        %i[dro collection admin_policy dro_with_metadata collection_with_metadata admin_policy_with_metadata].include?(type)
+      end
+
+      WITH_METADATA_SUFFIX = '_with_metadata'
+
+      def self.build(type, attributes = {})
+        raise "Unsupported factory type #{type}" unless supported_type?(type)
+
+        build_type = type.to_s.delete_suffix(WITH_METADATA_SUFFIX)
+
+        fixture = public_send("build_#{build_type}".to_sym, attributes)
+        return fixture unless type.end_with?(WITH_METADATA_SUFFIX)
+
+        Cocina::Models.with_metadata(fixture, 'abc123')
+      end
+
+      DRO_DEFAULTS = {
+        type: Cocina::Models::ObjectType.object,
+        id: 'druid:bc234fg5678',
+        version: 1,
+        label: 'test object',
+        title: 'test object',
+        source_id: 'sul:1234',
+        admin_policy_id: 'druid:hv992ry2431'
+      }.freeze
+
+      COLLECTION_DEFAULTS = DRO_DEFAULTS.except(:source_id).merge(type: Cocina::Models::ObjectType.collection)
+
+      ADMIN_POLICY_DEFAULTS = {
+        type: Cocina::Models::ObjectType.admin_policy,
+        id: 'druid:bc234fg5678',
+        version: 1,
+        label: 'test admin policy',
+        title: 'test admin policy',
+        admin_policy_id: 'druid:hv992ry2431',
+        agreement_id: 'druid:hp308wm0436'
+      }.freeze
+
+      # rubocop:disable Metrics/ParameterLists
+      def self.build_dro_properties(type:, id:, version:, label:, title:, source_id:, admin_policy_id:,
+                                    barcode: nil, catkeys: [], collection_ids: [])
+        {
+          type: type,
+          externalIdentifier: id,
+          version: version,
+          label: label,
+          access: {},
+          administrative: { hasAdminPolicy: admin_policy_id },
+          description: {
+            title: [{ value: title }],
+            purl: "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
+          },
+          identification: {
+            sourceId: source_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          }
+        }.tap do |props|
+          if catkeys.present?
+            props[:identification][:catalogLinks] = catkeys.map.with_index do |catkey, index|
+              { catalog: 'symphony', catalogRecordId: catkey, refresh: index.zero? }
+            end
+          end
+          props[:identification][:barcode] = barcode if barcode
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      def self.build_dro(attributes)
+        Cocina::Models.build(build_dro_properties(**DRO_DEFAULTS.merge(attributes)))
+      end
+
+      # rubocop:disable Metrics/ParameterLists
+      def self.build_collection_properties(type:, id:, version:, label:, title:, admin_policy_id:, source_id: nil, catkeys: [])
+        {
+          type: type,
+          externalIdentifier: id,
+          version: version,
+          label: label,
+          access: {},
+          administrative: { hasAdminPolicy: admin_policy_id },
+          description: {
+            title: [{ value: title }],
+            purl: "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
+          },
+          identification: {}
+        }.tap do |props|
+          if catkeys.present?
+            props[:identification][:catalogLinks] = catkeys.map.with_index do |catkey, index|
+              { catalog: 'symphony', catalogRecordId: catkey, refresh: index.zero? }
+            end
+          end
+          props[:identification][:sourceId] = source_id if source_id
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      def self.build_collection(attributes)
+        Cocina::Models.build(build_collection_properties(**COLLECTION_DEFAULTS.merge(attributes)))
+      end
+
+      def self.build_admin_policy(attributes)
+        Cocina::Models.build(build_admin_policy_properties(**ADMIN_POLICY_DEFAULTS.merge(attributes)))
+      end
+
+      # rubocop:disable Metrics/ParameterLists
+      def self.build_admin_policy_properties(type:, id:, version:, label:, title:,
+                                             admin_policy_id:, agreement_id:,
+                                             use_statement: nil, copyright: nil, license: nil,
+                                             registration_workflow: nil, collections_for_registration: nil,
+                                             without_description: false)
+        {
+          type: type,
+          externalIdentifier: id,
+          version: version,
+          label: label,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            hasAgreement: agreement_id,
+            accessTemplate: {
+              view: 'world',
+              download: 'world'
+            }
+          },
+          description: {
+            title: [{ value: title }],
+            purl: "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
+          }
+        }.tap do |props|
+          props[:administrative][:accessTemplate][:useAndReproductionStatement] = use_statement if use_statement
+          props[:administrative][:accessTemplate][:copyright] = copyright if copyright
+          props[:administrative][:accessTemplate][:license] = license if license
+          props[:administrative][:registrationWorkflow] = registration_workflow if registration_workflow
+          props[:administrative][:collectionsForRegistration] = collections_for_registration if collections_for_registration
+          props.delete(:description) if without_description
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
+    end
+  end
+end

--- a/spec/cocina/models/builders/dro_rights_description_builder_spec.rb
+++ b/spec/cocina/models/builders/dro_rights_description_builder_spec.rb
@@ -3,29 +3,18 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
-  subject(:build) { described_class.build(cocina_object) }
+  subject(:builder_build) { described_class.build(cocina_object) }
 
   let(:structural) { {} }
   let(:cocina_object) do
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc753qt7345',
-                            type: Cocina::Models::ObjectType.object,
-                            label: 'A new map of Africa',
-                            version: 1,
-                            description: {
-                              title: [{ value: 'However am I going to be' }],
-                              purl: 'https://purl.stanford.edu/bc753qt7345'
-                            },
-                            identification: { sourceId: 'sul:123' },
-                            access: access,
-                            administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
-                            structural: structural)
+    build(:dro).new(access: access, structural: structural)
   end
 
   context 'when access is limited by controlled digital lending' do
     let(:access) { { controlledDigitalLending: true, view: 'stanford', download: 'none' } }
 
     it 'returns the controlled digital lending rights description' do
-      expect(build).to eq('controlled digital lending')
+      expect(builder_build).to eq('controlled digital lending')
     end
   end
 
@@ -33,7 +22,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'world', download: 'world' } }
 
     it 'returns the world rights description' do
-      expect(build).to eq(['world'])
+      expect(builder_build).to eq(['world'])
     end
   end
 
@@ -41,7 +30,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'world', download: 'none' } }
 
     it 'returns the world (no-download) rights description' do
-      expect(build).to eq(['world (no-download)'])
+      expect(builder_build).to eq(['world (no-download)'])
     end
   end
 
@@ -49,7 +38,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'world', download: 'stanford' } }
 
     it 'returns the world (no-download) rights description' do
-      expect(build).to eq(['stanford', 'world (no-download)'])
+      expect(builder_build).to eq(['stanford', 'world (no-download)'])
     end
   end
 
@@ -57,7 +46,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'world', download: 'location-based', location: 'm&m' } }
 
     it 'returns the world (no-download) and location rights description' do
-      expect(build).to eq(['world (no-download)', 'location: m&m'])
+      expect(builder_build).to eq(['world (no-download)', 'location: m&m'])
     end
   end
 
@@ -65,7 +54,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'citation-only', download: 'none' } }
 
     it 'returns the citation rights description' do
-      expect(build).to eq(['citation'])
+      expect(builder_build).to eq(['citation'])
     end
   end
 
@@ -73,7 +62,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'location-based', download: 'none', location: 'm&m' } }
 
     it 'returns the location (no-download) rights description' do
-      expect(build).to eq(['location: m&m (no-download)'])
+      expect(builder_build).to eq(['location: m&m (no-download)'])
     end
   end
 
@@ -81,7 +70,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     let(:access) { { view: 'stanford', download: 'location-based', location: 'm&m' } }
 
     it 'returns the stanford (no-download) and location rights description' do
-      expect(build).to eq(['stanford (no-download)', 'location: m&m'])
+      expect(builder_build).to eq(['stanford (no-download)', 'location: m&m'])
     end
   end
 
@@ -124,7 +113,7 @@ RSpec.describe Cocina::Models::Builders::DroRightsDescriptionBuilder do
     end
 
     it 'returns to the rights description with file access included' do
-      expect(build).to eq(['world', 'stanford (file)'])
+      expect(builder_build).to eq(['world', 'stanford (file)'])
     end
   end
 end

--- a/spec/cocina/models/builders/rights_description_builder_spec.rb
+++ b/spec/cocina/models/builders/rights_description_builder_spec.rb
@@ -3,14 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
-  subject(:build) { described_class.build(cocina_object) }
+  subject(:builder_build) { described_class.build(cocina_object) }
 
   let(:cocina_object) do
-    Cocina::Models::AdminPolicy.new(
-      externalIdentifier: 'druid:bc123df4567',
-      label: 'My admin policy',
-      type: Cocina::Models::ObjectType.admin_policy,
-      version: 1,
+    build(:admin_policy).new(
       administrative: {
         hasAdminPolicy: 'druid:bc123df4567',
         hasAgreement: 'druid:bc123df4567',
@@ -23,7 +19,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { controlledDigitalLending: true, view: 'world', download: 'world' } }
 
     it 'returns the controlled digital lending rights description' do
-      expect(build).to eq('controlled digital lending')
+      expect(builder_build).to eq('controlled digital lending')
     end
   end
 
@@ -31,7 +27,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'world', download: 'world' } }
 
     it 'returns the world rights description' do
-      expect(build).to eq(['world'])
+      expect(builder_build).to eq(['world'])
     end
   end
 
@@ -39,7 +35,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'world', download: 'none' } }
 
     it 'returns the world (no-download) rights description' do
-      expect(build).to eq(['world (no-download)'])
+      expect(builder_build).to eq(['world (no-download)'])
     end
   end
 
@@ -47,7 +43,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'world', download: 'stanford' } }
 
     it 'returns the world (no-download) rights description' do
-      expect(build).to eq(['stanford', 'world (no-download)'])
+      expect(builder_build).to eq(['stanford', 'world (no-download)'])
     end
   end
 
@@ -55,7 +51,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'world', download: 'location-based', location: 'm&m' } }
 
     it 'returns the world (no-download) and location rights description' do
-      expect(build).to eq(['world (no-download)', 'location: m&m'])
+      expect(builder_build).to eq(['world (no-download)', 'location: m&m'])
     end
   end
 
@@ -63,7 +59,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'citation-only', download: 'none' } }
 
     it 'returns the citation rights description' do
-      expect(build).to eq(['citation'])
+      expect(builder_build).to eq(['citation'])
     end
   end
 
@@ -71,7 +67,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'location-based', download: 'none', location: 'm&m' } }
 
     it 'returns the location (no-download) rights description' do
-      expect(build).to eq(['location: m&m (no-download)'])
+      expect(builder_build).to eq(['location: m&m (no-download)'])
     end
   end
 
@@ -79,7 +75,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'location-based', download: 'world', location: 'm&m' } }
 
     it 'returns the location rights description' do
-      expect(build).to eq(['location: m&m'])
+      expect(builder_build).to eq(['location: m&m'])
     end
   end
 
@@ -87,7 +83,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'stanford', download: 'none' } }
 
     it 'returns the stanford (no-download) rights description' do
-      expect(build).to eq(['stanford (no-download)'])
+      expect(builder_build).to eq(['stanford (no-download)'])
     end
   end
 
@@ -95,7 +91,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'stanford', download: 'location-based', location: 'm&m' } }
 
     it 'returns the stanford (no-download) and location rights description' do
-      expect(build).to eq(['stanford (no-download)', 'location: m&m'])
+      expect(builder_build).to eq(['stanford (no-download)', 'location: m&m'])
     end
   end
 
@@ -103,7 +99,7 @@ RSpec.describe Cocina::Models::Builders::RightsDescriptionBuilder do
     let(:access_template) { { view: 'stanford', download: 'world' } }
 
     it 'returns the stanford rights description' do
-      expect(build).to eq(['stanford'])
+      expect(builder_build).to eq(['stanford'])
     end
   end
 end

--- a/spec/cocina/models/builders/title_builder_spec.rb
+++ b/spec/cocina/models/builders/title_builder_spec.rb
@@ -3,32 +3,24 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Builders::TitleBuilder do
-  subject(:build) { described_class.build(cocina_titles, strategy: strategy, add_punctuation: add_punctuation) }
+  subject(:builder_build) { described_class.build(cocina_titles, strategy: strategy, add_punctuation: add_punctuation) }
 
   let(:cocina_titles) { titles.map { |hash| Cocina::Models::Title.new(hash) } }
   let(:strategy) { :first }
   let(:add_punctuation) { true }
   let(:druid) { 'druid:bc753qt7345' }
-  let(:apo_druid) { 'druid:pp000pp0000' }
 
   context 'with a DRO (deprecated)' do
-    subject(:build) { described_class.build(cocina_object, strategy: strategy, add_punctuation: add_punctuation) }
+    subject(:builder_build) { described_class.build(cocina_object, strategy: strategy, add_punctuation: add_punctuation) }
 
     before do
       allow(Deprecation).to receive(:warn)
     end
 
     let(:cocina_object) do
-      Cocina::Models::DRO.new(externalIdentifier: druid,
-                              type: Cocina::Models::ObjectType.object,
-                              label: 'A new map of Africa',
-                              version: 1,
-                              description: description,
-                              identification: { sourceId: 'sul:123' },
-                              access: {},
-                              administrative: { hasAdminPolicy: apo_druid },
-                              structural: {})
+      build(:dro, id: druid).new(description: description)
     end
+
     let(:description) do
       {
         title: [
@@ -39,7 +31,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the first title object and logs a deprecation' do
-      expect(build).to eq('However am I going to be')
+      expect(builder_build).to eq('However am I going to be')
       expect(Deprecation).to have_received(:warn)
     end
   end
@@ -64,7 +56,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the expected title' do
-      expect(build).to eq [['The master and Margarita', 'Мастер и Маргарита']]
+      expect(builder_build).to eq [['The master and Margarita', 'Мастер и Маргарита']]
     end
   end
 
@@ -78,7 +70,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
     context 'with a :first strategy' do
       it 'returns the first title object' do
-        expect(build).to eq('However am I going to be')
+        expect(builder_build).to eq('However am I going to be')
       end
     end
 
@@ -86,7 +78,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       let(:strategy) { :all }
 
       it 'returns an array with each title object' do
-        expect(build).to eq(['However am I going to be', 'A second title'])
+        expect(builder_build).to eq(['However am I going to be', 'A second title'])
       end
     end
   end
@@ -100,7 +92,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the first title object' do
-      expect(build).to eq('A very silly primary title')
+      expect(builder_build).to eq('A very silly primary title')
     end
   end
 
@@ -114,7 +106,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
     context 'with a :first strategy' do
       it 'returns the main title object' do
-        expect(build).to eq('A very silly main title')
+        expect(builder_build).to eq('A very silly main title')
       end
     end
 
@@ -122,7 +114,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       let(:strategy) { :all }
 
       it 'returns the main title object' do
-        expect(build).to eq(['A very silly main title', 'A very silly sub title'])
+        expect(builder_build).to eq(['A very silly main title', 'A very silly sub title'])
       end
     end
   end
@@ -160,7 +152,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the structured title' do
-      expect(build).to eq('ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName')
+      expect(builder_build).to eq('ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName')
     end
   end
 
@@ -189,7 +181,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the first structured title' do
-      expect(build).to eq('brisk junketti1:nonSort')
+      expect(builder_build).to eq('brisk junketti1:nonSort')
     end
   end
 
@@ -215,7 +207,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
     context 'when add punctuation is default true' do
       it 'returns the structured title' do
-        expect(build).to eq('ti1:partNumber, ti1:partName')
+        expect(builder_build).to eq('ti1:partNumber, ti1:partName')
       end
     end
 
@@ -223,7 +215,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       let(:add_punctuation) { false }
 
       it 'reeturns the structured title without punctuation' do
-        expect(build).to eq('ti1:partNumber ti1:partName')
+        expect(builder_build).to eq('ti1:partNumber ti1:partName')
       end
     end
   end
@@ -250,7 +242,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
     context 'when add punctuation is default true' do
       it 'returns the structured title' do
-        expect(build).to eq('A random subtitleA random title')
+        expect(builder_build).to eq('A random subtitleA random title')
       end
     end
 
@@ -258,7 +250,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       let(:add_punctuation) { false }
 
       it 'reeturns the structured title without punctuation' do
-        expect(build).to eq('A random subtitleA random title')
+        expect(builder_build).to eq('A random subtitleA random title')
       end
     end
   end
@@ -289,7 +281,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
     context 'when add punctuation is default true' do
       it 'returns the structured title' do
-        expect(build).to eq('The first subtitle : The second subtitleA Title')
+        expect(builder_build).to eq('The first subtitle : The second subtitleA Title')
       end
     end
 
@@ -297,7 +289,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       let(:add_punctuation) { false }
 
       it 'reeturns the structured title without punctuation' do
-        expect(build).to eq('The first subtitle The second subtitleA Title')
+        expect(builder_build).to eq('The first subtitle The second subtitleA Title')
       end
     end
   end
@@ -322,7 +314,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the correct title' do
-      expect(build).to eq('A Random Title')
+      expect(builder_build).to eq('A Random Title')
     end
   end
 
@@ -348,7 +340,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the title with non sorting characters included' do
-      expect(build).to eq('The  means to prosperity')
+      expect(builder_build).to eq('The  means to prosperity')
     end
   end
 
@@ -368,7 +360,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the title with non sorting characters included' do
-      expect(build).to eq('The means to prosperity')
+      expect(builder_build).to eq('The means to prosperity')
     end
   end
 
@@ -388,7 +380,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the title with non sorting characters included' do
-      expect(build).to eq('The-means to prosperity')
+      expect(builder_build).to eq('The-means to prosperity')
     end
   end
 
@@ -408,7 +400,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'returns the title with non sorting characters included' do
-      expect(build).to eq('L\'means to prosperity')
+      expect(builder_build).to eq('L\'means to prosperity')
     end
   end
 end

--- a/spec/cocina/models/dro_access_spec.rb
+++ b/spec/cocina/models/dro_access_spec.rb
@@ -6,25 +6,12 @@ RSpec.describe Cocina::Models::DROAccess do
   # Verifying that correctly validate access, download, location, and controlledDigitalLending.
 
   def dro(access, download, location, controlled_digital_lending)
-    Cocina::Models::DRO.new(
-      externalIdentifier: 'druid:bc123df4567',
-      label: 'My DRO',
-      type: Cocina::Models::ObjectType.book,
-      version: 1,
-      description: {
-        title: [{ value: 'Test DRO' }],
-        purl: 'https://purl.stanford.edu/bc123df4567'
-      },
-      administrative: { hasAdminPolicy: 'druid:bc123df4567' },
-      access: {
-        view: access,
-        download: download,
-        location: location,
-        controlledDigitalLending: controlled_digital_lending
-      }.compact,
-      structural: {},
-      identification: { sourceId: 'sul:123' }
-    )
+    build(:dro).new(access: {
+      view: access,
+      download: download,
+      location: location,
+      controlledDigitalLending: controlled_digital_lending
+    }.compact)
   end
 
   context 'with dark access' do

--- a/spec/cocina/models/file_access_spec.rb
+++ b/spec/cocina/models/file_access_spec.rb
@@ -6,52 +6,44 @@ RSpec.describe Cocina::Models::FileAccess do
   # Verifying that correctly validate access, download, location, and controlledDigitalLending.
 
   def dro(access, download, location, controlled_digital_lending)
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
-                            label: 'My DRO',
-                            type: Cocina::Models::ObjectType.book,
-                            version: 1,
-                            description: {
-                              title: [{ value: 'Test DRO' }],
-                              purl: 'https://purl.stanford.edu/bc123df4567'
-                            },
-                            administrative: { hasAdminPolicy: 'druid:bc123df4567' },
-                            identification: { sourceId: 'sul:123' },
-                            access: {},
-                            structural: {
-                              contains: [
-                                {
-                                  version: 1,
-                                  type: 'https://cocina.sul.stanford.edu/models/resources/file',
-                                  label: 'Page 1',
-                                  externalIdentifier: 'abc123',
-                                  structural: {
-                                    contains: [
-                                      {
-                                        version: 1,
-                                        type: 'https://cocina.sul.stanford.edu/models/file',
-                                        filename: '00002.jp2',
-                                        label: '00002.jp2',
-                                        hasMimeType: 'image/jp2',
-                                        externalIdentifier: 'abc123',
-                                        size: 111_467,
-                                        administrative: {
-                                          publish: true,
-                                          sdrPreserve: true,
-                                          shelve: true
-                                        },
-                                        access: {
-                                          view: access,
-                                          download: download,
-                                          location: location,
-                                          controlledDigitalLending: controlled_digital_lending
-                                        },
-                                        hasMessageDigests: []
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            })
+    build(:dro).new(
+      access: { view: 'world', download: 'world' },
+      structural: {
+        contains: [
+          {
+            version: 1,
+            type: 'https://cocina.sul.stanford.edu/models/resources/file',
+            label: 'Page 1',
+            externalIdentifier: 'abc123',
+            structural: {
+              contains: [
+                {
+                  version: 1,
+                  type: 'https://cocina.sul.stanford.edu/models/file',
+                  filename: '00002.jp2',
+                  label: '00002.jp2',
+                  hasMimeType: 'image/jp2',
+                  externalIdentifier: 'abc123',
+                  size: 111_467,
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  access: {
+                    view: access,
+                    download: download,
+                    location: location,
+                    controlledDigitalLending: controlled_digital_lending
+                  },
+                  hasMessageDigests: []
+                }
+              ]
+            }
+          }
+        ]
+      }
+    )
   end
 
   context 'with dark access' do

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -8,24 +8,10 @@ RSpec.describe Cocina::Models do
   end
 
   describe '.build' do
-    subject(:build) { described_class.build(data) }
+    subject(:model_build) { described_class.build(data) }
 
     context 'with a collection type' do
-      let(:data) do
-        {
-          'type' => 'https://cocina.sul.stanford.edu/models/exhibit',
-          'externalIdentifier' => 'druid:bc123df4567',
-          'label' => 'bar',
-          'version' => 5,
-          'access' => {},
-          'description' => {
-            'title' => [{ 'value' => 'Test Collection' }],
-            'purl' => 'https://purl.stanford.edu/bc123df4567'
-          },
-          'identification' => {},
-          'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' }
-        }
-      end
+      let(:data) { build(:collection).to_h }
 
       it { is_expected.to be_kind_of Cocina::Models::Collection }
     end
@@ -42,69 +28,24 @@ RSpec.describe Cocina::Models do
       end
 
       it 'raises' do
-        expect { build }.to raise_error(Cocina::Models::ValidationError)
+        expect { model_build }.to raise_error(Cocina::Models::ValidationError)
       end
     end
 
     context 'with a DRO type' do
-      let(:data) do
-        {
-          'type' => 'https://cocina.sul.stanford.edu/models/image',
-          'externalIdentifier' => 'druid:bc123df4567',
-          'label' => 'bar',
-          'version' => 5,
-          'access' => {},
-          'administrative' => { 'hasAdminPolicy' => 'druid:bc123df4567' },
-          'identification' => {
-            'doi' => '10.25740/bc123df4567',
-            sourceId: 'sul:123'
-          },
-          'description' => {
-            'title' => [{ 'value' => 'Test DRO' }],
-            'purl' => 'https://purl.stanford.edu/bc123df4567'
-          },
-          'structural' => {}
-        }
-      end
+      let(:data) { build(:dro).to_h }
 
       it { is_expected.to be_kind_of Cocina::Models::DRO }
     end
 
     context 'with an AdminPolicy type' do
-      let(:data) do
-        {
-          'type' => 'https://cocina.sul.stanford.edu/models/admin_policy',
-          'externalIdentifier' => 'druid:bc123df4567',
-          'label' => 'bar',
-          'version' => 5,
-          'administrative' => {
-            'hasAdminPolicy' => 'druid:bc123df4567',
-            'hasAgreement' => 'druid:bc123df4567',
-            'accessTemplate' => {}
-          }
-        }
-      end
+      let(:data) { build(:admin_policy).to_h }
 
       it { is_expected.to be_kind_of Cocina::Models::AdminPolicy }
     end
 
-    context 'with keys as symbols' do
-      let(:data) do
-        {
-          type: 'https://cocina.sul.stanford.edu/models/image',
-          externalIdentifier: 'druid:bc123df4567',
-          label: 'bar',
-          version: 5,
-          access: {},
-          administrative: { 'hasAdminPolicy' => 'druid:bc123df4567' },
-          description: {
-            title: [{ 'value' => 'Test DRO' }],
-            purl: 'https://purl.stanford.edu/bc123df4567'
-          },
-          structural: {},
-          identification: { sourceId: 'sul:123' }
-        }
-      end
+    context 'with keys as strings' do
+      let(:data) { build(:dro).to_h.deep_stringify_keys }
 
       it { is_expected.to be_kind_of Cocina::Models::DRO }
     end
@@ -115,7 +56,7 @@ RSpec.describe Cocina::Models do
       end
 
       it 'raises an error' do
-        expect { build }.to raise_error Cocina::Models::UnknownTypeError, "Unknown type: 'foo'"
+        expect { model_build }.to raise_error Cocina::Models::UnknownTypeError, "Unknown type: 'foo'"
       end
     end
 
@@ -125,7 +66,7 @@ RSpec.describe Cocina::Models do
       end
 
       it 'raises an error' do
-        expect { build }.to raise_error Cocina::Models::ValidationError
+        expect { model_build }.to raise_error Cocina::Models::ValidationError
       end
     end
   end
@@ -241,25 +182,7 @@ RSpec.describe Cocina::Models do
   describe '.without_metadata' do
     subject(:cocina_object_without_metadata) { described_class.without_metadata(cocina_object) }
 
-    let(:cocina_object) do
-      Cocina::Models::DROWithMetadata.new(
-        type: 'https://cocina.sul.stanford.edu/models/image',
-        externalIdentifier: 'druid:bc123df4567',
-        label: 'bar',
-        version: 5,
-        access: {},
-        administrative: { 'hasAdminPolicy' => 'druid:bc123df4567' },
-        description: {
-          title: [{ 'value' => 'Test DRO' }],
-          purl: 'https://purl.stanford.edu/bc123df4567'
-        },
-        structural: {},
-        identification: { sourceId: 'sul:123' },
-        created: DateTime.now.iso8601,
-        modified: DateTime.now.iso8601,
-        lock: 'abc123'
-      )
-    end
+    let(:cocina_object) { build(:dro_with_metadata) }
 
     it { is_expected.to be_kind_of Cocina::Models::DRO }
   end
@@ -271,24 +194,9 @@ RSpec.describe Cocina::Models do
 
     let(:date) { DateTime.now }
 
-    let(:props) do
-      {
-        type: 'https://cocina.sul.stanford.edu/models/image',
-        externalIdentifier: 'druid:bc123df4567',
-        label: 'bar',
-        version: 5,
-        access: {},
-        administrative: { 'hasAdminPolicy' => 'druid:bc123df4567' },
-        description: {
-          title: [{ 'value' => 'Test DRO' }],
-          purl: 'https://purl.stanford.edu/bc123df4567'
-        },
-        structural: {},
-        identification: { sourceId: 'sul:123' }
-      }
-    end
+    let(:cocina_object) { build(:dro) }
 
-    let(:cocina_object) { Cocina::Models::DRO.new(props) }
+    let(:props) { cocina_object.to_h }
 
     let(:expected) do
       Cocina::Models::DROWithMetadata.new(props.merge({ lock: 'abc123', created: date, modified: date }))


### PR DESCRIPTION
closes #445

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
So that all of the repos can share in factory goodness.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



