### PR TITLE
Change to subject identifier mapping to mods.

### DIFF
--- a/lib/cocina/models/mapping/to_mods/subject.rb
+++ b/lib/cocina/models/mapping/to_mods/subject.rb
@@ -433,7 +433,11 @@ module Cocina
 
           def write_identifier(identifiers)
             identifiers.each do |identifier|
-              xml.nameIdentifier identifier.value, type: identifier.source.code
+              if identifier.uri.present?
+                xml.nameIdentifier identifier.uri
+              elsif identifier.value.present? || identifier.code.present?
+                xml.nameIdentifier identifier&.value || identifier&.code, type: identifier.source&.code || identifier.source&.uri || identifier.source&.value
+              end
             end
           end
 

--- a/spec/cocina/models/mapping/to_mods/subject_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/subject_spec.rb
@@ -304,4 +304,73 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Subject do
       XML
     end
   end
+
+  context 'when it has a name subject with an identifier uri' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          { value: 'Genu, Fetras',
+            type: 'person',
+            identifier: [
+              {
+                uri: 'https://www.wikidata.org/wiki/Q99810743'
+              }
+            ],
+            source: {
+              code: 'wikidata'
+            } }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="wikidata">
+          <name type="personal">
+             <namePart>Genu, Fetras</namePart>
+             <nameIdentifier>https://www.wikidata.org/wiki/Q99810743</nameIdentifier>
+          </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when it has a name subject with an identifier value' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          { type: 'person',
+            value: 'Kleinschmidt, Angeline',
+            identifier: [
+              {
+                value: 'https://www.wikidata.org/wiki/Q99810910',
+                type: 'Wikidata',
+                source: {
+                  code: 'wikidata'
+                }
+              }
+            ] }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name type="personal">
+              <namePart>Kleinschmidt, Angeline</namePart>
+              <nameIdentifier type="wikidata">https://www.wikidata.org/wiki/Q99810910</nameIdentifier>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Resolves #538 to handle different subject name identifier fields in mapping to MODS. 


## How was this change tested? 🤨
Added a spec and ran unit tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



