### PR TITLE
switch LanguageTagValidator to operate on DRO::TYPES so that it's invoked automatically when building item models

### DIFF
--- a/lib/cocina/models/validators/language_tag_validator.rb
+++ b/lib/cocina/models/validators/language_tag_validator.rb
@@ -17,10 +17,10 @@ module Cocina
         def validate
           return unless meets_preconditions?
 
-          return if valid_language_tag?
+          return if invalid_files.empty?
 
-          raise ValidationError, 'The provided language tag is not valid according to RFC 4646: ' \
-                                 "#{attributes[:languageTag]}"
+          raise ValidationError, 'Some files have invalid language tags according to RFC 4646: ' \
+                                 "#{invalid_filenames_with_language_tags.join(', ')}"
         end
 
         private
@@ -28,19 +28,45 @@ module Cocina
         attr_reader :clazz, :attributes
 
         def meets_preconditions?
-          file? && attributes[:languageTag].present?
+          dro?
         end
 
-        def file?
-          (clazz::TYPES & File::TYPES).any?
+        def dro?
+          (clazz::TYPES & DRO::TYPES).any?
         rescue NameError
           false
         end
 
-        def valid_language_tag?
-          parsed_tag = I18n::Locale::Tag::Rfc4646.tag(attributes[:languageTag])
+        def valid_language_tag?(file)
+          # I18n::Locale::Tag::Rfc4646.tag will return an instance of I18n::Locale::Tag::Rfc4646 (with fields like language, script,
+          # region) for strings that can be parsed according to RFC 4646, and nil for strings that do not conform to the spec.
+          I18n::Locale::Tag::Rfc4646.tag(file[:languageTag]).present?
+        end
 
-          parsed_tag.present? && parsed_tag.is_a?(I18n::Locale::Tag::Rfc4646)
+        def invalid_files
+          @invalid_files ||= language_tag_files.reject { |file| valid_language_tag?(file) }
+        end
+
+        def invalid_filenames_with_language_tags
+          invalid_files.map { |invalid_file| "#{invalid_file[:filename] || invalid_file[:label]} (#{invalid_file[:languageTag]})" }
+        end
+
+        def language_tag_files
+          files.select { |file| file[:languageTag].present? }
+        end
+
+        def files
+          [].tap do |files|
+            next if attributes.dig(:structural, :contains).nil?
+
+            attributes[:structural][:contains].each do |fileset|
+              next if fileset.dig(:structural, :contains).nil?
+
+              fileset[:structural][:contains].each do |file|
+                files << file
+              end
+            end
+          end
         end
       end
     end

--- a/spec/cocina/models/validators/language_tag_validator_spec.rb
+++ b/spec/cocina/models/validators/language_tag_validator_spec.rb
@@ -3,7 +3,27 @@
 require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validators::LanguageTagValidator do
-  let(:validate) { described_class.validate(clazz, props) }
+  let(:validate) { described_class.validate(clazz, dro_props) }
+
+  let(:dro_props) do
+    {
+      type: Cocina::Models::ObjectType.book,
+      access: { view: 'dark', download: 'none' },
+      structural: {
+        contains: [
+          {
+            externalIdentifier: 'bc123df4567_1',
+            label: 'Fileset 1',
+            type: Cocina::Models::FileSetType.file,
+            version: 1,
+            structural: {
+              contains: [props]
+            }
+          }
+        ]
+      }
+    }
+  end
 
   let(:props) { file_props }
 
@@ -26,16 +46,16 @@ RSpec.describe Cocina::Models::Validators::LanguageTagValidator do
   end
 
   context 'with no value for languageTag specified' do
-    context 'with a File' do
-      let(:clazz) { Cocina::Models::File }
+    context 'with a DRO' do
+      let(:clazz) { Cocina::Models::DRO }
 
       it 'does not raise' do
         expect { validate }.not_to raise_error
       end
     end
 
-    context 'with a RequestFile' do
-      let(:clazz) { Cocina::Models::RequestFile }
+    context 'with a RequestDRO' do
+      let(:clazz) { Cocina::Models::RequestDRO }
 
       it 'does not raise' do
         expect { validate }.not_to raise_error
@@ -53,16 +73,16 @@ RSpec.describe Cocina::Models::Validators::LanguageTagValidator do
     context 'with a recognized language, script, and region' do
       let(:language_tag) { 'ru-Cyrl-RU' }
 
