### PR TITLE
Marks parallelContributor as deprecated and adds class-level comments.

### DIFF
--- a/docs/description_types.md
+++ b/docs/description_types.md
@@ -385,6 +385,7 @@ _Path: identifier.type_
   * record id
   * Senate Number
   * Series
+  * SICI
   * SIRSI
   * Source ID
   * sourceID

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -13,8 +13,8 @@ module Cocina
           # frozen_string_literal: true
 
           module Cocina
-            module Models
-              class #{name} < Struct
+            module Models#{'              '}
+              #{preamble}class #{name} < Struct
 
                 #{validate}
                 #{types}

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -41,6 +41,12 @@ module Cocina
         "# #{schema_doc.description}\n"
       end
 
+      def deprecation
+        return '' unless schema_doc.deprecated?
+
+        "# DEPRECATED\n"
+      end
+
       def example
         return '' unless schema_doc.example
 
@@ -81,6 +87,10 @@ module Cocina
         else
           'Strict::String'
         end
+      end
+
+      def preamble
+        "#{deprecation}#{description}#{example}#{relaxed_comment}"
       end
     end
   end

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -19,10 +19,6 @@ module Cocina
         "Types::#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}"
       end
 
-      def preamble
-        "#{description}#{example}#{relaxed_comment}"
-      end
-
       def enum
         return '' if !schema_doc.enum || relaxed
 

--- a/lib/cocina/models/access_role.rb
+++ b/lib/cocina/models/access_role.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Access role conferred by an AdminPolicy to objects within it. (used by Argo)
     class AccessRole < Struct
       # Name of role
       attribute :name, Types::Strict::String.enum('dor-apo-depositor', 'dor-apo-manager', 'dor-apo-viewer', 'sdr-administrator', 'sdr-viewer', 'hydrus-collection-creator', 'hydrus-collection-manager', 'hydrus-collection-depositor', 'hydrus-collection-item-depositor', 'hydrus-collection-reviewer', 'hydrus-collection-viewer')

--- a/lib/cocina/models/access_role_member.rb
+++ b/lib/cocina/models/access_role_member.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Represents a user or group that is a member of an AccessRole
     class AccessRoleMember < Struct
       include Checkable
 

--- a/lib/cocina/models/admin_policy_access_template.rb
+++ b/lib/cocina/models/admin_policy_access_template.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Provides the template of access settings that is copied to the items goverend by an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo.
     class AdminPolicyAccessTemplate < Struct
       attribute? :view, Types::Strict::String.enum('world', 'stanford', 'location-based', 'citation-only', 'dark')
       # Available for controlled digital lending.

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Administrative properties for an AdminPolicy
     class AdminPolicyAdministrative < Struct
       attribute(:accessTemplate, AdminPolicyAccessTemplate.default { AdminPolicyAccessTemplate.new })
       attribute :registrationWorkflow, Types::Strict::Array.of(Types::Strict::String).default([].freeze)

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Admin Policy with addition object metadata.
     class AdminPolicyWithMetadata < Struct
       include Validatable
 

--- a/lib/cocina/models/applies_to.rb
+++ b/lib/cocina/models/applies_to.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Property model for indicating the parts, aspects, or versions of the resource to which a descriptive element is applicable.
     class AppliesTo < Struct
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
     end

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
     class Collection < Struct
       include Validatable
 

--- a/lib/cocina/models/collection_access.rb
+++ b/lib/cocina/models/collection_access.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Access metadata for collections
     class CollectionAccess < Struct
       # Access level
       attribute? :view, Types::Strict::String.default('dark').enum('world', 'dark')

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Collection with addition object metadata.
     class CollectionWithMetadata < Struct
       include Validatable
 

--- a/lib/cocina/models/contributor.rb
+++ b/lib/cocina/models/contributor.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Property model for describing agents contributing in some way to the creation and history of the resource.
     class Contributor < Struct
       attribute :name, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Entity type of the contributor (person, organization, etc.). See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.

--- a/lib/cocina/models/descriptive_access_metadata.rb
+++ b/lib/cocina/models/descriptive_access_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Information about how to access digital and physical versions of the object.
     class DescriptiveAccessMetadata < Struct
       attribute :url, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :physicalLocation, Types::Strict::Array.of(DescriptiveValue).default([].freeze)

