### PR TITLE
Update openapi_parser to match latest committee

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       jsonpath
       nokogiri
       openapi3_parser
-      openapi_parser (>= 0.11.1, < 1.0)
+      openapi_parser (~> 1.0)
       rss
       super_diff
       thor
@@ -29,9 +29,9 @@ GEM
     attr_extras (7.1.0)
     base64 (0.1.1)
     byebug (11.1.3)
-    committee (4.99.1)
+    committee (5.0.0)
       json_schema (~> 0.14, >= 0.14.3)
-      openapi_parser (>= 0.11.1, < 1.0)
+      openapi_parser (~> 1.0)
       rack (>= 1.5)
     commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
@@ -78,7 +78,7 @@ GEM
       racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
-    openapi_parser (0.15.0)
+    openapi_parser (1.0.0)
     optimist (3.1.0)
     parallel (1.23.0)
     parser (3.2.2.3)

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openapi3_parser' # Parsing openapi doc
   # Match these version requirements to what committee wants,
   # so that our client (non-committee) users have the same dependencies.
-  spec.add_dependency 'openapi_parser', '>= 0.11.1', '< 1.0'
+  spec.add_dependency 'openapi_parser', '~> 1.0'
   spec.add_dependency 'rss' # used for date/time validation
   spec.add_dependency 'super_diff'
   spec.add_dependency 'thor'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Update to latest to allow committee to be updated on gem consumers.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



