### PR TITLE
appease rubocop overlords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -311,3 +311,28 @@ Style/RedundantInitialize: # new in 1.27
   Enabled: true
 RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
+
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11.0
+  Enabled: true
+RSpec/Capybara/SpecificMatcher: # new in 2.12
+  Enabled: false
+RSpec/Rails/HaveHttpStatus: # new in 2.12
+  Enabled: false

--- a/spec/cocina/models/mapping/descriptive/mods/identifier_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/mods/identifier_spec.rb
@@ -254,16 +254,8 @@ RSpec.describe 'MODS identifier <--> cocina mappings' do
             <identifier/>
           XML
         end
-
-        let(:roundtrip_mods) do
-          <<~XML
-          XML
-        end
-
-        let(:cocina) do
-          {
-          }
-        end
+        let(:roundtrip_mods) { '' }
+        let(:cocina) { {} }
       end
     end
   end

--- a/spec/cocina/models/mapping/descriptive/mods/name_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/mods/name_spec.rb
@@ -2816,17 +2816,8 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           </name>
         XML
       end
-
-      let(:roundtrip_mods) do
-        <<~XML
-        XML
-      end
-
-      let(:cocina) do
-        {
-        }
-      end
-
+      let(:roundtrip_mods) { '' }
+      let(:cocina) { {} }
       let(:warnings) do
         [
           Notification.new(msg: 'name/namePart missing value'),
@@ -3095,17 +3086,8 @@ RSpec.describe 'MODS name <--> cocina mappings' do
             </name>
           XML
         end
-
-        let(:roundtrip_mods) do
-          <<~XML
-          XML
-        end
-
-        let(:cocina) do
-          {
-          }
-        end
-
+        let(:roundtrip_mods) { '' }
+        let(:cocina) { {} }
         let(:warnings) { [Notification.new(msg: 'Missing name/namePart element')] }
       end
     end

--- a/spec/cocina/models/mapping/descriptive/mods/note_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/mods/note_spec.rb
@@ -605,16 +605,8 @@ RSpec.describe 'MODS note <--> cocina mappings' do
             <note/>
           XML
         end
-
-        let(:roundtrip_mods) do
-          <<~XML
-          XML
-        end
-
-        let(:cocina) do
-          {
-          }
-        end
+        let(:roundtrip_mods) { '' }
+        let(:cocina) { {} }
       end
     end
   end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

because I got sick of seeing warnings for the new cops when generating schemas.

## How was this change tested? 🤨

changes are to rubocop.yml and 3 spec files;  CI build is sufficient

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