-      context 'with a File' do
-        let(:clazz) { Cocina::Models::File }
+      context 'with a DRO' do
+        let(:clazz) { Cocina::Models::DRO }
 
         it 'does not raise' do
           expect { validate }.not_to raise_error
         end
       end
 
-      context 'with a RequestFile' do
-        let(:clazz) { Cocina::Models::RequestFile }
+      context 'with a RequestDRO' do
+        let(:clazz) { Cocina::Models::RequestDRO }
 
         it 'does not raise' do
           expect { validate }.not_to raise_error
@@ -73,16 +93,16 @@ RSpec.describe Cocina::Models::Validators::LanguageTagValidator do
     context 'with an unrecognized language, script, and region' do
       let(:language_tag) { 'foo-Barr-BZ' } # still conforms to the expected format of BCP 47/RFC 4646, should parse
 
-      context 'with a File' do
-        let(:clazz) { Cocina::Models::File }
+      context 'with a DRO' do
+        let(:clazz) { Cocina::Models::DRO }
 
         it 'does not raise' do
           expect { validate }.not_to raise_error
         end
       end
 
-      context 'with a RequestFile' do
-        let(:clazz) { Cocina::Models::RequestFile }
+      context 'with a RequestDRO' do
+        let(:clazz) { Cocina::Models::RequestDRO }
 
         it 'does not raise' do
           expect { validate }.not_to raise_error
@@ -98,19 +118,19 @@ RSpec.describe Cocina::Models::Validators::LanguageTagValidator do
       end
     end
 
-    context 'with a File' do
-      let(:clazz) { Cocina::Models::File }
+    context 'with a DRO' do
+      let(:clazz) { Cocina::Models::DRO }
 
       it 'raises a validation error' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError, 'The provided language tag is not valid according to RFC 4646: fooooooooooooo')
+        expect { validate }.to raise_error(Cocina::Models::ValidationError, 'Some files have invalid language tags according to RFC 4646: page1.txt (fooooooooooooo)')
       end
     end
 
-    context 'with a RequestFile' do
-      let(:clazz) { Cocina::Models::RequestFile }
+    context 'with a RequestDRO' do
+      let(:clazz) { Cocina::Models::RequestDRO }
 
       it 'raises a validation error' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError, 'The provided language tag is not valid according to RFC 4646: fooooooooooooo')
+        expect { validate }.to raise_error(Cocina::Models::ValidationError, 'Some files have invalid language tags according to RFC 4646: page1.txt (fooooooooooooo)')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

this makes `LanguageTagValidator` operate more like `DarkValidator`, which we determined in [slack discussion](https://stanfordlib.slack.com/archives/C09M7P91R/p1699289637148319) is likely desirable for real world validation usage:

@mjgiarlo 💬 
> What I think is happening: only some models use the ruby validation code (items, collections, APOs), and I don't think files are in that list. So they're strictly openapi validated.
>
> We likely need to rewrite the language tag validator so that it works against items instead of against files (so it runs at the item level and descends down into files, just like the dark-access validator)
> ...
> (and we can't lean on openapi validation for BCP unless we want to couple a given cocina-models release to a  an enum of allowed BCP values, which is maybe a bit brittle)
> ...
> It's a pretty small code change for a cocina-models patch, I think
> to rework the language tag validator to operate against DROs like the https://github.com/sul-dlss/cocina-models/blob/35ef3bdf826f53e7fd6e158b2db3b85a8cfadd78/lib/cocina/models/validators/dark_validator.rb

@jmartin-sul 💬 
> ah, ok, that makes sense.  didn't realize validation would be invoked automatically on the argo side for only some model types, and there wasn't any overarching info needed at the item level (i don't think?) to validate the tag on an individual file, so i went for the simpler file level thing.

@mjgiarlo 💬 
> validation in cocina-models is maybe a bit surprising in this way. it's like that in the gem, too, not just argo. validation is wired up on the instance and class new methods: https://github.com/sul-dlss/cocina-models/blob/main/lib/cocina/models/validatable.rb
> but not every model uses the `Validatable` module. (`DRO` does. `File` doesn't.)

## How was this change tested? 🤨

- [x] unit tests
- [ ] tweak the argo branch for [this PR](https://github.com/sul-dlss/argo/pull/4266) to use this cocina-models branch,  deploy to stage, and see if that fixes the lack of validation on `languageTag` mentioned in the linked slack discussion?  and if so, merge this PR and cut a new patch release and update the argo PR to use that?

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



