### PR TITLE
Implement H2 contributor specs.

### DIFF
--- a/lib/cocina/models/mapping/to_mods/name_writer.rb
+++ b/lib/cocina/models/mapping/to_mods/name_writer.rb
@@ -199,8 +199,6 @@ module Cocina
                 xml.affiliation note.value
               when 'description'
                 xml.description note.value
-              when 'citation status'
-                xml.description UNCITED_DESCRIPTION if note.value == 'false'
               end
             end
           end

--- a/spec/cocina/models/mapping/descriptive/h2/contributor_h2_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/h2/contributor_h2_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Leland Stanford. Contributing author.
 
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -456,7 +456,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Sponsor.
 
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -586,7 +586,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## San Francisco Symphony Concert. Event.
 
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -708,7 +708,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## LDCX. Conference.
 
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -839,7 +839,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Funder.
 
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1159,7 +1159,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Jane Stanford. Contributing author.
     ## ORCID: 0000-0000-0000-0000
-    xit 'updated cocina MODS mapping' do
+    it_behaves_like 'cocina to MODS only mapping' do
       let(:cocina) do
         {
           contributor: [

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -186,7 +186,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
   end
 end
 
-# When starting from cocina, e.g., H2.
+# When starting from cocina, e.g., H2 and roundtrips.
 RSpec.shared_examples 'cocina MODS mapping' do
   # Required: mods, cocina
   # Optional: druid, roundtrip_cocina, warnings, errors, mods_attributes, label
@@ -307,6 +307,39 @@ RSpec.shared_examples 'cocina MODS mapping' do
 
     it 'roundtrip MODS maps to roundtrip cocina' do
       expect(re_roundtrip_cocina_props).to eq(add_purl_and_title(roundtrip_cocina, local_druid)) if defined?(roundtrip_cocina)
+    end
+  end
+end
+
+# When starting from cocina, e.g., H2 and does not (intentionally) roundtrip.
+RSpec.shared_examples 'cocina to MODS only mapping' do
+  # Required: mods, cocina
+  # Optional: druid, label
+
+  let(:orig_cocina_description) { Cocina::Models::Description.new(add_purl_and_title(cocina, local_druid)) }
+
+  let(:mods_attributes) { MODS_ATTRIBUTES }
+
+  let(:mods_ng) { ng_mods_for(mods, mods_attributes) }
+
+  let(:local_druid) { defined?(druid) ? druid : 'druid:zn746hz1696' }
+
+  let(:label) { 'Test title' }
+
+  context 'when mapping from cocina (to MODS)' do
+    let(:actual_mods_ng) { Cocina::Models::Mapping::ToMods::Description.transform(orig_cocina_description, local_druid) }
+
+    let(:actual_xml) { actual_mods_ng.to_xml }
+
+    it 'mods snippet(s) produce valid MODS' do
+      expect { mods_ng }.not_to raise_error
+    end
+
+    # as we are starting with a cocina representation, there may be empty cocina values
+    # which could result in empty MODS elements from the transform.  The empty elements are correct at this point.
+    it 'cocina Description maps to expected MODS' do
+      expect(actual_xml).to be_equivalent_to Cocina::Models::Mapping::Normalizers::ModsNormalizer.normalize_purl_and_missing_title(mods_ng_xml: mods_ng, druid: local_druid,
+                                                                                                                                   label: label).to_xml
     end
   end
 end


### PR DESCRIPTION
closes #459

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Remove mapping that is no longer necessary.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

