### PR TITLE
Allow generators to create and use custom types and union types

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module Cocina
   module Generator
     # Class for generating Cocina models from openapi.
-    class Generator < Thor
+    class Generator < Thor # rubocop:disable Metrics/ClassLength
       include Thor::Actions
 
       class_option :openapi, desc: 'Path of openapi.yml', default: 'openapi.yml'
@@ -100,9 +100,13 @@ module Cocina
 
         case schema_doc.type
         when 'object'
-          Schema.new(schema_doc)
+          Schema.new(schema_doc, schemas: schemas.keys)
         when 'string'
-          Datatype.new(schema_doc)
+          Datatype.new(schema_doc, schemas: schemas.keys)
+        when NilClass
+          return unless schema_doc.one_of.map(&:name).all? { |ref_schema_name| schemas.keys.include?(ref_schema_name) }
+
+          UnionType.new(schema_doc)
         end
       end
 

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -111,7 +111,8 @@ module Cocina
                                                    # different oneOf schemas. Validation is still performed
                                                    # by openAPI.
                                                    relaxed: true,
-                                                   parent: self)
+                                                   parent: self,
+                                                   schemas: schemas)
           end
         end
       end
@@ -122,7 +123,8 @@ module Cocina
                                                  key: key,
                                                  required: doc.requires?(key),
                                                  nullable: properties_doc.nullable?,
-                                                 parent: self)
+                                                 parent: self,
+                                                 schemas: schemas)
         end
       end
     end

--- a/lib/cocina/generator/schema_array.rb
+++ b/lib/cocina/generator/schema_array.rb
@@ -9,7 +9,7 @@ module Cocina
       end
 
       def array_of_type
-        schema_doc.items.name || "Types::#{dry_datatype(schema_doc.items)}"
+        schema_doc.items.name || dry_datatype(schema_doc.items)
       end
     end
   end

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -4,15 +4,16 @@ module Cocina
   module Generator
     # Base class for generating from openapi
     class SchemaBase
-      attr_reader :schema_doc, :key, :required, :nullable, :parent, :relaxed
+      attr_reader :schema_doc, :key, :required, :nullable, :parent, :relaxed, :schemas
 
-      def initialize(schema_doc, key: nil, required: false, nullable: false, parent: nil, relaxed: false)
+      def initialize(schema_doc, key: nil, required: false, nullable: false, parent: nil, relaxed: false, schemas: [])
         @schema_doc = schema_doc
         @key = key
         @required = required
         @nullable = nullable
         @parent = parent
         @relaxed = relaxed
+        @schemas = schemas
       end
 
       def filename
@@ -60,7 +61,7 @@ module Cocina
       end
 
       def dry_datatype(doc)
-        return doc.name if doc.name.present? && Cocina::Models.const_defined?(doc.name)
+        return doc.name if doc.name.present? && schemas.include?(doc.name)
 
         datatype_from_doc_type(doc) ||
           datatype_from_doc_names(doc) ||
@@ -91,7 +92,7 @@ module Cocina
       end
 
       def defined_datatypes?(doc)
-        doc.one_of&.map(&:name).all? { |name| name.present? && Cocina::Models.const_defined?(name) }
+        doc.one_of&.map(&:name).all? { |name| name.present? && schemas.include?(name) }
       end
 
       def any_datatype?(doc)

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -16,7 +16,7 @@ module Cocina
       private
 
       def type
-        "Types::#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}"
+        "#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}"
       end
 
       def enum
@@ -33,7 +33,7 @@ module Cocina
 
       def default
         # Provide version as default for cocinaVersion
-        return '.default(Cocina::Models::VERSION)' if name == 'cocinaVersion'
+        return '.default(VERSION)' if name == 'cocinaVersion'
 
         # If type is boolean and default is false, erroneously getting a nil.
         # Assuming that if required, then default is false.

--- a/lib/cocina/generator/union_type.rb
+++ b/lib/cocina/generator/union_type.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Generator
+    # Class for generating a union type
+    class UnionType < SchemaBase
+      def generate
+        <<~RUBY
+          # frozen_string_literal: true
+
+          module Cocina
+            module Models
+              #{name} = #{type_names}
+            end
+          end
+        RUBY
+      end
+
+      def type_names
+        schema_doc.one_of.map(&:name).join(' | ')
+      end
+    end
+  end
+end

--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -11,10 +11,10 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       attribute :type, Types::Strict::String.enum(*AdminPolicy::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })

--- a/lib/cocina/models/admin_policy_administrative.rb
+++ b/lib/cocina/models/admin_policy_administrative.rb
@@ -11,9 +11,9 @@ module Cocina
       attribute? :disseminationWorkflow, Types::Strict::String
       attribute :collectionsForRegistration, Types::Strict::Array.of(Types::Strict::String).default([].freeze)
       # example: druid:bc123df4567
-      attribute :hasAdminPolicy, Types::Strict::String
+      attribute :hasAdminPolicy, Druid
       # example: druid:bc123df4567
