### PR TITLE
Expose access to the druid regex

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -153,5 +153,12 @@ module Cocina
       raise ValidationError, 'Type field not found'
     end
     private_class_method :type_for
+
+    def self.druid_regex
+      @druid_regex ||= begin
+        str = Openapi3Parser.load_file('openapi.yml').components.schemas['Druid'].pattern
+        Regexp.new(str)
+      end
+    end
   end
 end

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -207,4 +207,12 @@ RSpec.describe Cocina::Models do
       expect(cocina_object_with_metadata).to match_cocina_object_with(expected.to_h)
     end
   end
+
+  describe '.druid_regex' do
+    subject(:druid_regex) { described_class.druid_regex }
+
+    it 'matches druids' do
+      expect(druid_regex).to match('druid:bc123df4567')
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

This will enable H2 to decouple from druid-tools: https://github.com/sul-dlss/happy-heron/blob/dbf2991b058bb668e74c26b00d49d287ac920882/lib/tasks/deposit.rake#L45

## How was this change tested? 🤨
ci

