### PR TITLE
refactor mapping: cocina model is description not descriptive

### DIFF
--- a/lib/cocina/models/mapping/from_mods/access.rb
+++ b/lib/cocina/models/mapping/from_mods/access.rb
@@ -14,16 +14,16 @@ module Cocina
           }.freeze
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder, purl: purl).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder, purl: purl).build
           end
 
-          def initialize(resource_element:, descriptive_builder:, purl:)
+          def initialize(resource_element:, description_builder:, purl:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
             @purl = purl
           end
 

--- a/lib/cocina/models/mapping/from_mods/admin_metadata.rb
+++ b/lib/cocina/models/mapping/from_mods/admin_metadata.rb
@@ -7,17 +7,17 @@ module Cocina
         # Maps MODS recordInfo to cocina
         class AdminMetadata # rubocop:disable Metrics/ClassLength
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @descriptive_builder = descriptive_builder
-            @notifier = descriptive_builder.notifier
+            @description_builder = description_builder
+            @notifier = description_builder.notifier
           end
 
           def build
@@ -35,7 +35,7 @@ module Cocina
 
           private
 
-          attr_reader :resource_element, :notifier, :descriptive_builder
+          attr_reader :resource_element, :notifier, :description_builder
 
           def build_events
             events = []

--- a/lib/cocina/models/mapping/from_mods/alt_rep_group.rb
+++ b/lib/cocina/models/mapping/from_mods/alt_rep_group.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Splits nodes by altRepGroup ids
+        # Helper class: splits nodes by altRepGroup ids
         class AltRepGroup
           # @param [Array<Nokogiri::XML::Element>] nodes to split
           # @return [Array<Array<Nokogiri::XML::Element>>, Array<Nokogiri::XML::Element>] nodes grouped by altRepGroup, other nodes

--- a/lib/cocina/models/mapping/from_mods/authority.rb
+++ b/lib/cocina/models/mapping/from_mods/authority.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Normalizes Authorities
+        # Helper class: normalizes Authorities
         class Authority
           NORMALIZE_AUTHORITY_URIS = [
             'http://id.loc.gov/authorities/names',

--- a/lib/cocina/models/mapping/from_mods/contributor.rb
+++ b/lib/cocina/models/mapping/from_mods/contributor.rb
@@ -22,16 +22,16 @@ module Cocina
           }.freeze
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/description.rb
+++ b/lib/cocina/models/mapping/from_mods/description.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Creates Cocina Descriptive objects from MODS xml
+        # Creates Cocina Description objects from MODS xml
         class Description
           DESC_METADATA_NS = 'http://www.loc.gov/mods/v3'
           XLINK_NS = 'http://www.w3.org/1999/xlink'

--- a/lib/cocina/models/mapping/from_mods/description_builder.rb
+++ b/lib/cocina/models/mapping/from_mods/description_builder.rb
@@ -26,7 +26,7 @@ module Cocina
           # @param [Cocina::Models::Mapping::ErrorNotifier] notifier
           # @param [TitleBuilder] title_builder - defaults to Title class
           # @param [String] purl
-          # @return [Hash] a hash that can be mapped to a cocina descriptive model
+          # @return [Hash] a hash that can be mapped to a cocina description model
           def self.build(resource_element:, notifier:, title_builder: Title, purl: nil)
             new(title_builder: title_builder, notifier: notifier).build(resource_element: resource_element,
                                                                         purl: purl)
@@ -37,7 +37,7 @@ module Cocina
             @notifier = notifier
           end
 
-          # @return [Hash] a hash that can be mapped to a cocina descriptive model
+          # @return [Hash] a hash that can be mapped to a cocina description model
           def build(resource_element:, purl: nil, require_title: true)
             cocina_description = {}
             title_result = @title_builder.build(resource_element: resource_element, require_title: require_title,
@@ -47,10 +47,10 @@ module Cocina
             purl_value = purl || Purl.primary_purl_value(resource_element, purl)
             cocina_description[:purl] = purl_value if purl_value
 
-            BUILDERS.each do |descriptive_property, builder|
-              result = builder.build(resource_element: resource_element, descriptive_builder: self,
+            BUILDERS.each do |description_property, builder|
+              result = builder.build(resource_element: resource_element, description_builder: self,
                                      purl: purl_value)
-              cocina_description.merge!(descriptive_property => result) if result.present?
+              cocina_description.merge!(description_property => result) if result.present?
             end
             cocina_description
           end

--- a/lib/cocina/models/mapping/from_mods/event.rb
+++ b/lib/cocina/models/mapping/from_mods/event.rb
@@ -55,16 +55,16 @@ module Cocina
           }.freeze
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/form.rb
+++ b/lib/cocina/models/mapping/from_mods/form.rb
@@ -11,16 +11,16 @@ module Cocina
           H2_GENRE_TYPE_PREFIX = 'H2 '
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/geographic.rb
+++ b/lib/cocina/models/mapping/from_mods/geographic.rb
@@ -40,16 +40,16 @@ module Cocina
           TYPE = 'type'
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/identifier.rb
+++ b/lib/cocina/models/mapping/from_mods/identifier.rb
@@ -7,10 +7,10 @@ module Cocina
         # Maps MODS identifer to cocina identifier
         class Identifier
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder: nil, purl: nil)
+          def self.build(resource_element:, description_builder: nil, purl: nil)
             new(resource_element: resource_element).build
           end
 

--- a/lib/cocina/models/mapping/from_mods/language.rb
+++ b/lib/cocina/models/mapping/from_mods/language.rb
@@ -7,16 +7,16 @@ module Cocina
         # Maps languages
         class Language
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/language_script.rb
+++ b/lib/cocina/models/mapping/from_mods/language_script.rb
@@ -7,7 +7,7 @@ module Cocina
         # Maps lang and script attributes
         class LanguageScript
           # @param [Nokogiri::XML::Element] element that may have lang or script attributes
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @return [Hash] a hash that can be mapped to a cocina model for a valueLanguage
           def self.build(node:)
             return nil unless node['lang'].present? || node['script'].present?

--- a/lib/cocina/models/mapping/from_mods/language_term.rb
+++ b/lib/cocina/models/mapping/from_mods/language_term.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Maps language terms
+        # Maps language term attributes
         class LanguageTerm
           # @param [Nokogiri::XML::Element] language_element language or languageOfCataloging element
           # @param [Cocina::Models::Mapping::ErrorNotifier] notifier

--- a/lib/cocina/models/mapping/from_mods/note.rb
+++ b/lib/cocina/models/mapping/from_mods/note.rb
@@ -7,11 +7,11 @@ module Cocina
         # Maps notes
         class Note # rubocop:disable Metrics/ClassLength
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder (not used, but passed in by DescriptionBuilder)
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder (not used, but passed in by DescriptionBuilder)
           # @param [String] purl (not used, but passed in by DescriptionBuilder)
           # @return [Hash] a hash that can be mapped to a cocina model
-          # def self.build(resource_element:, descriptive_builder: nil, purl: nil)
-          def self.build(resource_element:, descriptive_builder: nil, purl: nil)
+          # def self.build(resource_element:, description_builder: nil, purl: nil)
+          def self.build(resource_element:, description_builder: nil, purl: nil)
             new(resource_element: resource_element).build
           end
 

--- a/lib/cocina/models/mapping/from_mods/primary.rb
+++ b/lib/cocina/models/mapping/from_mods/primary.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Checks and fixes status: primary
+        # Helper class: checks and fixes status: primary
         class Primary
           # @params [Nokogiri::XML::NodeSet] node_set
           # @params [String] type the value of a node's type attribute we are concerned with

--- a/lib/cocina/models/mapping/from_mods/related_resource.rb
+++ b/lib/cocina/models/mapping/from_mods/related_resource.rb
@@ -10,17 +10,17 @@ module Cocina
           DETAIL_TYPES = Cocina::Models::Mapping::ToMods::RelatedResource::DETAIL_TYPES.invert.freeze
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl:)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder, purl: purl).build
+          def self.build(resource_element:, description_builder:, purl:)
+            new(resource_element: resource_element, description_builder: description_builder, purl: purl).build
           end
 
