### PR TITLE
Assume OpenAPI patterns are meant to be case-sensitive

### DIFF
--- a/lib/cocina/generator/datatype.rb
+++ b/lib/cocina/generator/datatype.rb
@@ -11,7 +11,7 @@ module Cocina
           module Cocina
             module Models
               #{name} = Types::String.constrained(
-                format: /#{schema_doc.pattern}/i
+                format: /#{schema_doc.pattern}/
               )
             end
           end

--- a/lib/cocina/models/business_barcode.rb
+++ b/lib/cocina/models/business_barcode.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     BusinessBarcode = Types::String.constrained(
-      format: /^2050[0-9]{7}$/i
+      format: /^2050[0-9]{7}$/
     )
   end
 end

--- a/lib/cocina/models/catkey_barcode.rb
+++ b/lib/cocina/models/catkey_barcode.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     CatkeyBarcode = Types::String.constrained(
-      format: /^[0-9]+-[0-9]+$/i
+      format: /^[0-9]+-[0-9]+$/
     )
   end
 end

--- a/lib/cocina/models/cocina_version.rb
+++ b/lib/cocina/models/cocina_version.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     CocinaVersion = Types::String.constrained(
-      format: /^\d+\.\d+\.\d+$/i
+      format: /^\d+\.\d+\.\d+$/
     )
   end
 end

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -20,7 +20,7 @@ module Cocina
       attribute? :adminMetadata, DescriptiveAdminMetadata.optional
       # URL or other pointer to the location of the resource description.
       attribute? :valueAt, Types::Strict::String
-      # Stanford persistent URL associated with the related resource. Note this is http, not https.
+      # Stanford persistent URL associated with the related resource.
       attribute :purl, Types::Strict::String
     end
   end

--- a/lib/cocina/models/doi_exceptions.rb
+++ b/lib/cocina/models/doi_exceptions.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     DoiExceptions = Types::String.constrained(
-      format: %r{^10\.(25740/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936/629[tT]-[bB][xX]79)$}i
+      format: %r{^10\.(25740/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936/629[tT]-[bB][xX]79)$}
     )
   end
 end

--- a/lib/cocina/models/doi_pattern.rb
+++ b/lib/cocina/models/doi_pattern.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     DoiPattern = Types::String.constrained(
-      format: %r{^10\.(25740|80343)/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}i
+      format: %r{^10\.(25740|80343)/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$}
     )
   end
 end

--- a/lib/cocina/models/druid.rb
+++ b/lib/cocina/models/druid.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     Druid = Types::String.constrained(
-      format: /^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$/i
+      format: /^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$/
     )
   end
 end

--- a/lib/cocina/models/lane_medical_barcode.rb
+++ b/lib/cocina/models/lane_medical_barcode.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     LaneMedicalBarcode = Types::String.constrained(
-      format: /^245[0-9]{8}$/i
+      format: /^245[0-9]{8}$/
     )
   end
 end

--- a/lib/cocina/models/purl.rb
+++ b/lib/cocina/models/purl.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     Purl = Types::String.constrained(
-      format: %r{^https://}i
+      format: %r{^https://}
     )
   end
 end

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -19,7 +19,7 @@ module Cocina
       attribute :identifier, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute? :standard, Standard.optional
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
-      # Stanford persistent URL associated with the related resource. Note this is http, not https.
+      # Stanford persistent URL associated with the related resource.
       attribute? :purl, Types::Strict::String
       attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)

--- a/lib/cocina/models/source_id.rb
+++ b/lib/cocina/models/source_id.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     SourceId = Types::String.constrained(
-      format: /^.+:.+$/i
+      format: /^.+:.+$/
     )
   end
 end

--- a/lib/cocina/models/standard_barcode.rb
+++ b/lib/cocina/models/standard_barcode.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     StandardBarcode = Types::String.constrained(
-      format: /^36105[0-9]{9}$/i
+      format: /^36105[0-9]{9}$/
     )
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to #561

Because catalog record regexes are case-sensitive and, AFAICT, none of our current regexes should be case-insensitive.


## How was this change tested? 🤨

CI and tested against all QA objects, all stage objects, and 1M prod objects on sdr-infra.
