### PR TITLE
make Cocina::Models::Validators::DarkValidator#invalid_files a bit more concise/idiomatic

### DIFF
--- a/lib/cocina/models/validators/dark_validator.rb
+++ b/lib/cocina/models/validators/dark_validator.rb
@@ -39,12 +39,7 @@ module Cocina
         end
 
         def invalid_files
-          @invalid_files ||=
-            [].tap do |invalid_files|
-              files.each do |file|
-                invalid_files << file if invalid?(file)
-              end
-            end
+          @invalid_files ||= files.select { |file| invalid?(file) }
         end
 
         def invalid_filenames


### PR DESCRIPTION
## Why was this change made? 🤔

cribbed off this class for `LanguageTagValidator`, switched to something more concise for a similar method there, doing the same here

see https://github.com/sul-dlss/cocina-models/pull/643


## How was this change tested? 🤨

(existing) unit tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