-          def initialize(resource_element:, descriptive_builder:, purl:)
+          def initialize(resource_element:, description_builder:, purl:)
             @resource_element = resource_element
-            @descriptive_builder = descriptive_builder
-            @notifier = descriptive_builder.notifier
+            @description_builder = description_builder
+            @notifier = description_builder.notifier
             @purl = purl
           end
 
@@ -30,7 +30,7 @@ module Cocina
 
           private
 
-          attr_reader :resource_element, :descriptive_builder, :notifier, :purl
+          attr_reader :resource_element, :description_builder, :notifier, :purl
 
           def related_items
             resource_element.xpath('mods:relatedItem', mods: Description::DESC_METADATA_NS).filter_map do |related_item|
@@ -47,7 +47,7 @@ module Cocina
           end
 
           def build_related_item(related_item)
-            descriptive_builder.build(resource_element: related_item, require_title: false).tap do |item|
+            description_builder.build(resource_element: related_item, require_title: false).tap do |item|
               item[:displayLabel] = related_item['displayLabel']
               if related_item['type']
                 item[:type] = normalized_type_for(related_item['type'])

--- a/lib/cocina/models/mapping/from_mods/subject.rb
+++ b/lib/cocina/models/mapping/from_mods/subject.rb
@@ -17,16 +17,16 @@ module Cocina
           }.freeze
 
           # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