--- a/lib/cocina/models/descriptive_admin_metadata.rb
+++ b/lib/cocina/models/descriptive_admin_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Information about this resource description.
     class DescriptiveAdminMetadata < Struct
       attribute :contributor, Types::Strict::Array.of(Contributor).default([].freeze)
       attribute :event, Types::Strict::Array.of(Event).default([].freeze)

--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Basic value model for descriptive elements. Can only have one of value, parallelValue, groupedValue, or structuredValue.
     class DescriptiveBasicValue < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)

--- a/lib/cocina/models/descriptive_geographic_metadata.rb
+++ b/lib/cocina/models/descriptive_geographic_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Value model for mods geographic extension metadata
     class DescriptiveGeographicMetadata < Struct
       attribute :form, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)

--- a/lib/cocina/models/descriptive_grouped_value.rb
+++ b/lib/cocina/models/descriptive_grouped_value.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Value model for a set of descriptive elements grouped together in an unstructured way.
     class DescriptiveGroupedValue < Struct
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
     end

--- a/lib/cocina/models/descriptive_parallel_contributor.rb
+++ b/lib/cocina/models/descriptive_parallel_contributor.rb
@@ -2,6 +2,8 @@
 
 module Cocina
   module Models
+    # DEPRECATED
+    # Value model for multiple representations of information about the same contributor (e.g. in different languages).
     class DescriptiveParallelContributor < Struct
       attribute :name, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Entity type of the contributor (person, organization, etc.). See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.

--- a/lib/cocina/models/descriptive_parallel_event.rb
+++ b/lib/cocina/models/descriptive_parallel_event.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Value model for multiple representations of information about the same event (e.g. in different languages).
     class DescriptiveParallelEvent < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Description of the event (creation, publication, etc.).

--- a/lib/cocina/models/descriptive_parallel_value.rb
+++ b/lib/cocina/models/descriptive_parallel_value.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Value model for multiple representations of the same information (e.g. in different languages).
     class DescriptiveParallelValue < Struct
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
     end

--- a/lib/cocina/models/descriptive_structured_value.rb
+++ b/lib/cocina/models/descriptive_structured_value.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Value model for descriptive elements structured as typed, ordered values.
     class DescriptiveStructuredValue < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
     end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Default value model for descriptive elements.
     class DescriptiveValue < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)

--- a/lib/cocina/models/descriptive_value_language.rb
+++ b/lib/cocina/models/descriptive_value_language.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Language of the descriptive element value
     class DescriptiveValueLanguage < Struct
       # Code representing the standard or encoding.
       attribute? :code, Types::Strict::String

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
     class DRO < Struct
       include Validatable
 

--- a/lib/cocina/models/dro_structural.rb
+++ b/lib/cocina/models/dro_structural.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Structural metadata
     class DROStructural < Struct
       attribute :contains, Types::Strict::Array.of(FileSet).default([].freeze)
       attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).default([].freeze)

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # DRO with addition object metadata.
     class DROWithMetadata < Struct
       include Validatable
 

--- a/lib/cocina/models/event.rb
+++ b/lib/cocina/models/event.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Property model for describing events in the history of the resource.
     class Event < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Description of the event (creation, publication, etc.).

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Binaries that are the basis of what our domain manages. Binaries here do not include metadata files generated for the domain's own management purposes.
     class File < Struct
       include Checkable
 

--- a/lib/cocina/models/file_access.rb
+++ b/lib/cocina/models/file_access.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Access metadata for files
     class FileAccess < Struct
       # Access level.
       # Validation of this property is relaxed. See the openapi for full validation.

--- a/lib/cocina/models/file_set.rb
+++ b/lib/cocina/models/file_set.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Relevant groupings of Files. Also called a File Grouping.
     class FileSet < Struct
       include Checkable
 

--- a/lib/cocina/models/file_set_structural.rb
+++ b/lib/cocina/models/file_set_structural.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Structural metadata
     class FileSetStructural < Struct
       attribute :contains, Types::Strict::Array.of(File).default([].freeze)
     end

