### PR TITLE
Allow non-required custom types to be optional

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -392,3 +392,5 @@ RSpec/Rails/InferredSpecType: # new in 2.14
   Enabled: true
 RSpec/Rails/MinitestAssertions: # new in 2.17
   Enabled: true
+Style/RedundantHeredocDelimiterQuotes: # new in 1.45
+  Enabled: true

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -24,10 +24,16 @@ module Cocina
         key || schema_doc.name
       end
 
-      # Allows nillable values to be set to nil. This is useful when doing
-      # an update and you want to clear out a value.
+      # Allows nullable values to be set to nil. This is useful when doing an
+      # update and you want to clear out a value. The logic also permits custom
+      # types (e.g., `Barcode`, `SourceId`) to be nullable if they are not
+      # required.
       def optional
-        nullable || relaxed ? '.optional' : ''
+        return '.optional' if nullable ||
+                              relaxed ||
+                              (custom_type? && !required)
+
+        ''
       end
 
       def quote(item)
@@ -58,6 +64,11 @@ module Cocina
         return '' unless relaxed
 
         "# Validation of this property is relaxed. See the openapi for full validation.\n"
+      end
+
+      # dry-types-based types contain the word `Types` (e.g., `Types::String`), and custom types (e.g., `SourceId`) do not
+      def custom_type?
+        !dry_datatype(schema_doc).match?('Types')
       end
 
       def dry_datatype(doc)

--- a/lib/cocina/generator/schema_value.rb
+++ b/lib/cocina/generator/schema_value.rb
@@ -5,7 +5,6 @@ module Cocina
     # Class for generating from an openapi value
     class SchemaValue < SchemaBase
       def generate
-        # optional has to come before default or the default value that gets set will be nil.
         if required && !relaxed
           "#{preamble}attribute :#{name.camelize(:lower)}, #{type}"
         else
@@ -16,6 +15,7 @@ module Cocina
       private
 
       def type
+        # optional has to come before default or the default value that gets set will be nil.
         "#{dry_datatype(schema_doc)}#{optional}#{default}#{enum}"
       end
 

--- a/lib/cocina/models/collection_identification.rb
+++ b/lib/cocina/models/collection_identification.rb
@@ -7,7 +7,7 @@ module Cocina
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026
-      attribute? :sourceId, SourceId
+      attribute? :sourceId, SourceId.optional
     end
   end
 end

--- a/lib/cocina/models/identification.rb
+++ b/lib/cocina/models/identification.rb
@@ -4,10 +4,10 @@ module Cocina
   module Models
     class Identification < Struct
       # A barcode
-      attribute? :barcode, Barcode
+      attribute? :barcode, Barcode.optional
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Digital Object Identifier (https://www.doi.org)
-      attribute? :doi, DOI
+      attribute? :doi, DOI.optional
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 
       # example: sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026

--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -20,7 +20,7 @@ module Cocina
       attribute? :standard, Standard.optional
       attribute :subject, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       # Stanford persistent URL associated with the related resource.
-      attribute? :purl, Purl
+      attribute? :purl, Purl.optional
       attribute? :access, DescriptiveAccessMetadata.optional
       attribute :relatedResource, Types::Strict::Array.of(RelatedResource).default([].freeze)
       attribute? :adminMetadata, DescriptiveAdminMetadata.optional

--- a/lib/cocina/models/request_identification.rb
+++ b/lib/cocina/models/request_identification.rb
@@ -5,7 +5,7 @@ module Cocina
     # Same as a Identification, but requires a sourceId and doesn't permit a DOI.
     class RequestIdentification < Struct
       # A barcode
-      attribute? :barcode, Barcode
+      attribute? :barcode, Barcode.optional
       attribute :catalogLinks, Types::Strict::Array.of(CatalogLink).default([].freeze)
       # Unique identifier in some other system. This is because a large proportion of what is deposited in SDR, historically and currently, are representations of objects that are also represented in other systems. For example, digitized paper and A/V collections have physical manifestations, and those physical objects are managed in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
 

--- a/spec/cocina/generator/schema_value_spec.rb
+++ b/spec/cocina/generator/schema_value_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe Cocina::Generator::SchemaValue do
         expect(access.download).to eq 'none'
       end
     end
+
+    context 'when property is custom' do
+      let(:identification) { Cocina::Models::Identification.new(sourceId: 'foo:bar', barcode: '36105123456789') }
+      let(:updated_identification) { identification.new(barcode: nil) }
+
+      it 'allows nulling the property' do
+        expect(updated_identification.barcode).to be_nil
+      end
+    end
   end
 
   context 'when property is nullable' do


### PR DESCRIPTION
## Why was this change made? 🤔

Custom types in Ruby models used to be "any" types, which allow null values. This change allows e.g. barcodes to be nulled out or reset. I discovered this deficiency in the models while rolling out cocina-models 0.87.0, and patched around it: https://github.com/sul-dlss/argo/blob/main/app/services/item_change_set_persister.rb#L134-L143. This cocina-models patch will allow the prior behavior of being able to reset these custom type values when the attribute is not required by adding logic around determining optionality.



## How was this change tested? 🤨

- [X] CI 
- [X] `sdr-infra`, against full QA dataset
- [X] `sdr-infra`, against full stage dataset
- [X] `sdr-infra`, against 500K prod dataset