-          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] descriptive_builder
+          # @param [Cocina::Models::Mapping::FromMods::DescriptionBuilder] description_builder
           # @param [String] purl
           # @return [Hash] a hash that can be mapped to a cocina model
-          def self.build(resource_element:, descriptive_builder:, purl: nil)
-            new(resource_element: resource_element, descriptive_builder: descriptive_builder).build
+          def self.build(resource_element:, description_builder:, purl: nil)
+            new(resource_element: resource_element, description_builder: description_builder).build
           end
 
-          def initialize(resource_element:, descriptive_builder:)
+          def initialize(resource_element:, description_builder:)
             @resource_element = resource_element
-            @notifier = descriptive_builder.notifier
+            @notifier = description_builder.notifier
           end
 
           def build

--- a/lib/cocina/models/mapping/from_mods/subject_authority_codes.rb
+++ b/lib/cocina/models/mapping/from_mods/subject_authority_codes.rb
@@ -5,7 +5,7 @@ module Cocina
   module Models
     module Mapping
       module FromMods
-        # Provides subject authority codes
+        # Helper class - provides subject authority codes
         class SubjectAuthorityCodes
           # Subject codes: https://id.loc.gov/vocabulary/subjectSchemes.html
           # curl https://id.loc.gov/vocabulary/subjectSchemes.madsrdf.json | jq '[.[0]."http://www.loc.gov/mads/rdf/v1#hasMADSSchemeMember"[]."@id"[44:]]'

--- a/lib/cocina/models/mapping/to_mods/description.rb
+++ b/lib/cocina/models/mapping/to_mods/description.rb
@@ -6,17 +6,17 @@ module Cocina
   module Models
     module Mapping
       module ToMods
-        # This transforms the DRO.descriptive schema to MODS xml
+        # This transforms the DRO.description schema to MODS xml
         class Description
-          # @param [Cocina::Models::Description] descriptive
+          # @param [Cocina::Models::Description] description
           # @param [string] druid
           # @return [Nokogiri::XML::Document]
-          def self.transform(descriptive, druid)
-            new(descriptive, druid).transform
+          def self.transform(description, druid)
+            new(description, druid).transform
           end
 
-          def initialize(descriptive, druid)
-            @descriptive = descriptive
+          def initialize(description, druid)
+            @description = description
             @druid = druid
           end
 
@@ -24,18 +24,18 @@ module Cocina
           def transform
             Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
               xml.mods(mods_attributes) do
-                ModsWriter.write(xml: xml, descriptive: descriptive, druid: druid)
+                ModsWriter.write(xml: xml, description: description, druid: druid)
               end
             end.doc
           end
 
           private
 
-          attr_reader :descriptive, :druid
+          attr_reader :description, :druid
 
           def mods_version
             @mods_version ||= begin
-              notes = descriptive.adminMetadata&.note || []
+              notes = description.adminMetadata&.note || []
               notes.select { |note| note.type == 'record origin' }.each do |note|
                 match = /MODS version (\d\.\d)/.match(note.value)
                 return match[1] if match

--- a/lib/cocina/models/mapping/to_mods/id_generator.rb
+++ b/lib/cocina/models/mapping/to_mods/id_generator.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     module Mapping
       module ToMods
-        # Generates altRepGroup and nameTitleGroup ids.
+        # Helper class - generates altRepGroup and nameTitleGroup ids.
         class IdGenerator
           def initialize
             @alt_rep_group = 0

--- a/lib/cocina/models/mapping/to_mods/mods_writer.rb
+++ b/lib/cocina/models/mapping/to_mods/mods_writer.rb
@@ -4,32 +4,32 @@ module Cocina
   module Models
     module Mapping
       module ToMods
-        # Maps descriptive resource from cocina to MODS XML
+        # Maps description resource from cocina to MODS XML
         class ModsWriter
           # @params [Nokogiri::XML::Builder] xml
-          # @param [Cocina::Models::Description] descriptive
+          # @param [Cocina::Models::Description] description
           # @param [string] druid
-          def self.write(xml:, descriptive:, druid:, id_generator: IdGenerator.new)
+          def self.write(xml:, description:, druid:, id_generator: IdGenerator.new)
             # ID Generator makes sure that different writers create unique altRepGroups and nameTitleGroups.