-      attribute :hasAgreement, Types::Strict::String
+      attribute :hasAgreement, Druid
       attribute :roles, Types::Strict::Array.of(AccessRole).default([].freeze)
     end
   end

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -12,10 +12,10 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       attribute :type, Types::Strict::String.enum(*AdminPolicyWithMetadata::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })

--- a/lib/cocina/models/administrative.rb
+++ b/lib/cocina/models/administrative.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class Administrative < Struct
       # example: druid:bc123df4567
-      attribute :hasAdminPolicy, Types::Strict::String
+      attribute :hasAdminPolicy, Druid
       attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
     end
   end

--- a/lib/cocina/models/barcode.rb
+++ b/lib/cocina/models/barcode.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    Barcode = BusinessBarcode | LaneMedicalBarcode | CatkeyBarcode | StandardBarcode
+  end
+end

--- a/lib/cocina/models/catalog_link.rb
+++ b/lib/cocina/models/catalog_link.rb
@@ -10,7 +10,7 @@ module Cocina
       attribute :refresh, Types::Strict::Bool.default(false)
       # Record identifier that is unique within the context of the linked record's catalog.
       # example: 11403803
-      attribute :catalogRecordId, Types::Strict::String
+      attribute :catalogRecordId, Types::Strict::String.constrained(format: /^\d+(:\d+)*$/)
     end
   end
 end

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -16,11 +16,11 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       # The content type of the Collection. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*Collection::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a Collection.
       attribute :label, Types::Strict::String
       # Version for the Collection within SDR.

--- a/lib/cocina/models/collection_identification.rb
+++ b/lib/cocina/models/collection_identification.rb
@@ -7,7 +7,7 @@ module Cocina
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
-      attribute? :sourceId, Types::Strict::String
+      attribute? :sourceId, SourceId
     end
   end
 end

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -16,11 +16,11 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       # The content type of the Collection. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*CollectionWithMetadata::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a Collection.
       attribute :label, Types::Strict::String
       # Version for the Collection within SDR.

--- a/lib/cocina/models/description.rb
+++ b/lib/cocina/models/description.rb
@@ -21,7 +21,7 @@ module Cocina
       # URL or other pointer to the location of the resource description.
       attribute? :valueAt, Types::Strict::String
       # Stanford persistent URL associated with the related resource.
-      attribute :purl, Types::Strict::String
+      attribute :purl, Purl
     end
   end
 end

--- a/lib/cocina/models/doi.rb
+++ b/lib/cocina/models/doi.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    DOI = DoiPattern | DoiExceptions
+  end
+end

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -26,11 +26,11 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       # The content type of the DRO. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*DRO::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a DRO.
       attribute :label, Types::Strict::String
       # Version for the DRO within SDR.

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -26,11 +26,11 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       # The content type of the DRO. Selected from an established set of values.
       attribute :type, Types::Strict::String.enum(*DROWithMetadata::TYPES)
       # example: druid:bc123df4567
-      attribute :externalIdentifier, Types::Strict::String
+      attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a DRO.
       attribute :label, Types::Strict::String
       # Version for the DRO within SDR.

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -4,10 +4,10 @@ module Cocina
   module Models
     class Identification < Struct
       # A barcode
-      attribute? :barcode, Types::Nominal::Any
+      attribute? :barcode, Barcode
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
-      attribute? :doi, Types::Nominal::Any
+      attribute? :doi, DOI
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -11,7 +11,7 @@ module Cocina
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
-      attribute :sourceId, Types::Strict::String
+      attribute :sourceId, SourceId
     end
   end
 end

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -20,7 +20,7 @@ module Cocina
       attribute? :standard, Standard.optional
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Stanford persistent URL associated with the related resource.
-      attribute? :purl, Types::Strict::String
+      attribute? :purl, Purl
       attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)
       attribute? :adminMetadata, DescriptiveAdminMetadata.optional

--- a/lib/cocina/models/request_admin_policy.rb
+++ b/lib/cocina/models/request_admin_policy.rb
@@ -12,7 +12,7 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       attribute :type, Types::Strict::String.enum(*RequestAdminPolicy::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)

--- a/lib/cocina/models/request_administrative.rb
+++ b/lib/cocina/models/request_administrative.rb
@@ -4,7 +4,7 @@ module Cocina
   module Models
     class RequestAdministrative < Struct
       # example: druid:bc123df4567
-      attribute :hasAdminPolicy, Types::Strict::String
+      attribute :hasAdminPolicy, Druid
       attribute :releaseTags, Types::Strict::Array.of(ReleaseTag).default([].freeze)
       # Internal project this resource is a part of. This governs routing of messages about this object.
       # example: Google Books

--- a/lib/cocina/models/request_collection.rb
+++ b/lib/cocina/models/request_collection.rb
@@ -16,7 +16,7 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       attribute :type, Types::Strict::String.enum(*RequestCollection::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)

--- a/lib/cocina/models/request_dro.rb
+++ b/lib/cocina/models/request_dro.rb
@@ -26,7 +26,7 @@ module Cocina
 
       # The version of Cocina with which this object conforms.
       # example: 1.2.3
