### PR TITLE
mods mapping: avoid nil on name.value

### DIFF
--- a/lib/cocina/models/mapping/to_mods/event.rb
+++ b/lib/cocina/models/mapping/to_mods/event.rb
@@ -77,7 +77,7 @@ module Cocina
                 write_location(loc)
               end
               Array(names).each do |name|
-                xml.publisher name.value, name_attributes(name)
+                xml.publisher name.value, name_attributes(name) if name
               end
               Array(notes).each do |note|
                 write_note(note)


### PR DESCRIPTION
## Why was this change made? 🤔

dor_indexing_app was throwing errors due to conversion to MODS in cocina:

![image](https://github.com/sul-dlss/cocina-models/assets/96775/6549653c-769c-463f-bfbf-d53037fc2b7a)



## How was this change tested? 🤨

CI

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