-            if descriptive.title
-              Title.write(xml: xml, titles: descriptive.title, contributors: descriptive.contributor,
+            if description.title
+              Title.write(xml: xml, titles: description.title, contributors: description.contributor,
                           id_generator: id_generator)
             end
-            Contributor.write(xml: xml, contributors: descriptive.contributor, titles: descriptive.title,
+            Contributor.write(xml: xml, contributors: description.contributor, titles: description.title,
                               id_generator: id_generator)
-            Form.write(xml: xml, forms: descriptive.form, id_generator: id_generator)
-            Language.write(xml: xml, languages: descriptive.language)
-            Note.write(xml: xml, notes: descriptive.note, id_generator: id_generator)
-            Subject.write(xml: xml, subjects: descriptive.subject, forms: descriptive.form,
+            Form.write(xml: xml, forms: description.form, id_generator: id_generator)
+            Language.write(xml: xml, languages: description.language)
+            Note.write(xml: xml, notes: description.note, id_generator: id_generator)
+            Subject.write(xml: xml, subjects: description.subject, forms: description.form,
                           id_generator: id_generator)
-            Event.write(xml: xml, events: descriptive.event, id_generator: id_generator)
-            Identifier.write(xml: xml, identifiers: descriptive.identifier, id_generator: id_generator)
-            Access.write(xml: xml, access: descriptive.access,
-                         purl: descriptive.respond_to?(:purl) ? descriptive.purl : nil)
-            AdminMetadata.write(xml: xml, admin_metadata: descriptive.adminMetadata)
-            RelatedResource.write(xml: xml, related_resources: descriptive.relatedResource, druid: druid,
+            Event.write(xml: xml, events: description.event, id_generator: id_generator)
+            Identifier.write(xml: xml, identifiers: description.identifier, id_generator: id_generator)
+            Access.write(xml: xml, access: description.access,
+                         purl: description.respond_to?(:purl) ? description.purl : nil)
+            AdminMetadata.write(xml: xml, admin_metadata: description.adminMetadata)
+            RelatedResource.write(xml: xml, related_resources: description.relatedResource, druid: druid,
                                   id_generator: id_generator)
-            Geographic.write(xml: xml, geos: descriptive.geographic, druid: druid) if descriptive.respond_to?(:geographic)
+            Geographic.write(xml: xml, geos: description.geographic, druid: druid) if description.respond_to?(:geographic)
           end
         end
       end

--- a/lib/cocina/models/mapping/to_mods/related_resource.rb
+++ b/lib/cocina/models/mapping/to_mods/related_resource.rb
@@ -51,7 +51,7 @@ module Cocina
           def write
             filtered_related_resources.each do |(attributes, new_related, _orig_related)|
               xml.relatedItem attributes do
-                ModsWriter.write(xml: xml, descriptive: new_related, druid: druid,
+                ModsWriter.write(xml: xml, description: new_related, druid: druid,
                                  id_generator: id_generator)
               end
             end

--- a/spec/cocina/models/mapping/from_mods/access_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/access_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Access do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) do
+  let(:description_builder) do
     instance_double(Cocina::Models::Mapping::FromMods::DescriptionBuilder, notifier: notifier)
   end
 

--- a/spec/cocina/models/mapping/from_mods/admin_metadata_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/admin_metadata_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::AdminMetadata do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) do
+  let(:description_builder) do
     instance_double(Cocina::Models::Mapping::FromMods::DescriptionBuilder, notifier: notifier)
   end
 

--- a/spec/cocina/models/mapping/from_mods/form_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/form_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Form do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) do
+  let(:description_builder) do
     instance_double(Cocina::Models::Mapping::FromMods::DescriptionBuilder, notifier: notifier)
   end
 

--- a/spec/cocina/models/mapping/from_mods/geographic_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/geographic_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Geographic do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) do
+  let(:description_builder) do
     instance_double(Cocina::Models::Mapping::FromMods::DescriptionBuilder, notifier: notifier)
   end
 

--- a/spec/cocina/models/mapping/from_mods/language_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/language_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Language do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) do
+  let(:description_builder) do
     instance_double(Cocina::Models::Mapping::FromMods::DescriptionBuilder, notifier: notifier)
   end
 

--- a/spec/cocina/models/mapping/from_mods/related_resource_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/related_resource_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::RelatedResource do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder, purl: nil)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder, purl: nil)
   end
 
-  let(:descriptive_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
+  let(:description_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
 
   let(:notifier) { instance_double(Cocina::Models::Mapping::ErrorNotifier) }
 

--- a/spec/cocina/models/mapping/from_mods/subject_name_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/subject_name_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Subject do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
+  let(:description_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
 
   let(:notifier) { instance_double(Cocina::Models::Mapping::ErrorNotifier) }
 

--- a/spec/cocina/models/mapping/from_mods/subject_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/subject_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMods::Subject do
   subject(:build) do
-    described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder)
+    described_class.build(resource_element: ng_xml.root, description_builder: description_builder)
   end
 
-  let(:descriptive_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
+  let(:description_builder) { Cocina::Models::Mapping::FromMods::DescriptionBuilder.new(notifier: notifier) }
 
   let(:notifier) { instance_double(Cocina::Models::Mapping::ErrorNotifier) }
 


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

"Description" is the cocina model name, not "Descriptive".

part of #431

## How was this change tested? 🤨

specs

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