-      attribute :cocinaVersion, Types::Strict::String.default(Cocina::Models::VERSION)
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
       attribute :type, Types::Strict::String.enum(*RequestDRO::TYPES)
       attribute :label, Types::Strict::String
       attribute :version, Types::Strict::Integer.default(1).enum(1)

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -5,7 +5,7 @@ module Cocina
     # Same as a Identification, but requires a sourceId and doesn't permit a DOI.
     class RequestIdentification < Struct
       # A barcode
-      attribute? :barcode, Types::Nominal::Any
+      attribute? :barcode, Barcode
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -10,7 +10,7 @@ module Cocina
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
-      attribute :sourceId, Types::Strict::String
+      attribute :sourceId, SourceId
     end
   end
 end

--- a/spec/cocina/generator/generator_spec.rb
+++ b/spec/cocina/generator/generator_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Cocina::Generator::Generator do
     expect(File.exist?('lib/cocina/models/request_dro.rb')).to be true
   end
 
+  it 'generates union types' do
+    expect(File).to exist('lib/cocina/models/barcode.rb')
+    expect(File).to exist('lib/cocina/models/doi.rb')
+  end
+
   it 'leaves files alone' do
     expect(File.exist?('lib/cocina/models/version.rb')).to be true
     expect(File.exist?('lib/cocina/models/checkable.rb')).to be true

--- a/spec/cocina/generator/schema_spec.rb
+++ b/spec/cocina/generator/schema_spec.rb
@@ -83,6 +83,28 @@ RSpec.describe Cocina::Generator::Schema do
     end
   end
 
+  context 'when schema references another custom type' do
+    let(:policy) do
+      Cocina::Models::AdminPolicy.new(
+        {
+          externalIdentifier: 'druid:iaminvalid',
+          label: 'My admin policy',
+          type: Cocina::Models::ObjectType.admin_policy,
+          version: 1,
+          administrative: {
+            hasAdminPolicy: 'druid:bc123df4567',
+            hasAgreement: 'druid:bc123df4567',
+            accessTemplate: {}
+          }
+        }, false, false
+      )
+    end
+
+    it 'does not validate' do
+      expect { policy }.to raise_error(Dry::Struct::Error)
+    end
+  end
+
   context 'when validatable' do
     # A model is validatable when there is a validation path in the openapi. For example, /validate/AdminPolicy
     # Its initializer then accepts a third argument which indicates whether to validate.
@@ -106,6 +128,14 @@ RSpec.describe Cocina::Generator::Schema do
 
     it 'cannot be validated' do
       expect { administrative }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when property has a pattern and data does not match pattern' do
+    let(:catalog_link) { Cocina::Models::CatalogLink.new({ catalog: 'symphony', catalogRecordId: 'foobar' }) }
+
+    it 'cannot be validated' do
+      expect { catalog_link }.to raise_error(Dry::Struct::Error)
     end
   end
 end

--- a/spec/cocina/models/validators/open_api_validator_spec.rb
+++ b/spec/cocina/models/validators/open_api_validator_spec.rb
@@ -119,6 +119,64 @@ RSpec.describe Cocina::Models::Validators::OpenApiValidator do
     end
   end
 
+  describe 'union types' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'My item',
+        type: Cocina::Models::ObjectType.object,
+        version: 1,
+        description: {
+          title: [{ value: 'Test DRO' }],
+          purl: 'https://purl.stanford.edu/bc123df4567'
+        },
+        administrative: {
+          hasAdminPolicy: 'druid:bc123df4567'
+        },
+        access: {},
+        identification: {
+          barcode: barcode,
+          sourceId: 'sul:123'
+        },
+        structural: {}
+      }
+    end
+
+    let(:clazz) { Cocina::Models::DRO }
+
+    context 'with a business barcode' do
+      let(:barcode) { '20501234567' }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'with a lane medical barcode' do
+      let(:barcode) { '24512345678' }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'with a catkey barcode' do
+      let(:barcode) { '12345-67890' }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'with a standard barcode' do
+      let(:barcode) { '36105123456789' }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+
   context 'when invalid' do
     let(:props) do
       {


### PR DESCRIPTION
## Why was this change made? 🤔

These commits change the Ruby models so that they are working more by reference and less by value, e.g., instead of having the druid regex in every model that has an `externalIdentifier`, point every `externalIdentifier` at the `Druid` model and let the model handle the validation.

Currently the models handle validation through a combination of validating against the OpenAPI spec and using the generated Ruby (dry-) types, and this commit adds a bit more smarts and descriptive oomph to the Ruby side.

A separate commit moves yet more smarts into the Ruby (dry-) types, allowing them to make use of union types defined in the OpenAPI spec, such as for barcodes and DOIs. This sets up a follow-on commit around Symphony and Folio catalog links which will similarly use union types.

## How was this change tested? 🤨

CI & tested against QA, stage, and 100K prod records on `sdr-infra`
