### PR TITLE
Make factories easier to distinguish and identify

### DIFF
--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -45,24 +45,31 @@ module Cocina
         type: Cocina::Models::ObjectType.object,
         id: 'druid:bc234fg5678',
         version: 1,
-        label: 'test object',
-        title: 'test object',
+        label: 'factory DRO label',
+        title: 'factory DRO title',
         source_id: 'sul:1234',
         admin_policy_id: 'druid:hv992ry2431'
       }.freeze
 
       REQUEST_DRO_DEFAULTS = DRO_DEFAULTS.except(:id)
 
-      COLLECTION_DEFAULTS = DRO_DEFAULTS.except(:source_id).merge(type: Cocina::Models::ObjectType.collection)
+      COLLECTION_DEFAULTS = {
+        type: Cocina::Models::ObjectType.collection,
+        id: 'druid:bb222ff5555',
+        version: 1,
+        label: 'factory collection label',
+        title: 'factory collection title',
+        admin_policy_id: 'druid:hv992ry2431'
+      }.freeze
 
       REQUEST_COLLECTION_DEFAULTS = COLLECTION_DEFAULTS.except(:id)
 
       ADMIN_POLICY_DEFAULTS = {
         type: Cocina::Models::ObjectType.admin_policy,
-        id: 'druid:bc234fg5678',
+        id: 'druid:cb432gf8765',
         version: 1,
-        label: 'test admin policy',
-        title: 'test admin policy',
+        label: 'factory APO label',
+        title: 'factory APO title',
         admin_policy_id: 'druid:hv992ry2431',
         agreement_id: 'druid:hp308wm0436'
       }.freeze


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #454

Note: This commit will cause one spec in dor-services-app to fail but it ought to be easy to remediate once a cocina-models release goes out with this change included.

```
Failures:

  1) CocinaMigrationService#migrate when migration needed maps and persists
     Failure/Error: expect(ar_cocina_object.label).to eq('test object')
       Expected "factory DRO label" to eq "test object".
     # /media/mjg/44aee93d-a48a-4ad3-ae90-4b084bb04b69/rvm/gems/ruby-2.7.5@dor-services-app/gems/super_diff-0.9.0/lib/super_diff/rspec
/monkey_patches.rb:43:in `handle_failure'
     # ./spec/services/cocina_migration_service_spec.rb:41:in `block (4 levels) in <top (required)>'
     # /media/mjg/44aee93d-a48a-4ad3-ae90-4b084bb04b69/rvm/gems/ruby-2.7.5@dor-services-app/gems/webmock-3.14.0/lib/webmock/rspec.rb:3
7:in `block (2 levels) in <top (required)>'

Finished in 31.91 seconds (files took 3.57 seconds to load)
2088 examples, 1 failure, 5 pending

Failed examples:

rspec ./spec/services/cocina_migration_service_spec.rb:37 # CocinaMigrationService#migrate when migration needed maps and persists
```

## How was this change tested? 🤨

CI + I pointed DSA at this branch (see above)
