### PR TITLE
Turn on date/time validation

### DIFF
--- a/lib/cocina/models/validators/date_time_validator.rb
+++ b/lib/cocina/models/validators/date_time_validator.rb
@@ -68,7 +68,15 @@ module Cocina
           Date.edtf!(value)
           true
         rescue StandardError
-          false
+          # NOTE: the upstream EDTF implementation in the `edtf` gem does not
+          #       allow a valid pattern that we use (possibly because only level
+          #       0 of the spec was implemented?):
+          #
+          # * Y-20555
+          #
+          # So we catch the false positives from the upstream gem and allow
+          # this pattern to validate
+          /\AY-?\d{5,}\Z/.match?(value)
         end
 
         def valid_iso8601?(value)
@@ -90,7 +98,7 @@ module Cocina
           #
           # So we catch the false positives from the upstream gem and allow
           # these two patterns to validate
-          /\A\d{4}(-0[1-9]|1[0-2])?\Z/.match?(value)
+          /\A\d{4}(-0[1-9]|-1[0-2])?\Z/.match?(value)
         end
 
         def druid

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -12,7 +12,8 @@ module Cocina
           CatalogLinksValidator,
           AssociatedNameValidator,
           DescriptionTypesValidator,
-          DescriptionValuesValidator
+          DescriptionValuesValidator,
+          DateTimeValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/spec/cocina/models/validators/date_time_validator_spec.rb
+++ b/spec/cocina/models/validators/date_time_validator_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe Cocina::Models::Validators::DateTimeValidator do
         ['edtf', '-3999', true],
         ['iso8601', '-3999', false],
         ['w3cdtf', '-3999', false],
+        ['edtf', 'Y-20555', true],
+        ['edtf', 'Y20555', true],
         ['edtf', '20220608', false],
         ['edtf', '20220608T1204', false],
         ['edtf', '20220608T120435', false],
@@ -102,7 +104,12 @@ RSpec.describe Cocina::Models::Validators::DateTimeValidator do
         ['w3cdtf', '202206081204', false],
         ['w3cdtf', '20220608120435', false],
         ['w3cdtf', '20220608T120435.123', false],
-        ['w3cdtf', '20220608120435.123', false]
+        ['w3cdtf', '20220608120435.123', false],
+        ['w3cdtf', '1997-7', false],
+        ['w3cdtf', '1997-00', false],
+        ['w3cdtf', '1997-13', false],
+        ['w3cdtf', '1997-1', false],
+        ['w3cdtf', '1997-111', false]
       ].each do |code, value, valid|
         context "with #{valid ? 'valid' : 'invalid'} #{code} value #{value}" do
           let(:props) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #485

This commit turns on the date/time validator, which has been available for some time but has been waiting for date/time remediation to happen. This is now finished. As part of this work, pull the latest date/time regular expressions over from DSA, so that validation matches report behavior.


## How was this change tested? 🤨

CI & tested against the full prod data set

- [x] [Test validation changes](https://github.com/sul-dlss/cocina-models#testing-validation-changes)
    * Two items failed validation and Arcadia remediated both.