### PR TITLE
Disable DescriptionTypesValidator

### DIFF
--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -11,7 +11,9 @@ module Cocina
           PurlValidator,
           CatalogLinksValidator,
           AssociatedNameValidator,
-          DescriptionTypesValidator,
+          # Removing until production data can be remediated and/or additional types can be added to configuration.
+          # See also spec/cocina/models/validatable_spec.rb:59
+          # DescriptionTypesValidator,
           DescriptionValuesValidator,
           DateTimeValidator
         ].freeze

--- a/spec/cocina/models/validatable_spec.rb
+++ b/spec/cocina/models/validatable_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Cocina::Models::Validatable do
       end
 
       it 'raises ValidationError' do
+        skip('DescriptionTypesValidator has been temporarily disabled')
         expect { Cocina::Models::DRO.new(props) }.to raise_error(Cocina::Models::ValidationError, /Unrecognized types in description/)
       end
     end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
There is existing data in production that fails validation with DescriptionTypesValidator. To prevent a problem, temporarily disabling the validator.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
Unit


