### PR TITLE
Validation performance improvements

### DIFF
--- a/lib/cocina/models/validators/associated_name_validator.rb
+++ b/lib/cocina/models/validators/associated_name_validator.rb
@@ -11,7 +11,7 @@ module Cocina
 
         def initialize(clazz, attributes)
           @clazz = clazz
-          @attributes = attributes.deep_symbolize_keys
+          @attributes = attributes
           @error_paths = []
         end
 

--- a/lib/cocina/models/validators/associated_name_validator.rb
+++ b/lib/cocina/models/validators/associated_name_validator.rb
@@ -29,9 +29,7 @@ module Cocina
         attr_reader :clazz, :attributes, :error_paths
 
         def meets_preconditions?
-          resources.any? do |resource|
-            titles_with_associated_name_note_for(resource).present?
-          end
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
         end
 
         def valid?(resource)

--- a/lib/cocina/models/validators/description_types_validator.rb
+++ b/lib/cocina/models/validators/description_types_validator.rb
@@ -11,7 +11,7 @@ module Cocina
 
         def initialize(clazz, attributes)
           @clazz = clazz
-          @attributes = attributes.deep_symbolize_keys
+          @attributes = attributes
           @error_paths = []
         end
 

--- a/lib/cocina/models/validators/description_types_validator.rb
+++ b/lib/cocina/models/validators/description_types_validator.rb
@@ -30,8 +30,7 @@ module Cocina
         attr_reader :clazz, :attributes, :error_paths
 
         def meets_preconditions?
-          attributes.key?(:description) || [Cocina::Models::Description,
-                                            Cocina::Models::RequestDescription].include?(clazz)
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
         end
 
         def validate_hash(hash, path)

--- a/lib/cocina/models/validators/description_values_validator.rb
+++ b/lib/cocina/models/validators/description_values_validator.rb
@@ -11,7 +11,7 @@ module Cocina
 
         def initialize(clazz, attributes)
           @clazz = clazz
-          @attributes = attributes.deep_symbolize_keys
+          @attributes = attributes
           @error_paths = []
         end
 

--- a/lib/cocina/models/validators/description_values_validator.rb
+++ b/lib/cocina/models/validators/description_values_validator.rb
@@ -30,8 +30,7 @@ module Cocina
         attr_reader :clazz, :attributes, :error_paths
 
         def meets_preconditions?
-          attributes.key?(:description) || [Cocina::Models::Description,
-                                            Cocina::Models::RequestDescription].include?(clazz)
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
         end
 
         def validate_hash(hash, path)

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -26,8 +26,7 @@ module Cocina
           # In the meantime, copying code.
           attributes_hash = deep_transform_values(attributes.to_h) do |value|
             value.class.name.starts_with?('Cocina::Models') ? value.to_h : value
-          end.with_indifferent_access
-
+          end.deep_symbolize_keys.with_indifferent_access
           VALIDATORS.each { |validator| validator.validate(clazz, attributes_hash) }
         end
 

--- a/spec/cocina/models/validators/associated_name_validator_spec.rb
+++ b/spec/cocina/models/validators/associated_name_validator_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validators::AssociatedNameValidator do
-  let(:validate) { described_class.validate(clazz, props) }
-
   let(:clazz) { Cocina::Models::Description }
 
   let(:desc_props) do
@@ -37,127 +35,131 @@ RSpec.describe Cocina::Models::Validators::AssociatedNameValidator do
 
   let(:contributor_name) { 'Smith, John' }
 
-  context 'when no description' do
-    let(:props) { {} }
+  describe '#validate' do
+    let(:validate) { described_class.validate(clazz, props) }
 
-    it 'does not raise' do
-      validate
-    end
-  end
+    context 'when no description' do
+      let(:props) { {} }
 
