### PR TITLE
use safe navigator for temporal encoding code mapping, and 2 small refactors

### DIFF
--- a/lib/cocina/models/mapping/to_mods/form.rb
+++ b/lib/cocina/models/mapping/to_mods/form.rb
@@ -9,14 +9,14 @@ module Cocina
           # NOTE: H2 is the first case of structured form values we're implementing
           H2_SOURCE_LABEL = 'Stanford self-deposit resource types'
           PHYSICAL_DESCRIPTION_TAG = {
-            'reformatting quality' => :reformattingQuality,
-            'form' => :form,
-            'media type' => :internetMediaType,
-            'extent' => :extent,
-            'digital origin' => :digitalOrigin,
-            'media' => :form,
             'carrier' => :form,
+            'digital origin' => :digitalOrigin,
+            'extent' => :extent,
+            'form' => :form,
             'material' => :form,
+            'media' => :form,
+            'media type' => :internetMediaType,
+            'reformatting quality' => :reformattingQuality,
             'technique' => :form
           }.freeze
 
@@ -183,10 +183,7 @@ module Cocina
               attributes = {
                 unit: unit_for(form_value)
               }.tap do |attrs|
-                if PHYSICAL_DESCRIPTION_TAG.fetch(form_type) == :form && form_type != 'form'
-                  attrs[:type] =
-                    form_type
-                end
+                attrs[:type] = form_type if PHYSICAL_DESCRIPTION_TAG.fetch(form_type) == :form && form_type != 'form'
               end.compact
 
               xml.public_send PHYSICAL_DESCRIPTION_TAG.fetch(form_type), form_value.value,

--- a/lib/cocina/models/mapping/to_mods/subject.rb
+++ b/lib/cocina/models/mapping/to_mods/subject.rb
@@ -298,7 +298,7 @@ module Cocina
 
           def time_range(subject)
             subject.structuredValue.each do |point|
-              xml.temporal point.value, point: point.type, encoding: subject.encoding.code
+              xml.temporal point.value, point: point.type, encoding: subject.encoding&.code
             end
           end
 


### PR DESCRIPTION
~~NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.~~

## Why was this change made? 🤔

See PR #sul-dlss/dor_indexing_app/pull/993 which is failing because specs have nils where cocina-models doesn't expect them for xform to MODS.

It adds a safe navigator so our fragments of cocina in specs can be translated without error into MODS.

This accommodates dor_indexing_app using stanford-mods code for some Argo Solr index fields (so they are the same as SearchWorks index fields).   Part of #sul-dlss/dor_indexing_app/pull/992

## How was this change tested? 🤨

specs.



