### PR TITLE
Fix description types validation

### DIFF
--- a/lib/cocina/models/validators/description_types_validator.rb
+++ b/lib/cocina/models/validators/description_types_validator.rb
@@ -35,7 +35,7 @@ module Cocina
 
         def validate_hash(hash, path)
           hash.each do |key, obj|
-            if key == :type
+            if key.to_sym == :type
               validate_type(obj, path)
             else
               validate_obj(obj, path + [key])
@@ -55,8 +55,10 @@ module Cocina
         end
 
         def validate_type(type, path)
+          clean_path = clean_path(path)
           valid_types.each do |type_signature, types|
-            next unless match?(path, type_signature)
+            next unless match?(clean_path, type_signature)
+
             break if types.include?(type.downcase)
 
             error_paths << "#{path_to_s(path)} (#{type})"
@@ -64,15 +66,15 @@ module Cocina
           end
         end
 
-        def match?(path, type_signature)
-          clean_path(path).last(type_signature.length) == type_signature
+        def match?(clean_path, type_signature)
+          clean_path.last(type_signature.length) == type_signature
         end
 
         # Some part of the path are ignored for the purpose of matching.
         def clean_path(path)
           new_path = path.reject do |part|
-            part.is_a?(Integer) || %i[parallelValue parallelContributor parallelEvent].include?(part)
-          end
+            part.is_a?(Integer) || %i[parallelValue parallelContributor parallelEvent].include?(part.to_sym)
+          end.map(&:to_sym)
           # This needs to happen after parallelValue is removed
           # to handle structuredValue > parallelValue > structuredValue
           new_path.reject.with_index do |part, index|

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -18,16 +18,9 @@ module Cocina
 
         def self.validate(clazz, attributes)
           # This gets rid of nested model objects.
-          # Once DSA is on Rails 6, this can be:
-          # attributes_hash = attributes.to_h.deep_transform_values do |value|
-          #   value.class.name.starts_with?('Cocina::Models') ? value.to_h : value
-          # end.with_indifferent_access
-          # And add require 'active_support/core_ext/hash/deep_transform_values' to models file.
-
-          # In the meantime, copying code.
-          attributes_hash = deep_transform_values(attributes.to_h) do |value|
+          attributes_hash = attributes.to_h.deep_transform_values do |value|
             value.class.name.starts_with?('Cocina::Models') ? value.to_h : value
-          end.deep_symbolize_keys.with_indifferent_access
+          end.with_indifferent_access
           VALIDATORS.each { |validator| validator.validate(clazz, attributes_hash) }
         end
 

--- a/spec/cocina/models/validatable_spec.rb
+++ b/spec/cocina/models/validatable_spec.rb
@@ -4,58 +4,92 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validatable do
   let(:props) do
+    # Deliberately not using factory to control validation.
     {
-      externalIdentifier: 'druid:bc123df4567',
-      label: 'My admin policy',
-      type: Cocina::Models::ObjectType.admin_policy,
+      type: Cocina::Models::ObjectType.object,
       version: 1,
-      administrative: administrative_props
+      label: 'DRO label',
+      externalIdentifier: 'druid:bc123df4567',
+      access: {},
+      administrative: administrative_props,
+      description: description_props,
+      identification: {sourceId: 'sul:1234'},
+      structural: {isMemberOf: []}
     }
+  end
+
+  let(:description_props) do
+    {title: [{value: 'DRO title'}], purl: 'https://purl.stanford.edu/bc123df4567'}
   end
 
   let(:administrative_props) do
     {
-      hasAdminPolicy: 'druid:bc123df4567',
-      hasAgreement: 'druid:bc123df4567',
-      accessTemplate: {}
+      hasAdminPolicy: 'druid:bc123df4567'
     }
   end
 
   before do
-    allow(Cocina::Models::Validators::Validator).to receive(:validate)
+    allow(Cocina::Models::Validators::Validator).to receive(:validate).and_call_original
   end
 
   context 'when validating a Validatable' do
     it 'performs validation' do
-      Cocina::Models::AdminPolicy.new(props)
-      expect(Cocina::Models::Validators::Validator).to have_received(:validate)
+      Cocina::Models::DRO.new(props)
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::DRO, props)
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::Description, description_props)
+    end
+
+    context 'when top-level object is invalid' do
+      # That is, this is a validation perform on the DRO.
+      let(:description_props) do
+        {title: [{value: 'DRO title'}], purl: 'https://purl.stanford.edu/xc123df4567'}
+      end
+
+      it 'raises ValidationError' do
+        expect { Cocina::Models::DRO.new(props) }.to raise_error(Cocina::Models::ValidationError, /Purl mismatch/)
+      end
+    end
+
+    context 'when nested object is invalid' do
+      # This is validated on the Description.
+      let(:description_props) do
+        {title: [structuredValue: [{value: 'DRO title', type: 'partname'}]], purl: 'https://purl.stanford.edu/bc123df4567'}
+      end
+
+      it 'raises ValidationError' do
+        expect { Cocina::Models::DRO.new(props) }.to raise_error(Cocina::Models::ValidationError, /Unrecognized types in description/)
+      end
     end
   end
 
   context 'when not validating a Validatable' do
     it 'does not perform validation' do
