### PR TITLE
Provide a temporary exemption for bad dates

### DIFF
--- a/lib/cocina/models/validators/date_time_validator.rb
+++ b/lib/cocina/models/validators/date_time_validator.rb
@@ -98,7 +98,9 @@ module Cocina
           #
           # So we catch the false positives from the upstream gem and allow
           # these two patterns to validate
-          /\A\d{4}(-0[1-9]|-1[0-2])?\Z/.match?(value)
+          #
+          # Also have a temporary exemption for MM/DD/YY
+          %r{\A((\d{4}(-0[1-9]|-1[0-2])?)|(\d{2}/\d{2}/\d{2}))\Z}.match?(value)
         end
 
         def druid

--- a/spec/cocina/models/validators/date_time_validator_spec.rb
+++ b/spec/cocina/models/validators/date_time_validator_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Cocina::Models::Validators::DateTimeValidator do
         ['w3cdtf', '1997-07-16T19:20+01:00', true],
         ['w3cdtf', '1997-07-16T19:20:30+01:00', true],
         ['w3cdtf', '1997-07-16T19:20:30.45+01:00', true],
+        ['w3cdtf', '09/14/07', true], # Temporary exemption for bad data
         # Type-specific cases
         ['edtf', '-3999', true],
         ['iso8601', '-3999', false],


### PR DESCRIPTION
When the date is coded as w3cdtf and the format is MM/DD/YY allow it for now.  

## Why was this change made? 🤔
We have bad data that doesn't work presently


## How was this change tested? 🤨
ci