--- a/lib/cocina/models/geographic.rb
+++ b/lib/cocina/models/geographic.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Geographic metadata
     class Geographic < Struct
       # Geographic ISO 19139 XML metadata
       attribute :iso19139, Types::Strict::String

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Languages, scripts, symbolic systems, and notations used in all or part of a resource or its descriptive metadata.
     class Language < Struct
       attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
       # Code value of the descriptive element.

--- a/lib/cocina/models/message_digest.rb
+++ b/lib/cocina/models/message_digest.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # The output of the message digest algorithm.
     class MessageDigest < Struct
       include Checkable
 

--- a/lib/cocina/models/object_metadata.rb
+++ b/lib/cocina/models/object_metadata.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Metadata for a cocina object.
     class ObjectMetadata < Struct
       # When the object was created.
       attribute? :created, Types::Params::DateTime

--- a/lib/cocina/models/presentation.rb
+++ b/lib/cocina/models/presentation.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Presentation data for the File.
     class Presentation < Struct
       # Height in pixels
       attribute? :height, Types::Strict::Integer

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Other resource associated with the described resource.
     class RelatedResource < Struct
       # The relationship of the related resource to the described resource.
       attribute? :type, Types::Strict::String

--- a/lib/cocina/models/release_tag.rb
+++ b/lib/cocina/models/release_tag.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # A tag that indicates the item or collection should be released.
     class ReleaseTag < Struct
       # Who did this release
       # example: petucket

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Same as an AdminPolicy, but doesn't have an externalIdentifier as one will be created
     class RequestAdminPolicy < Struct
       include Validatable
 

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Same as a Collection, but doesn't have an externalIdentifier as one will be created
     class RequestCollection < Struct
       include Validatable
 

--- a/lib/cocina/models/request_description.rb
+++ b/lib/cocina/models/request_description.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Description that is included in a request to create a DRO. This is the same as a Description, except excludes PURL.
     class RequestDescription < Struct
       include Validatable
 

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # A request to create a DRO.  This has the same general structure as a DRO but doesn't have externalIdentifier and doesn't require the access subschema. If no access subschema is provided, these values will be inherited from the AdminPolicy.
     class RequestDRO < Struct
       include Validatable
 

--- a/lib/cocina/models/request_dro_structural.rb
+++ b/lib/cocina/models/request_dro_structural.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Structural metadata
     class RequestDROStructural < Struct
       attribute :contains, Types::Strict::Array.of(RequestFileSet).default([].freeze)
       attribute :hasMemberOrders, Types::Strict::Array.of(Sequence).default([].freeze)

--- a/lib/cocina/models/request_file_set_structural.rb
+++ b/lib/cocina/models/request_file_set_structural.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Structural metadata
     class RequestFileSetStructural < Struct
       attribute :contains, Types::Strict::Array.of(RequestFile).default([].freeze)
     end

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Same as a Identification, but requires a sourceId and doesn't permit a DOI.
     class RequestIdentification < Struct
       # A barcode
       attribute? :barcode, Types::Nominal::Any

--- a/lib/cocina/models/sequence.rb
+++ b/lib/cocina/models/sequence.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # A sequence or ordering of resources within a Collection or Object.
     class Sequence < Struct
       attribute :members, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # The direction that a sequence of canvases should be displayed to the user

--- a/lib/cocina/models/source.rb
+++ b/lib/cocina/models/source.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Property model for indicating the vocabulary, authority, or other origin for a term, code, or identifier.
     class Source < Struct
       # Code representing the value source.
       attribute? :code, Types::Strict::String

--- a/lib/cocina/models/standard.rb
+++ b/lib/cocina/models/standard.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   module Models
+    # Property model for indicating the encoding, standard, or syntax to which a value conforms (e.g. RDA).
     class Standard < Struct
       # Code representing the standard or encoding.
       attribute? :code, Types::Strict::String

--- a/openapi.yml
+++ b/openapi.yml
@@ -779,6 +779,7 @@ components:
             $ref: "#/components/schemas/DescriptiveValue"
     DescriptiveParallelContributor:
       description: Value model for multiple representations of information about the same contributor (e.g. in different languages).
+      deprecated: true
       type: object
       additionalProperties: false
       properties:


### PR DESCRIPTION
closes #475

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
* Indicate that parallelContributor is deprecated.
* Provide a mechanism for deprecating without removing.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



