### PR TITLE
improve efficiency of object type detection

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -148,9 +148,13 @@ module Cocina
     end
 
     def self.type_for(dyn)
-      dyn.with_indifferent_access.fetch('type')
-    rescue KeyError
-      raise ValidationError, 'Type field not found'
+      # Intentionally checking both string- and symbol-type keys in the hash via `#[]`
+      #  instead of `#with_indifferent_access` (and/or `#fetch`) in order to be more memory-efficient
+      object_type = dyn[:type] || dyn['type']
+
+      raise(ValidationError, 'Type field not found') unless object_type
+
+      object_type
     end
     private_class_method :type_for
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/common-accessioning/issues/1005, which is timeouts on a large object.

Experimentation as shown in that ticket has demonstrated that for very large cocina objects (which in DSA are manipulated as in memory hashes), the detection of object type may not be very efficient due to the use of both the rails method `with_indifferent_access` (this makes a full copy of the giant hash in memory and returns a new object) and `fetch` (also possibly makes a copy of the hash based on console output).  Neither of these are really necessary, we can simply inspect the hash directly for the key and raise as needed.

While I did not characterize the actual performance/memory improvements achieved by this refactor (may only be a few seconds even for very large object), this method is also well tested, so seems low risk.

## How was this change tested? 🤨

Existing specs (which cover this method well).
