### PR TITLE
DOI schema gets exceptions for 5 hydrus identiiers

### DIFF
--- a/lib/cocina/models/doi_exceptions.rb
+++ b/lib/cocina/models/doi_exceptions.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     DoiExceptions = Types::String.constrained(
-      format: %r{^10\.(25740/(VA90-CT15|syxa-m256|12qf-5243|65j8-6114)|25936/629T-BX79)$}i
+      format: %r{^10\.(25740/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936/629[tT]-[bB][xX]79)$}i
     )
   end
 end

--- a/lib/cocina/models/doi_exceptions.rb
+++ b/lib/cocina/models/doi_exceptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    DoiExceptions = Types::String.constrained(
+      format: %r{^10\.(25740/(VA90-CT15|syxa-m256|12qf-5243|65j8-6114)|25936/629T-BX79)$}i
+    )
+  end
+end

--- a/lib/cocina/models/doi_pattern.rb
+++ b/lib/cocina/models/doi_pattern.rb
@@ -2,7 +2,7 @@
 
 module Cocina
   module Models
-    DOI = Types::String.constrained(
+    DoiPattern = Types::String.constrained(
       format: %r{^10\.(25740|80343)/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}i
     )
   end

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -7,8 +7,7 @@ module Cocina
       attribute? :barcode, Types::Nominal::Any
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
-      # example: 10.25740/bc123df4567
-      attribute? :doi, Types::Strict::String
+      attribute? :doi, Types::Nominal::Any
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026

--- a/openapi.yml
+++ b/openapi.yml
@@ -902,9 +902,9 @@ components:
         - $ref: '#/components/schemas/DoiExceptions'
     DoiExceptions:
       type: string
-      description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern
-      pattern: '^10\.(25740\/(VA90-CT15|syxa-m256|12qf-5243|65j8-6114)|25936\/629T-BX79)$'
-      example: '10.25740/12qf-5243'
+      description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern (case insensitive)
+      pattern: '^10\.(25740\/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936\/629[tT]-[bB][xX]79)$'
+      example: '10.25740/12qF-5243'
     DoiPattern:
       type: string
       description: Digital Object Identifier (https://www.doi.org) regex pattern

--- a/openapi.yml
+++ b/openapi.yml
@@ -896,8 +896,18 @@ components:
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
     DOI:
-      type: string
       description: Digital Object Identifier (https://www.doi.org)
+      oneOf:
+        - $ref: '#/components/schemas/DoiPattern'
+        - $ref: '#/components/schemas/DoiExceptions'
+    DoiExceptions:
+      type: string
+      description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern
+      pattern: '^10\.(25740\/(VA90-CT15|syxa-m256|12qf-5243|65j8-6114)|25936\/629T-BX79)$'
+      example: '10.25740/12qf-5243'
+    DoiPattern:
+      type: string
+      description: Digital Object Identifier (https://www.doi.org) regex pattern
       # The prod and test prefixes are permitted
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
       example: '10.25740/bc123df4567'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

Adds DOI exceptions (from H2 work) to the DOI schema.

Part of #512

## How was this change tested? 🤨

rubular

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



