### PR TITLE
Allow file use and language tag attrs to be removed

### DIFF
--- a/lib/cocina/models/file.rb
+++ b/lib/cocina/models/file.rb
@@ -23,9 +23,9 @@ module Cocina
       # MIME Type of the File.
       attribute? :hasMimeType, Types::Strict::String
       # BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang
-      attribute? :languageTag, Types::Strict::String
+      attribute? :languageTag, LanguageTag.optional
       # Use for the File.
-      attribute? :use, Types::Strict::String
+      attribute? :use, FileUse.optional
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, FileAccess.default { FileAccess.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })

--- a/lib/cocina/models/file_use.rb
+++ b/lib/cocina/models/file_use.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    FileUse = Types::String
+  end
+end

--- a/lib/cocina/models/language_tag.rb
+++ b/lib/cocina/models/language_tag.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    LanguageTag = Types::String
+  end
+end

--- a/lib/cocina/models/request_file.rb
+++ b/lib/cocina/models/request_file.rb
@@ -13,9 +13,11 @@ module Cocina
       attribute? :size, Types::Strict::Integer
       attribute :version, Types::Strict::Integer
       attribute? :hasMimeType, Types::Strict::String
-      attribute? :languageTag, Types::Strict::String
+      # BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang
+      attribute? :languageTag, LanguageTag.optional
       attribute? :externalIdentifier, Types::Strict::String
-      attribute? :use, Types::Strict::String
+      # Use for the File.
+      attribute? :use, FileUse.optional
       attribute :hasMessageDigests, Types::Strict::Array.of(MessageDigest).default([].freeze)
       attribute(:access, FileAccess.default { FileAccess.new })
       attribute(:administrative, FileAdministrative.default { FileAdministrative.new })

--- a/openapi.yml
+++ b/openapi.yml
@@ -1045,11 +1045,9 @@ components:
           description: MIME Type of the File.
           type: string
         languageTag:
-          description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         use:
-          description: Use for the File.
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:
@@ -1144,6 +1142,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/File'
+    FileUse:
+      description: Use for the File.
+      type: string
+      nullable: true
     FolioCatalogLink:
       description: A linkage between an object and a Folio catalog record
       type: object
@@ -1272,6 +1274,10 @@ components:
         valueLanguage:
           # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
           $ref: "#/components/schemas/DescriptiveValueLanguage"
+    LanguageTag:
+      description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
+      type: string
+      nullable: true
     License:
       description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
       type: string
@@ -1779,11 +1785,11 @@ components:
         hasMimeType:
           type: string
         languageTag:
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         externalIdentifier:
           type: string
         use:
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:


### PR DESCRIPTION
# Why was this change made?

Prior to this commit, it was not possible to create a new instance of a `File` model containing use or language tag attrs with either or both removed (replaced by `nil`s). See https://github.com/sul-dlss/argo/blob/main/app/services/structure_updater.rb#L92, which prevents users from removing file use values. 

This commit makes it possible to do so.

Because this makes our models slightly more permissive, I don't think running a validation in a deployed env is worth the time/cost.

# How was this change tested?

CI, `bundle console`
