### PR TITLE
Do not validate for with_metadata and without_metadata methods.

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -119,7 +119,7 @@ module Cocina
     # @param [DROWithMetadata,CollectionWithMetadata,AdminPolicyWithMetadata] cocina_object
     # @return [DRO,Collection,AdminPolicy]
     def self.without_metadata(cocina_object)
-      build(cocina_object.to_h.except(:created, :modified, :lock))
+      build(cocina_object.to_h.except(:created, :modified, :lock), validate: false)
     end
 
     # Adds metadata to a DRO, Collection, AdminPolicy
@@ -144,7 +144,7 @@ module Cocina
               else
                 AdminPolicyWithMetadata
               end
-      clazz.new(props)
+      clazz.new(props, false, false)
     end
 
     def self.type_for(dyn)


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Validation is redundant and has performance implications.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



