### PR TITLE
Adds support for lite (relaxed, unvalidated) models.

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -24,6 +24,11 @@ module Cocina
           generate_for(schema) if schema
         end
 
+        %w[DRO Collection AdminPolicy].each do |schema_name|
+          schema = schema_for(schema_name, lite: true)
+          filepaths << generate_for(schema)
+        end
+
         auto_format(filepaths)
         generate_vocab
         generate_descriptive_docs
@@ -94,13 +99,13 @@ module Cocina
         @schemas ||= Openapi3Parser.load_file(options[:openapi]).components.schemas
       end
 
-      def schema_for(schema_name)
+      def schema_for(schema_name, lite: false)
         schema_doc = schemas[schema_name]
         return nil if schema_doc.nil?
 
         case schema_doc.type
         when 'object'
-          Schema.new(schema_doc, schemas: schemas.keys)
+          Schema.new(schema_doc, schemas: schemas.keys, lite: lite)
         when 'string'
           Datatype.new(schema_doc, schemas: schemas.keys)
         when NilClass

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -71,7 +71,7 @@ module Cocina
       end
 
       def validatable?
-        !schema_doc.node_context.document.paths["/validate/#{schema_doc.name}"].nil?
+        !schema_doc.node_context.document.paths["/validate/#{schema_doc.name}"].nil? && !lite
       end
 
       def properties
@@ -119,12 +119,14 @@ module Cocina
 
       def schema_properties_for(doc)
         doc.properties.map do |key, properties_doc|
-          property_class_for(properties_doc).new(properties_doc,
-                                                 key: key,
-                                                 required: doc.requires?(key),
-                                                 nullable: properties_doc.nullable?,
-                                                 parent: self,
-                                                 schemas: schemas)
+          clazz = property_class_for(properties_doc)
+          clazz.new(properties_doc,
+                    key: key,
+                    required: doc.requires?(key),
+                    relaxed: lite && clazz != SchemaValue,
+                    nullable: properties_doc.nullable?,
+                    parent: self,
+                    schemas: schemas)
         end
       end
     end

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -4,9 +4,9 @@ module Cocina
   module Generator
     # Base class for generating from openapi
     class SchemaBase
-      attr_reader :schema_doc, :key, :required, :nullable, :parent, :relaxed, :schemas
+      attr_reader :schema_doc, :key, :required, :nullable, :parent, :relaxed, :schemas, :lite
 
-      def initialize(schema_doc, key: nil, required: false, nullable: false, parent: nil, relaxed: false, schemas: [])
+      def initialize(schema_doc, key: nil, required: false, nullable: false, parent: nil, relaxed: false, schemas: [], lite: false)
         @schema_doc = schema_doc
         @key = key
         @required = required
@@ -14,6 +14,7 @@ module Cocina
         @parent = parent
         @relaxed = relaxed
         @schemas = schemas
+        @lite = lite
       end
 
       def filename
@@ -21,7 +22,7 @@ module Cocina
       end
 
       def name
-        key || schema_doc.name
+        "#{key || schema_doc.name}#{lite ? 'Lite' : ''}"
       end
 
       # Allows nullable values to be set to nil. This is useful when doing an

