### PR TITLE
fix description of catkey barcode

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -390,7 +390,7 @@ components:
         - catalogRecordId
         - refresh
     CatkeyBarcode:
-      description: The barcode associated with a DRO object based on catkey, prefixed with 36105
+      description: The barcode associated with a DRO object based on catkey, prefixed with a catkey followed by a hyphen
       type: string
       pattern: '^[0-9]+-[0-9]+$'
       example: '6772719-1001'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

I noticed an error in the catkey barcode description.  I will port change and make PRs for sdr-api and dor-services-app but I am not going to generate models, nor put this in a new gem release.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