-  context 'when no associated name' do
-    let(:props) do
-      {
-        title: [
-          {
-            value: 'A title',
-            type: 'uniform',
-            note: [
-              {
-                value: 'Smith, John',
-                type: 'not an associated name'
-              }
-            ]
-          }
-        ],
-        relatedResource: [
-          {
-            title: [
-              {
-                value: 'A title',
-                type: 'uniform'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  context 'when valid Description with name title group' do
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  context 'when invalid Description with name title group' do
-    let(:contributor_name) { 'not Smith, John' }
-
-    it 'raises' do
-      expect do
+      it 'does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Missing data: Name associated with uniform title does not match any contributor.')
-    end
-  end
-
-  context 'when invalid Description with missing contributors' do
-    let(:props) do
-      props = desc_props.dup
-      props.delete(:contributor)
-      props
+      end
     end
 
-    it 'raises' do
-      expect do
+    context 'when no associated name' do
+      let(:props) do
+        {
+          title: [
+            {
+              value: 'A title',
+              type: 'uniform',
+              note: [
+                {
+                  value: 'Smith, John',
+                  type: 'not an associated name'
+                }
+              ]
+            }
+          ],
+          relatedResource: [
+            {
+              title: [
+                {
+                  value: 'A title',
+                  type: 'uniform'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Missing data: Name associated with uniform title does not match any contributor.')
+      end
     end
-  end
 
-  context 'when valid Description with related resource' do
-    let(:props) { { relatedResource: [desc_props] } }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  context 'when invalid Description with related resource' do
-    let(:props) { { relatedResource: [desc_props] } }
-
-    let(:contributor_name) { 'not Smith, John' }
-
-    it 'raises' do
-      expect do
+    context 'when valid Description with name title group' do
+      it 'does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Missing data: Name associated with uniform title does not match any contributor.')
+      end
+    end
+
+    context 'when invalid Description with name title group' do
+      let(:contributor_name) { 'not Smith, John' }
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Missing data: Name associated with uniform title does not match any contributor.')
+      end
+    end
+
+    context 'when invalid Description with missing contributors' do
+      let(:props) do
+        props = desc_props.dup
+        props.delete(:contributor)
+        props
+      end
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Missing data: Name associated with uniform title does not match any contributor.')
+      end
+    end
+
+    context 'when valid Description with related resource' do
+      let(:props) { { relatedResource: [desc_props] } }
+
+      it 'does not raise' do
+        validate
+      end
+    end
+
+    context 'when invalid Description with related resource' do
+      let(:props) { { relatedResource: [desc_props] } }
+
+      let(:contributor_name) { 'not Smith, John' }
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Missing data: Name associated with uniform title does not match any contributor.')
+      end
     end
   end
 
-  context 'when valid RequestDescription with name title group' do
-    let(:clazz) { Cocina::Models::RequestDescription }
+  describe '#meets_preconditions?' do
+    let(:validator) { described_class.new(clazz, props) }
 
-    it 'does not raise' do
-      validate
+    let(:meets_preconditions) { validator.send(:meets_preconditions?) }
+
+    context 'when RequestDescription' do
+      let(:clazz) { Cocina::Models::RequestDescription }
+
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
     end
-  end
 
-  context 'when invalid RequestDescription with name title group' do
-    let(:clazz) { Cocina::Models::RequestDescription }
+    context 'when Description' do
+      let(:clazz) { Cocina::Models::Description }
 
-    let(:contributor_name) { 'not Smith, John' }
-
-    it 'raises' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
     end
-  end
 
-  context 'when invalid DRO with name title group' do
-    let(:clazz) { Cocina::Models::DRO }
+    context 'when DRO' do
+      let(:clazz) { Cocina::Models::DRO }
 
-    let(:contributor_name) { 'not Smith, John' }
-
-    let(:props) { { description: desc_props } }
-
-    it 'does not validate' do
-      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
+      it 'does not meet preconditions' do
+        expect(meets_preconditions).to be false
+      end
     end
   end
 end

--- a/spec/cocina/models/validators/associated_name_validator_spec.rb
+++ b/spec/cocina/models/validators/associated_name_validator_spec.rb
@@ -149,16 +149,6 @@ RSpec.describe Cocina::Models::Validators::AssociatedNameValidator do
     end
   end
 
-  context 'when valid DRO with name title group' do
-    let(:clazz) { Cocina::Models::DRO }
-
-    let(:props) { { description: desc_props } }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
   context 'when invalid DRO with name title group' do
     let(:clazz) { Cocina::Models::DRO }
 
@@ -166,8 +156,8 @@ RSpec.describe Cocina::Models::Validators::AssociatedNameValidator do
 
     let(:props) { { description: desc_props } }
 
-    it 'raises' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    it 'does not validate' do
+      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
     end
   end
 end

--- a/spec/cocina/models/validators/description_types_validator_spec.rb
+++ b/spec/cocina/models/validators/description_types_validator_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
-  let(:validate) { described_class.validate(clazz, props) }
-
   let(:clazz) { Cocina::Models::Description }
 
   let(:props) { desc_props }
@@ -58,413 +56,401 @@ RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
   let(:related_resource_contributor_type) { 'person' }
 
   let(:request_desc_props) do
-    dro_props.dup.tap do |props|
-      props[:description].delete(:purl)
+    desc_props.dup.tap do |props|
+      props.delete(:purl)
     end
   end
 
-  let(:dro_props) { { description: desc_props } }
+  describe '#validate' do
+    let(:validate) { described_class.validate(clazz, props) }
 
-  describe 'when a valid Description' do
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  describe 'when a valid RequestDescription' do
-    let(:props) { request_desc_props }
-    let(:clazz) { Cocina::Models::RequestDescription }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  describe 'when an invalid RequestDescription' do
-    let(:props) { request_desc_props }
-    let(:clazz) { Cocina::Models::RequestDRO }
-    let(:contributor_type) { 'foo' }
-
-    it 'does not validate' do
-      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
-    end
-  end
-
-  describe 'when an invalid DRO' do
-    let(:clazz) { Cocina::Models::DRO }
-    let(:props) { dro_props }
-    let(:contributor_type) { 'foo' }
-
-    it 'does not validate' do
-      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
-    end
-  end
-
-  describe 'when an invalid type at top level' do
-    let(:contributor_type) { 'foo' }
-
-    it 'raises' do
-      expect do
+    describe 'when a valid Description' do
+      it 'does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError, 'Unrecognized types in description: contributor1 (foo)')
+      end
     end
-  end
 
-  describe 'when an invalid type at other level' do
-    let(:contributor_identifier_type) { 'foo' }
+    describe 'when a valid RequestDescription' do
+      let(:props) { request_desc_props }
+      let(:clazz) { Cocina::Models::RequestDescription }
 
-    it 'raises' do
-      expect do
+      it 'does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Unrecognized types in description: contributor1.identifier1 (foo)')
+      end
     end
-  end
 
-  describe 'when an invalid type at nested level' do
-    let(:related_resource_contributor_type) { 'foo' }
+    describe 'when an invalid type at top level' do
+      let(:contributor_type) { 'foo' }
 
-    it 'raises' do
-      expect do
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Unrecognized types in description: contributor1 (foo)')
+      end
+    end
+
+    describe 'when an invalid type at other level' do
+      let(:contributor_identifier_type) { 'foo' }
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Unrecognized types in description: contributor1.identifier1 (foo)')
+      end
+    end
+
+    describe 'when an invalid type at nested level' do
+      let(:related_resource_contributor_type) { 'foo' }
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Unrecognized types in description: relatedResource1.contributor1 (foo)')
+      end
+    end
+
+    describe 'when a case mismatch' do
+      let(:contributor_type) { 'PERson' }
+
+      it 'is case insensitive' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Unrecognized types in description: relatedResource1.contributor1 (foo)')
-    end
-  end
-
-  describe 'when a case mismatch' do
-    let(:contributor_type) { 'PERson' }
-
-    it 'is case insensitive' do
-      validate
-    end
-  end
-
-  describe 'with a parallelValue' do
-    let(:desc_props) do
-      {
-        title: [{ value: 'The Professor: A Sentimental Education' }],
-        purl: 'https://purl.stanford.edu/bc123df4567',
-        contributor: [
-          {
-            name: [
-              {
-                parallelValue: [
-                  {
-                    structuredValue: [
-                      {
-                        value: 'Terry',
-                        # This type is invalid
-                        type: 'fooname'
-                      },
-                      {
-                        value: 'Castle',
-                        type: 'surname'
-                      }
-                    ]
-                  },
-                  {
-                    value: 'Castle, Terry',
-                    type: 'display'
-                  }
-                ]
-              }
-            ],
-            status: 'primary',
-            type: 'person',
-            identifier: [
-              {
-                value: 'https://www.wikidata.org/wiki/Q7704207',
-                type: 'Wikidata'
-              }
-            ],
-            note: [
-              {
-                value: 'Stanford University',
-                type: 'affiliation'
-              },
-              {
-                value: 'Professor of English',
-                type: 'description'
-              }
-            ]
-          }
-        ]
-      }
+      end
     end
 
-    it 'ignores parallelValue and raises' do
-      expect do
-        validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Unrecognized types in description: ' \
-                         'contributor1.name1.parallelValue1.structuredValue1 (fooname)')
-    end
-  end
-
-  describe 'with an invalid parallelEvent' do
-    let(:desc_props) do
-      {
-        title: [
-          {
-            parallelValue: [
-              { value: 'Ṣammamtu an ahwāka yā sayyidī', status: 'primary' },
-              { value: 'صممت أن اهواك يا سيدي' }
-            ]
-          }
-        ],
-        purl: 'https://purl.stanford.edu/xq000jd3530',
-        event: [
-          {
-            parallelEvent: [
-              {
-                note: [
-                  { type: 'edition', value: 'al-Ṭabʻah 1.' }
-                ]
-              },
-              {
-                note: [
-                  { type: 'foo', value: 'الطبعة ١.' }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    it 'ignores parallelEvent and raises' do
-      expect do
-        validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Unrecognized types in description: event1.parallelEvent2.note1 (foo)')
-    end
-  end
-
-  describe 'with a valid parallelEvent' do
-    let(:desc_props) do
-      {
-        title: [
-          {
-            parallelValue: [
-              { value: 'Ṣammamtu an ahwāka yā sayyidī', status: 'primary' },
-              { value: 'صممت أن اهواك يا سيدي' }
-            ]
-          }
-        ],
-        purl: 'https://purl.stanford.edu/xq000jd3530',
-        event: [
-          {
-            parallelEvent: [
-              {
-                note: [
-                  { type: 'edition', value: 'al-Ṭabʻah 1.' }
-                ]
-              },
-              {
-                note: [
-                  { type: 'edition', value: 'الطبعة ١.' }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    it 'ignores parallelEvent and does not raise' do
-      validate
-    end
-  end
-
-  describe 'with an invalid parallelContributor' do
-    let(:desc_props) do
-      {
-        contributor: [
-          {
-            parallelContributor: [
-              {
-                name: [
-                  {
-                    structuredValue: [
-                      {
-                        value: 'Li, Yahong',
-                        type: 'foo'
-                      },
-                      {
-                        value: '1963-',
-                        type: 'life dates'
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                name: [
-                  {
-                    value: '李亞虹'
-                  }
-                ]
-              }
-            ],
-            type: 'person'
-          }
-        ]
-      }
-    end
-
-    it 'ignores parallelContributor and raises' do
-      expect do
-        validate
-      end.to raise_error(Cocina::Models::ValidationError,
-                         'Unrecognized types in description: ' \
-                         'contributor1.parallelContributor1.name1.structuredValue1 (foo)')
-    end
-  end
-
-  describe 'with an valid parallelContributor' do
-    let(:desc_props) do
-      {
-        contributor: [
-          {
-            parallelContributor: [
-              {
-                name: [
-                  {
-                    structuredValue: [
-                      {
-                        value: 'Li, Yahong',
-                        type: 'name'
-                      },
-                      {
-                        value: '1963-',
-                        type: 'life dates'
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                name: [
-                  {
-                    value: '李亞虹'
-                  }
-                ]
-              }
-            ],
-            type: 'person'
-          }
-        ]
-      }
-    end
-
-    it 'ignores parallelContributor and does not raise' do
-      validate
-    end
-  end
-
-  describe 'with a nested structuredValue' do
-    let(:desc_props) do
-      {
-        title: [{ value: 'Leon Kolb collection of portraits' }],
-        purl: 'https://purl.stanford.edu/rr239pp1335',
-        subject: [
-          {
-            structuredValue: [
-              {
-                parallelValue: [
-                  {
-                    structuredValue: [
-                      {
-                        value: 'Andrada',
-                        type: 'surname'
-                      },
-                      {
-                        value: 'Leitao, Francisco d\'',
-                        type: 'fooname'
-                      },
-                      {
-                        value: '17th C.',
-                        type: 'life dates'
-                      }
-                    ]
-                  },
-                  {
-                    value: 'Andrada, Leitao, Francisco d\', 17th C.',
-                    type: 'display'
-                  }
-                ],
-                type: 'person',
-                note: [
-                  {
-                    value: 'Depicted',
-                    type: 'role',
-                    code: 'dpc',
-                    uri: 'http://id.loc.gov/vocabulary/relators/dpc',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+    describe 'with a parallelValue' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'The Professor: A Sentimental Education' }],
+          purl: 'https://purl.stanford.edu/bc123df4567',
+          contributor: [
+            {
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Terry',
+                          # This type is invalid
+                          type: 'fooname'
+                        },
+                        {
+                          value: 'Castle',
+                          type: 'surname'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'Castle, Terry',
+                      type: 'display'
                     }
-                  }
-                ]
-              },
-              {
-                value: 'Pictorial works',
-                type: 'topic'
-              }
-            ]
-          }
-        ]
-      }
+                  ]
+                }
+              ],
+              status: 'primary',
+              type: 'person',
+              identifier: [
+                {
+                  value: 'https://www.wikidata.org/wiki/Q7704207',
+                  type: 'Wikidata'
+                }
+              ],
+              note: [
+                {
+                  value: 'Stanford University',
+                  type: 'affiliation'
+                },
+                {
+                  value: 'Professor of English',
+                  type: 'description'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'ignores parallelValue and raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Unrecognized types in description: ' \
+                           'contributor1.name1.parallelValue1.structuredValue1 (fooname)')
+      end
     end
 
-    it 'ignores nesting and raises' do
-      expect do
+    describe 'with an invalid parallelEvent' do
+      let(:desc_props) do
+        {
+          title: [
+            {
+              parallelValue: [
+                { value: 'Ṣammamtu an ahwāka yā sayyidī', status: 'primary' },
+                { value: 'صممت أن اهواك يا سيدي' }
+              ]
+            }
+          ],
+          purl: 'https://purl.stanford.edu/xq000jd3530',
+          event: [
+            {
+              parallelEvent: [
+                {
+                  note: [
+                    { type: 'edition', value: 'al-Ṭabʻah 1.' }
+                  ]
+                },
+                {
+                  note: [
+                    { type: 'foo', value: 'الطبعة ١.' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'ignores parallelEvent and raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Unrecognized types in description: event1.parallelEvent2.note1 (foo)')
+      end
+    end
+
+    describe 'with a valid parallelEvent' do
+      let(:desc_props) do
+        {
+          title: [
+            {
+              parallelValue: [
+                { value: 'Ṣammamtu an ahwāka yā sayyidī', status: 'primary' },
+                { value: 'صممت أن اهواك يا سيدي' }
+              ]
+            }
+          ],
+          purl: 'https://purl.stanford.edu/xq000jd3530',
+          event: [
+            {
+              parallelEvent: [
+                {
+                  note: [
+                    { type: 'edition', value: 'al-Ṭabʻah 1.' }
+                  ]
+                },
+                {
+                  note: [
+                    { type: 'edition', value: 'الطبعة ١.' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'ignores parallelEvent and does not raise' do
         validate
-      end.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+
+    describe 'with an invalid parallelContributor' do
+      let(:desc_props) do
+        {
+          contributor: [
+            {
+              parallelContributor: [
+                {
+                  name: [
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Li, Yahong',
+                          type: 'foo'
+                        },
+                        {
+                          value: '1963-',
+                          type: 'life dates'
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  name: [
+                    {
+                      value: '李亞虹'
+                    }
+                  ]
+                }
+              ],
+              type: 'person'
+            }
+          ]
+        }
+      end
+
+      it 'ignores parallelContributor and raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           'Unrecognized types in description: ' \
+                           'contributor1.parallelContributor1.name1.structuredValue1 (foo)')
+      end
+    end
+
+    describe 'with an valid parallelContributor' do
+      let(:desc_props) do
+        {
+          contributor: [
+            {
+              parallelContributor: [
+                {
+                  name: [
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Li, Yahong',
+                          type: 'name'
+                        },
+                        {
+                          value: '1963-',
+                          type: 'life dates'
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  name: [
+                    {
+                      value: '李亞虹'
+                    }
+                  ]
+                }
+              ],
+              type: 'person'
+            }
+          ]
+        }
+      end
+
+      it 'ignores parallelContributor and does not raise' do
+        validate
+      end
+    end
+
+    describe 'with a nested structuredValue' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'Leon Kolb collection of portraits' }],
+          purl: 'https://purl.stanford.edu/rr239pp1335',
+          subject: [
+            {
+              structuredValue: [
+                {
+                  parallelValue: [
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Andrada',
+                          type: 'surname'
+                        },
+                        {
+                          value: 'Leitao, Francisco d\'',
+                          type: 'fooname'
+                        },
+                        {
+                          value: '17th C.',
+                          type: 'life dates'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'Andrada, Leitao, Francisco d\', 17th C.',
+                      type: 'display'
+                    }
+                  ],
+                  type: 'person',
+                  note: [
+                    {
+                      value: 'Depicted',
+                      type: 'role',
+                      code: 'dpc',
+                      uri: 'http://id.loc.gov/vocabulary/relators/dpc',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                },
+                {
+                  value: 'Pictorial works',
+                  type: 'topic'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'ignores nesting and raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+
+    context 'when description_types.yml has value with special character' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'Testing West Mat #' }],
+          purl: 'https://purl.stanford.edu/bc123df4567',
+          identifier: [
+            {
+              value: '123',
+              type: 'West Mat #'
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        validate
+      end
     end
   end
 
-  describe 'when an invalid Description with string keys' do
-    let(:props) do
-      {
-        'title' => [{ 'value' => 'The Structure of Scientific Revolutions' }],
-        'purl' => 'https://purl.stanford.edu/bc123df4567',
-        'contributor' => [
-          {
-            'name' => [
-              {
-                'value' => 'Kuhn, Thomas'
-              }
-            ],
-            'type' => 'foo',
-            'status' => 'primary'
-          }
-        ]
-      }
+  describe '#meets_preconditions?' do
+    let(:validator) { described_class.new(clazz, props) }
+
+    let(:meets_preconditions) { validator.send(:meets_preconditions?) }
+
+    context 'when RequestDescription' do
+      let(:clazz) { Cocina::Models::RequestDescription }
+
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
     end
 
-    it 'is not valid' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
-    end
-  end
+    context 'when Description' do
+      let(:clazz) { Cocina::Models::Description }
 
-  context 'when description_types.yml has value with special character' do
-    let(:desc_props) do
-      {
-        title: [{ value: 'Testing West Mat #' }],
-        purl: 'https://purl.stanford.edu/bc123df4567',
-        identifier: [
-          {
-            value: '123',
-            type: 'West Mat #'
-          }
-        ]
-      }
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
     end
 
-    it 'does not raise' do
-      validate
+    context 'when DRO' do
+      let(:clazz) { Cocina::Models::DRO }
+
+      it 'does not meet preconditions' do
+        expect(meets_preconditions).to be false
+      end
     end
   end
 end

--- a/spec/cocina/models/validators/description_types_validator_spec.rb
+++ b/spec/cocina/models/validators/description_types_validator_spec.rb
@@ -80,31 +80,13 @@ RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
     end
   end
 
-  describe 'when a valid DRO' do
-    let(:clazz) { Cocina::Models::DRO }
-    let(:props) { dro_props }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  describe 'when none of the above' do
-    let(:props) { {} }
-    let(:clazz) { Cocina::Models::Identification }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
   describe 'when an invalid RequestDescription' do
     let(:props) { request_desc_props }
     let(:clazz) { Cocina::Models::RequestDRO }
     let(:contributor_type) { 'foo' }
 
-    it 'is not valid' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    it 'does not validate' do
+      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
     end
   end
 
@@ -113,8 +95,8 @@ RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
     let(:props) { dro_props }
     let(:contributor_type) { 'foo' }
 
-    it 'is not valid' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    it 'does not validate' do
+      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
     end
   end
 

--- a/spec/cocina/models/validators/description_values_validator_spec.rb
+++ b/spec/cocina/models/validators/description_values_validator_spec.rb
@@ -76,24 +76,6 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
     end
   end
 
-  describe 'when a valid DRO' do
-    let(:clazz) { Cocina::Models::DRO }
-    let(:props) { dro_props }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
-  describe 'when none of the above' do
-    let(:props) { {} }
-    let(:clazz) { Cocina::Models::Identification }
-
-    it 'does not raise' do
-      validate
-    end
-  end
-
   describe 'when an invalid Description' do
     let(:props) { invalid_desc_props }
 
@@ -105,7 +87,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
   end
 
   describe 'when an invalid RequestDescription' do
-    let(:clazz) { Cocina::Models::RequestDRO }
+    let(:clazz) { Cocina::Models::RequestDescription }
     let(:props) { request_desc_props }
     let(:dro_props) { { description: invalid_desc_props } }
 
@@ -119,8 +101,8 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
     let(:props) { dro_props }
     let(:dro_props) { { description: invalid_desc_props } }
 
-    it 'is not valid' do
-      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    it 'does not validate' do
+      expect { validate }.not_to raise_error(Cocina::Models::ValidationError)
     end
   end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Improve performance by stopping redundant validation.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Before:
```
puts Benchmark.measure { Cocina::Models::Validators::Validator.validate(c.class, c) }
  1.381309   0.008735   1.390044 (  1.393821)
```

After:
```
puts Benchmark.measure { Cocina::Models::Validators::Validator.validate(c.class, c) }
  0.588038   0.007669   0.595707 (  0.596772)
```