### PR TITLE
touchups from file languageTag PR discussion

### DIFF
--- a/docs/description_types.md
+++ b/docs/description_types.md
@@ -363,6 +363,8 @@ _Path: identifier.type_
   * document number
   * DOI
   * druid
+  * FOLIO
+    * FOLIO HRID for the source record of the metadata.
   * GTIN-14 ID
   * Handle
   * inventory number

--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -23,7 +23,7 @@ module Cocina
       # MIME Type of the File.
       attribute? :hasMimeType, Types::Strict::String
       # BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang
-      attribute? :languageTag, Types::Strict::String.optional
+      attribute? :languageTag, Types::Strict::String
       # Use for the File.
       attribute? :use, Types::Strict::String
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -13,7 +13,7 @@ module Cocina
       attribute? :size, Types::Strict::Integer
       attribute :version, Types::Strict::Integer
       attribute? :hasMimeType, Types::Strict::String
-      attribute? :languageTag, Types::Strict::String.optional
+      attribute? :languageTag, Types::Strict::String
       attribute? :externalIdentifier, Types::Strict::String
       attribute? :use, Types::Strict::String
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)


### PR DESCRIPTION
## Why was this change made? 🤔

make the couple agreed upon touchups from https://github.com/sul-dlss/cocina-models/pull/640#issuecomment-1790929840

## How was this change tested? 🤨

existing unit tests (`language_tag_validator_spec.rb` already confirms that `languageTag` can be omitted from `Cocina::Models::File` and `Cocina::Models::RequestFile` properties).
