### PR TITLE
Remove lies

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1459,7 +1459,7 @@ components:
           description: Width in pixels
           type: integer
     Purl:
-      description: Stanford persistent URL associated with the related resource. Note this is http, not https.
+      description: Stanford persistent URL associated with the related resource.
       type: string
       format: uri
       # Canonical URI is https


### PR DESCRIPTION



## Why was this change made? 🤔

It's important to have a low lie to truth ratio in the documentation. This documentation was contradicting the regex pattern


## How was this change tested? 🤨
🤷 