-      Cocina::Models::AdminPolicy.new(props, false, false)
-      expect(Cocina::Models::Validators::Validator).not_to have_received(:validate)
+      Cocina::Models::DRO.new(props, false, false)
+      expect(Cocina::Models::Validators::Validator).not_to have_received(:validate).with(Cocina::Models::DRO, props)
+      # This is a flaw. Nested Validatables are still validated.
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::Description, description_props)
     end
   end
 
   context 'when validating a Validatable created from existing object' do
     it 'performs validation' do
-      Cocina::Models::AdminPolicy.new(props).new(label: 'My new admin policy')
-      expect(Cocina::Models::Validators::Validator).to have_received(:validate).twice
+      Cocina::Models::DRO.new(props).new(label: 'My new DRO')
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::DRO, props)
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::Description, description_props)
     end
   end
 
   context 'when not validating a Validatable created from existing object' do
     it 'does not perform validation' do
-      Cocina::Models::AdminPolicy.new(props).new(label: 'My new admin policy', validate: false)
-      expect(Cocina::Models::Validators::Validator).to have_received(:validate).once
+      Cocina::Models::DRO.new(props).new(label: 'My new DRO', validate: false)
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::DRO, props)
+      expect(Cocina::Models::Validators::Validator).to have_received(:validate).with(Cocina::Models::Description, description_props)
     end
   end
 
   context 'when not a Validatable' do
     it 'does not perform validation' do
-      Cocina::Models::AdminPolicyAdministrative.new(administrative_props)
+      Cocina::Models::Administrative.new(administrative_props)
       expect(Cocina::Models::Validators::Validator).not_to have_received(:validate)
     end
   end

--- a/spec/cocina/models/validators/description_types_validator_spec.rb
+++ b/spec/cocina/models/validators/description_types_validator_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionTypesValidator do
           type: 'related to'
         }
       ]
-    }
+    }.with_indifferent_access
   end
 
   let(:contributor_type) { 'person' }

--- a/spec/cocina/models/validators/validator_spec.rb
+++ b/spec/cocina/models/validators/validator_spec.rb
@@ -3,62 +3,71 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validators::Validator do
-  subject(:validate) { described_class.validate(clazz, dro_props) }
+  subject(:validate) { described_class.validate(clazz, props) }
 
   let(:clazz) { Cocina::Models::DRO }
 
-  let(:dro_props) { props }
-
   let(:props) do
+    # Deliberately not using factory to control validation.
     {
-      externalIdentifier: 'druid:jq000jd3530',
-      description: {
-        title: [{
-          value: 'Rockhounding Utah',
-          appliesTo: [],
-          groupedValue: [],
-          identifier: [],
-          note: [],
-          parallelValue: [],
-          structuredValue: []
-        }],
-        purl: 'https://purl.stanford.edu/jq000jd3530'
-      }
-    }.with_indifferent_access
-  end
-
-  before do
-    Cocina::Models::Validators::Validator::VALIDATORS.each do |validator_clazz|
-      allow(validator_clazz).to receive(:validate)
-    end
+      type: Cocina::Models::ObjectType.object,
+      version: 1,
+      label: 'DRO label',
+      access: {},
+      administrative: {hasAdminPolicy: 'druid:hv992ry2431'},
+      description: {title: [{value: 'DRO title'}], purl: 'https://purl.stanford.edu/bc234fg5678'},
+      identification: {sourceId: 'sul:1234'},
+      structural: {isMemberOf: []},
+      externalIdentifier: 'druid:bc234fg5678'
+    }.deep_stringify_keys
   end
 
   context 'with a props hash' do
+    before do
+      Cocina::Models::Validators::Validator::VALIDATORS.each do |validator_clazz|
+        allow(validator_clazz).to receive(:validate)
+      end
+    end
+
     it 'invokes validators' do
       validate
 
-      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(clazz,
+      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(Cocina::Models::DRO,
                                                                                                      props))
     end
   end
 
   # Yes, this can happen.
   context 'with a mixed hash' do
-    let(:dro_props) do
-      {
-        externalIdentifier: 'druid:jq000jd3530',
-        description: {
-          title: [Cocina::Models::Title.new(value: 'Rockhounding Utah')],
-          purl: 'https://purl.stanford.edu/jq000jd3530'
-        }
-      }
+    {
+      type: Cocina::Models::ObjectType.object,
+      version: 1,
+      label: 'DRO label',
+      access: {},
+      administrative: {hasAdminPolicy: 'druid:hv992ry2431'},
+      description: {title: [Cocina::Models::Title.new(value: 'DRO title')], purl: 'https://purl.stanford.edu/bc234fg5678'},
+      identification: {sourceId: 'sul:1234'},
+      structural: {isMemberOf: []},
+      externalIdentifier: 'druid:bc234fg5678'
+    }.deep_stringify_keys
+
+    before do
+      Cocina::Models::Validators::Validator::VALIDATORS.each do |validator_clazz|
+        allow(validator_clazz).to receive(:validate)
+      end
     end
 
     it 'invokes validators' do
       validate
 
-      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(clazz,
+      expect(Cocina::Models::Validators::Validator::VALIDATORS).to all(have_received(:validate).with(Cocina::Models::DRO,
                                                                                                      props))
+    end
+  end
+
+  context 'with a valid hash' do
+    it 'does not raise an error' do
+      expect { validate }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Types validation was not being performed.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, qa, stage, and prod.

