### PR TITLE
Simplify Zeitwerk configuration

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -40,7 +40,7 @@ loader = Zeitwerk::Loader.new
 loader.inflector = CocinaModelsInflector.new
 loader.push_dir(File.absolute_path("#{__FILE__}/../.."))
 loader.ignore("#{__dir__}/rspec.rb")
-loader.ignore("#{__dir__}/rspec/**/*.rb")
+loader.ignore("#{__dir__}/rspec")
 loader.setup
 
 module Cocina


### PR DESCRIPTION
Hi! I just saw this configuration in passing.

You can ignore the very `lib/cocina/rspec` directory. This is simpler and more performant than a wildcard pattern.