--- a/lib/cocina/models/admin_policy_lite.rb
+++ b/lib/cocina/models/admin_policy_lite.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    class AdminPolicyLite < Struct
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/admin_policy'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
+      attribute :type, Types::Strict::String.enum(*AdminPolicyLite::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Druid
+      attribute :label, Types::Strict::String
+      attribute :version, Types::Strict::Integer
+      attribute? :administrative, AdminPolicyAdministrative.optional
+      attribute? :description, Description.optional
+    end
+  end
+end

--- a/lib/cocina/models/collection_lite.rb
+++ b/lib/cocina/models/collection_lite.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
+    class CollectionLite < Struct
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/collection',
+               'https://cocina.sul.stanford.edu/models/curated-collection',
+               'https://cocina.sul.stanford.edu/models/user-collection',
+               'https://cocina.sul.stanford.edu/models/exhibit',
+               'https://cocina.sul.stanford.edu/models/series'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
+      # The content type of the Collection. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*CollectionLite::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Druid
+      # Primary processing label (can be same as title) for a Collection.
+      attribute :label, Types::Strict::String
+      # Version for the Collection within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute? :access, CollectionAccess.optional
+      attribute? :administrative, Administrative.optional
+      attribute? :description, Description.optional
+      attribute? :identification, CollectionIdentification.optional
+    end
+  end
+end

--- a/lib/cocina/models/dro_lite.rb
+++ b/lib/cocina/models/dro_lite.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
+    class DROLite < Struct
+      include Checkable
+
+      TYPES = ['https://cocina.sul.stanford.edu/models/object',
+               'https://cocina.sul.stanford.edu/models/3d',
+               'https://cocina.sul.stanford.edu/models/agreement',
+               'https://cocina.sul.stanford.edu/models/book',
+               'https://cocina.sul.stanford.edu/models/document',
+               'https://cocina.sul.stanford.edu/models/geo',
+               'https://cocina.sul.stanford.edu/models/image',
+               'https://cocina.sul.stanford.edu/models/page',
+               'https://cocina.sul.stanford.edu/models/photograph',
+               'https://cocina.sul.stanford.edu/models/manuscript',
+               'https://cocina.sul.stanford.edu/models/map',
+               'https://cocina.sul.stanford.edu/models/media',
+               'https://cocina.sul.stanford.edu/models/track',
+               'https://cocina.sul.stanford.edu/models/webarchive-binary',
+               'https://cocina.sul.stanford.edu/models/webarchive-seed'].freeze
+
+      # The version of Cocina with which this object conforms.
+      # example: 1.2.3
+      attribute :cocinaVersion, CocinaVersion.default(VERSION)
+      # The content type of the DRO. Selected from an established set of values.
+      attribute :type, Types::Strict::String.enum(*DROLite::TYPES)
+      # example: druid:bc123df4567
+      attribute :externalIdentifier, Druid
+      # Primary processing label (can be same as title) for a DRO.
+      attribute :label, Types::Strict::String
+      # Version for the DRO within SDR.
+      attribute :version, Types::Strict::Integer
+      attribute? :access, DROAccess.optional
+      attribute? :administrative, Administrative.optional
+      attribute? :description, Description.optional
+      attribute? :identification, Identification.optional
+      attribute? :structural, DROStructural.optional
+      attribute? :geographic, Geographic.optional
+    end
+  end
+end

--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -15,10 +15,13 @@ module Cocina
       SUPPORTED_TYPES = %i[
         admin_policy
         admin_policy_with_metadata
+        admin_policy_lite
         collection
         collection_with_metadata
+        collection_lite
         dro
         dro_with_metadata
+        dro_lite
         request_admin_policy
         request_collection
         request_dro
@@ -86,6 +89,10 @@ module Cocina
 
       def self.build_dro(attributes)
         Cocina::Models.build(build_dro_properties(**DRO_DEFAULTS.merge(attributes)))
+      end
+
+      def self.build_dro_lite(attributes)
+        Cocina::Models.build_lite(build_dro_properties(**DRO_DEFAULTS.merge(attributes)))
       end
 
       # rubocop:disable Metrics/ParameterLists
@@ -166,12 +173,20 @@ module Cocina
         Cocina::Models.build(build_collection_properties(**COLLECTION_DEFAULTS.merge(attributes)))
       end
 
+      def self.build_collection_lite(attributes)
+        Cocina::Models.build_lite(build_collection_properties(**COLLECTION_DEFAULTS.merge(attributes)))
+      end
+
       def self.build_request_collection(attributes)
         Cocina::Models.build_request(build_request_collection_properties(**REQUEST_COLLECTION_DEFAULTS.merge(attributes)))
       end
 
       def self.build_admin_policy(attributes)
         Cocina::Models.build(build_admin_policy_properties(**ADMIN_POLICY_DEFAULTS.merge(attributes)))
+      end
+
+      def self.build_admin_policy_lite(attributes)
+        Cocina::Models.build_lite(build_admin_policy_properties(**ADMIN_POLICY_DEFAULTS.merge(attributes)))
       end
 
       def self.build_request_admin_policy(attributes)

--- a/spec/cocina/generator/generator_spec.rb
+++ b/spec/cocina/generator/generator_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Cocina::Generator::Generator do
   it 'generates models for schemas' do
     expect(File.exist?('lib/cocina/models/dro.rb')).to be true
     expect(File.exist?('lib/cocina/models/request_dro.rb')).to be true
+    expect(File.exist?('lib/cocina/models/dro_lite.rb')).to be true
   end
 
   it 'generates union types' do

--- a/spec/cocina/generator/schema_spec.rb
+++ b/spec/cocina/generator/schema_spec.rb
@@ -167,4 +167,29 @@ RSpec.describe Cocina::Generator::Schema do
       end
     end
   end
+
+  describe 'lite schemas' do
+    context 'when validating' do
+      let(:dro) { Cocina::Models::DROLite.new({}, false, true) }
+
+      it 'cannot be validated' do
+        expect { dro }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when missing referenced attributes' do
+      let(:policy) do
+        Cocina::Models::AdminPolicyLite.new(
+          externalIdentifier: 'druid:bc123df4567',
+          label: 'My admin policy',
+          type: Cocina::Models::ObjectType.admin_policy,
+          version: 1
+        )
+      end
+
+      it 'is relaxed' do
+        expect(policy.administrative).to be_nil
+      end
+    end
+  end
 end

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -185,6 +185,64 @@ RSpec.describe Cocina::Models do
     end
   end
 
+  describe '.build_lite' do
+    subject(:model_build) { described_class.build_lite(data) }
+
+    context 'with a collection type' do
+      let(:data) { build(:collection).to_h }
+
+      it { is_expected.to be_a Cocina::Models::CollectionLite }
+    end
+
+    context 'with a DRO type' do
+      let(:data) { build(:dro).to_h }
+
+      it { is_expected.to be_a Cocina::Models::DROLite }
+    end
+
+    context 'with an AdminPolicy type' do
+      let(:data) { build(:admin_policy).to_h }
+
+      it { is_expected.to be_a Cocina::Models::AdminPolicyLite }
+    end
+
+    context 'with extra fields' do
+      let(:data) do
+        data = build(:dro).to_h
+        data[:extra] = 'field'
+        data
+      end
+
+      it { is_expected.to be_a Cocina::Models::DROLite }
+    end
+
+    context 'with keys as strings' do
+      let(:data) { build(:dro).to_h.deep_stringify_keys }
+
+      it { is_expected.to be_a Cocina::Models::DROLite }
+    end
+
+    context 'with an invalid type' do
+      let(:data) do
+        { 'type' => 'foo' }
+      end
+
+      it 'raises an error' do
+        expect { model_build }.to raise_error Cocina::Models::UnknownTypeError, "Unknown type: 'foo'"
+      end
+    end
+
+    context 'without a type' do
+      let(:data) do
+        {}
+      end
+
+      it 'raises an error' do
+        expect { model_build }.to raise_error Cocina::Models::ValidationError
+      end
+    end
+  end
+
   describe '.without_metadata' do
     subject(:cocina_object_without_metadata) { described_class.without_metadata(cocina_object) }
 


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Allow for only partially populated cocina models.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



