### PR TITLE
edtf validation as it should be

### DIFF
--- a/lib/cocina/models/validators/date_time_validator.rb
+++ b/lib/cocina/models/validators/date_time_validator.rb
@@ -76,8 +76,7 @@ module Cocina
           #
           # So we catch the false positives from the upstream gem and allow
           # this pattern to validate
-          /\AY-?\d{5,}\Z/.match?(value) ||
-            /\A-?\d{1,3}\Z/.match?(value) # temporarily allow format violations
+          /\AY-?\d{5,}\Z/.match?(value)
         end
 
         def valid_iso8601?(value)

--- a/spec/cocina/models/validators/date_time_validator_spec.rb
+++ b/spec/cocina/models/validators/date_time_validator_spec.rb
@@ -85,9 +85,9 @@ RSpec.describe Cocina::Models::Validators::DateTimeValidator do
         ['edtf', 'Y-20555', true],
         ['edtf', 'Y20555', true],
         ['edtf', '0800', true],
-        ['edtf', '800', true], # temporary exception for format violation
-        ['edtf', '-800', true], # temporary exception for format violation
-        ['edtf', '1', true], # temporary exception for format violation
+        ['edtf', '800', false],
+        ['edtf', '-800', false],
+        ['edtf', '1', false],
         ['edtf', '20220608', false],
         ['edtf', '20220608T1204', false],
         ['edtf', '20220608T120435', false],


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

edtf dates now all pass strict validation;  this PR removes the temporary allowance of some format violations.

## How was this change tested? 🤨

Ran reports on edtf dates.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



