### PR TITLE
If an event note has a parallelValue, extract the data

### DIFF
--- a/lib/cocina/models/mapping/to_mods/event.rb
+++ b/lib/cocina/models/mapping/to_mods/event.rb
@@ -87,9 +87,15 @@ module Cocina
           # rubocop:enable Metrics/ParameterLists
 
           def write_note(note)
-            attributes = {}
-            attributes[:authority] = note.source.code if note&.source&.code
-            xml.send(note_tag_for(note), note.value, attributes)
+            if note.parallelValue.present?
+              note.parallelValue.each do |parallel_note|
+                write_note(parallel_note)
+              end
+            else
+              attributes = {}
+              attributes[:authority] = note.source.code if note&.source&.code
+              xml.send(note_tag_for(note), note.value, attributes)
+            end
           end
 
           def note_tag_for(note)

--- a/spec/cocina/models/mapping/to_mods/description_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/description_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Description do
     end
   end
 
-  context 'when it has an abstract' do
+  context 'when it has an abstract and frequency' do
     let(:druid) { 'druid:aa666bb1234' }
     let(:descriptive) do
       Cocina::Models::Description.new(
@@ -73,6 +73,21 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Description do
                 value: '1980'
               }
             ]
+          },
+          {
+            note: [
+              {
+                parallelValue: [
+                  {
+                    value: 'monthly',
+                    type: 'frequency'
+                  },
+                  {
+                    value: 'Another value'
+                  }
+                ]
+              }
+            ]
           }
         ]
       )
@@ -96,6 +111,10 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Description do
           </subject>
           <originInfo eventType="creation">
             <dateCreated>1980</dateCreated>
+          </originInfo>
+          <originInfo>
+            <frequency>monthly</frequency>
+            <edition>Another value</edition>
           </originInfo>
           <location>
             <url usage="primary display">https://purl.stanford.edu/aa666bb1234</url>

--- a/spec/cocina/models/mapping/to_mods/note_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/note_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Note do
                'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                'version' => '3.6',
                'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
-        described_class.write(xml: xml, notes: notes, id_generator: nil)
+        described_class.write(xml: xml, notes: notes, id_generator: id_generator)
       end
     end
   end
+  let(:id_generator) { nil }
 
   context 'when notes is nil' do
     let(:notes) { nil }
@@ -38,6 +39,32 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Note do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <note>I have some <![CDATA[<cite>]]>title<![CDATA[</cite>]]> and <![CDATA[<i>]]>italic<![CDATA[</i>]]> formats.</note>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when notes has a parallelValue' do
+    let(:notes) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          parallelValue:
+            [
+              Cocina::Models::DescriptiveValue.new(value: 'monthly', type: 'frequency'),
+              Cocina::Models::DescriptiveValue.new(value: 'some other value')
+            ]
+        )
+      ]
+    end
+    let(:id_generator) { Cocina::Models::Mapping::ToMods::IdGenerator.new }
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note altRepGroup="1" type="frequency">monthly</note>
+          <note altRepGroup="1">some other value</note>
         </mods>
       XML
     end


### PR DESCRIPTION
## Why was this change made? 🤔

While working on https://github.com/sul-dlss/dor_indexing_app/issues/992 for resource_type - I discovered that while we follow the same logic internally to determine this should provide a resource_type of `Journal/Periodical`, when translating the cocina to mods in order to use `stanford-mods` to determine the resource_type we do not look for the parallelValue and thus miss `value="monthly"` and `type="frequency"`.

This checks if the note has a parallelValue and if so, uses value(s) found there to write the note.

The Cocina for a note that has a parallelValue:

```
#<Cocina::Models::DescriptiveValue 
    structuredValue=[]
    parallelValue=[
        #<Cocina::Models::DescriptiveValue 
            structuredValue=[] parallelValue=[] groupedValue=[] 
            value="monthly" 
            type="frequency" 
            status=nil code=nil uri=nil standard=nil encoding=nil 
            identifier=[] source=nil displayLabel=nil qualifier=nil note=[] valueLanguage=nil valueAt=nil appliesTo=[]>
```

## How was this change tested? 🤨

unit


