### PR TITLE
Remove exclusion of latest Rubocop version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     rss (0.2.9)
       rexml
-    rubocop (1.53.1)
+    rubocop (1.54.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -159,7 +159,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter
-  rubocop (~> 1.24, != 1.54.0)
+  rubocop (~> 1.24)
   rubocop-rake
   rubocop-rspec (~> 2.1)
   simplecov

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'committee'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 1.24', '!= 1.54.0' # 1.54.0 breaks the build
+  spec.add_development_dependency 'rubocop', '~> 1.24'
   spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.1'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
# Why was this change made? 🤔

Now that the latest Rubocop version no longer breaks the build, stop carrying the exclusion in the gemspec. Keep pace with dependencies.

# How was this change tested? 🤨

CI
