### PR TITLE
TitleBuilder corrections

### DIFF
--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -49,6 +49,14 @@ module Cocina
           [new(strategy: :all, add_punctuation: false).build(titles)].flatten - full_title(titles)
         end
 
+        # @param strategy [Symbol] ":first" selects a single title value based on precedence of
+        #   primary, untyped, first occurrence. ":all" returns an array containing all the values.
+        # @param add_punctuation [boolean] whether the title should be formmated with punctuation (think of a structured
+        #   value coming from a MARC record, which is designed for catalog cards.)
+        # @param only_one_parallel_value [boolean] when true, choose one of the parallel values according to precedence
+        #   of primary, untyped, first occurrence.  When false, return an array containing all the parallel values.
+        #   Why? Think of e.g. title displayed in blacklight search results vs boosting values for ranking of search
+        #   results
         def initialize(strategy:, add_punctuation:, only_one_parallel_value: true)
           @strategy = strategy
           @add_punctuation = add_punctuation
@@ -143,9 +151,6 @@ module Cocina
           @add_punctuation
         end
 
-        # in order to return a single value, we need to choose one of the parallel values
-        #   otherwise, we will return an array containing all the parallel values
-        #   (e.g. title displayed in blacklight search results vs boosting values for search result rankings)
         def only_one_parallel_value?
           @only_one_parallel_value
         end

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -199,6 +199,8 @@ module Cocina
         # @return [String] the title value from combining the pieces of the structured_values by type and order
         #   with desired punctuation per specs
         #
+        # for punctuaion funky town, thank MARC and catalog cards
+        #
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/MethodLength
@@ -214,7 +216,7 @@ module Cocina
             value = structured_value.value&.strip
             next unless value
 
-            # additional types ignored here:  name, uniform ...
+            # additional types ignored here, e.g. name, uniform ...
             case structured_value.type&.downcase
             when 'nonsorting characters'
               padding = non_sorting_padding(cocina_title, value)
@@ -225,12 +227,15 @@ module Cocina
                 result = if !add_punctuation?
                            [result, part_name_number].join(' ')
                          elsif result.present?
+                           # part name/number is preceded by period space, unless it is at the beginning of the title string
                            "#{result.sub(/[ .,]*$/, '')}. #{part_name_number}. "
                          else
                            "#{part_name_number}. "
                          end
               end
             when 'main title', 'title'
+              # nonsorting characters ending with hyphen, apostrophe or space should be slammed against the main title,
+              #   even if we are not adding punctuation
               result = if add_punctuation? || result.ends_with?(' ') || result.ends_with?('-') || result.ends_with?('\'')
                          [result, value].join
                        else

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -85,6 +85,8 @@ module Cocina
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
+        # this is the single "short title" - the title without subtitle, part name, etc.
+        #    this may be useful for boosting and exact matching for search results
         # @return [Array<String>] the main title value(s) for Solr - can be array due to parallel titles
         def main_title(titles)
           cocina_title = primary_title(titles) || untyped_title(titles)

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -27,7 +27,7 @@ module Cocina
         #   we can boost matches on it in search results (boost matching this string higher than matching full title string)
         #   e.g. "The Hobbit" (main_title) vs "The Hobbit, or, There and Back Again (full_title)
         # @param [[Array<Cocina::Models::Title,Cocina::Models::DescriptiveValue>] titles the titles to consider
-        # @return [String] the main title value for Solr
+        # @return [Array<String>] the main title value(s) for Solr - array due to possible parallelValue
         def self.main_title(titles)
           new(strategy: :first, add_punctuation: false).main_title(titles)
         end
@@ -35,9 +35,9 @@ module Cocina
         # the "full title" is the title WITH subtitle, part name, etc.  We want to able able to index it separately so
         #   we can boost matches on it in search results (boost matching this string higher than other titles present)
         # @param [[Array<Cocina::Models::Title,Cocina::Models::DescriptiveValue>] titles the titles to consider
-        # @return [String] the title value for Solr
+        # @return [Array<String>] the full title value(s) for Solr - array due to possible parallelValue
         def self.full_title(titles)
-          new(strategy: :first, add_punctuation: false).build(titles)
+          [new(strategy: :first, add_punctuation: false, only_one_parallel_value: false).build(titles)].flatten.compact
         end
 
         # "additional titles" are all title data except for full_title.  We want to able able to index it separately so
@@ -45,16 +45,19 @@ module Cocina
         # @param [[Array<Cocina::Models::Title,Cocina::Models::DescriptiveValue>] titles the titles to consider
         # @return [Array<String>] the values for Solr
         def self.additional_titles(titles)
-          new(strategy: :all, add_punctuation: false).build(titles) - [full_title(titles)]
+          [new(strategy: :all, add_punctuation: false).build(titles)].flatten - full_title(titles)
         end
 
-        def initialize(strategy:, add_punctuation:)
+        def initialize(strategy:, add_punctuation:, only_one_parallel_value: true)
           @strategy = strategy
           @add_punctuation = add_punctuation
+          @only_one_parallel_value = only_one_parallel_value
         end
 
         # @param [[Array<Cocina::Models::Title>] cocina_titles the titles to consider
         # @return [String] the title value for Solr
+        #
+        # rubocop:disable Metrics/PerceivedComplexity
         def build(cocina_titles)
           cocina_title = primary_title(cocina_titles) || untyped_title(cocina_titles)
           cocina_title = other_title(cocina_titles) if cocina_title.blank?
@@ -62,15 +65,21 @@ module Cocina
           if strategy == :first
             extract_title(cocina_title)
           else
-            cocina_titles.map { |ctitle| extract_title(ctitle) }.flatten
+            result = cocina_titles.map { |ctitle| extract_title(ctitle) }.flatten
+            if only_one_parallel_value? && result.length == 1
+              result.first
+            else
+              result
+            end
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
+        # @return [Array<String>] the main title value(s) for Solr - can be array due to parallel titles
         def main_title(titles)
           cocina_title = primary_title(titles) || untyped_title(titles)
           cocina_title = other_title(titles) if cocina_title.blank?
 
-          cocina_title = cocina_title.first if cocina_title.is_a?(Array)
           extract_main_title(cocina_title)
         end
 
@@ -78,41 +87,67 @@ module Cocina
 
         attr_reader :strategy
 
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/PerceivedComplexity
         def extract_title(cocina_title)
-          result = if cocina_title.value
-                     cocina_title.value
-                   elsif cocina_title.structuredValue.present?
-                     rebuild_structured_value(cocina_title)
-                   elsif cocina_title.parallelValue.present?
-                     return build(cocina_title.parallelValue)
-                   end
-          remove_trailing_punctuation(result.strip) if result.present?
+          title_values = if cocina_title.value
+                           cocina_title.value
+                         elsif cocina_title.structuredValue.present?
+                           rebuild_structured_value(cocina_title)
+                         elsif cocina_title.parallelValue.present?
+                           primary = cocina_title.parallelValue.find { |pvalue| pvalue.status == 'primary' }
+                           if primary && only_one_parallel_value? && strategy == :first
+                             extract_title(primary)
+                           elsif only_one_parallel_value? && strategy == :first
+                             untyped = cocina_title.parallelValue.find { |pvalue| pvalue.type.blank? }
+                             extract_title(untyped || cocina_title.parallelValue.first)
+                           else
+                             cocina_title.parallelValue.map { |pvalue| extract_title(pvalue) }
+                           end
+                         end
+          result = [title_values].flatten.compact.map { |val| remove_trailing_punctuation(val.strip) }
+          result.length == 1 ? result.first : result
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/PerceivedComplexity
 
-        def extract_main_title(cocina_title)
-          if cocina_title.value
-            cocina_title.value # covers both title and main title types
-          elsif cocina_title.structuredValue.present?
-            main_title_from_structured_values(cocina_title)
-          elsif cocina_title.parallelValue.present?
-            main_title(cocina_title.parallelValue)
-          end
+        # @return [Array<String>] the main title value(s) for Solr - can be array due to parallel titles
+        def extract_main_title(cocina_title) # rubocop:disable Metrics/PerceivedComplexity
+          result = if cocina_title.value
+                     cocina_title.value # covers both title and main title types
+                   elsif cocina_title.structuredValue.present?
+                     main_title_from_structured_values(cocina_title)
+                   elsif cocina_title.parallelValue.present?
+                     primary = cocina_title.parallelValue.find { |pvalue| pvalue.status == 'primary' }
+                     if primary
+                       extract_main_title(primary)
+                     else
+                       cocina_title.parallelValue.map { |pvalue| extract_main_title(pvalue) }
+                     end
+                   end
+          return [] if result.blank?
+
+          [result].flatten.compact.map(&:strip)
         end
 
         def add_punctuation?
           @add_punctuation
         end
 
+        def only_one_parallel_value?
+          @only_one_parallel_value
+        end
+
         # @return [Cocina::Models::Title, nil] title that has status=primary
-        def primary_title(titles)
-          primary_title = titles.find do |title|
-            title.status == 'primary'
-          end
+        def primary_title(cocina_titles)
+          primary_title = cocina_titles.find { |title| title.status == 'primary' }
           return primary_title if primary_title.present?
 
           # NOTE: structuredValues would only have status primary assigned as a sibling, not as an attribute
 
-          titles.find do |title|
+          cocina_titles.find do |title|
             title.parallelValue&.find do |parallel_title|
               parallel_title.status == 'primary'
             end
@@ -168,12 +203,7 @@ module Cocina
             case structured_value.type&.downcase
             when 'nonsorting characters'
               padding = non_sorting_padding(cocina_title, value)
-              non_sort_value = "#{value}#{padding}"
-              result = if result.present?
-                         [result, padding, non_sort_value].join
-                       else
-                         non_sort_value
-                       end
+              result = add_non_sorting_value(result, value, padding)
             when 'part name', 'part number'
               if part_name_number.blank?
                 part_name_number = part_name_number(cocina_title.structuredValue)
@@ -186,7 +216,7 @@ module Cocina
                          end
               end
             when 'main title', 'title'
-              result = if add_punctuation?
+              result = if add_punctuation? || result.ends_with?(' ') || result.ends_with?('-') || result.ends_with?('\'')
                          [result, value].join
                        else
                          [remove_trailing_punctuation(result), remove_trailing_punctuation(value)].select(&:presence).join(' ')
@@ -213,11 +243,14 @@ module Cocina
         # main_title is title.structuredValue.value with type 'main title' (or just title.value)
         # @param [Cocina::Models::Title] title with structured values
         # @return [String] the main title value
-        def main_title_from_structured_values(cocina_title) # rubocop:disable Metrics/MethodLength
+        #
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/PerceivedComplexity
+        def main_title_from_structured_values(cocina_title)
           result = ''
           # combine pieces of the cocina structuredValue into a single title
           cocina_title.structuredValue.each do |structured_value|
-            # There can be a structuredValue inside a structuredValue.  For example,
+            # There can be a structuredValue inside a structuredValue, for example,
             #   a uniform title where both the name and the title have internal StructuredValue
             return main_title_from_structured_values(structured_value) if structured_value.structuredValue.present?
 
@@ -226,20 +259,34 @@ module Cocina
 
             case structured_value.type&.downcase
             when 'nonsorting characters'
-              non_sort_value = "#{value}#{non_sorting_padding(cocina_title, value)}"
-              result = "#{non_sort_value}#{result}" # non-sorting characters are at the beginning of the title
-            when 'main title'
-              result = "#{result}#{value}"
-            when 'title'
-              result = value
+              padding = non_sorting_padding(cocina_title, value)
+              result = add_non_sorting_value(result, value, padding)
+            when 'main title', 'title'
+              result = if ['\'', '-'].include?(result.last)
+                         [result, value].join
+                       else
+                         [remove_trailing_punctuation(result).strip, remove_trailing_punctuation(value).strip].select(&:presence).join(' ')
+                       end
             end
           end
+
           result
         end
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/PerceivedComplexity
 
         # Thank MARC and catalog cards for this mess.
         def remove_trailing_punctuation(title)
-          title.sub(%r{[ .,;:/\\]+$}, '')
+          title.sub(%r{[.,;:/\\]+$}, '')
+        end
+
+        def add_non_sorting_value(title_so_far, non_sorting_value, padding)
+          non_sort_value = "#{non_sorting_value}#{padding}"
+          if title_so_far.present?
+            [title_so_far, padding, non_sort_value].join
+          else
+            non_sort_value
+          end
         end
 
         def non_sorting_padding(title, non_sorting_value)

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -299,7 +299,7 @@ module Cocina
 
         # Thank MARC and catalog cards for this mess.
         def remove_trailing_punctuation(title)
-          title.sub(%r{[.,;:/\\]+$}, '')
+          title.sub(%r{[ .,;:/\\]+$}, '')
         end
 
         def add_non_sorting_value(title_so_far, non_sorting_value, padding)

--- a/spec/cocina/models/builders/title_builder_spec.rb
+++ b/spec/cocina/models/builders/title_builder_spec.rb
@@ -57,20 +57,20 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       }]
     end
 
-    it '.build returns the expected title strings from parallel value' do
+    it '.build returns both title strings from parallel value' do
       expect(builder_build).to eq ['The master and Margarita', 'Мастер и Маргарита']
     end
 
-    it '.main_title returns the first title string' do
-      expect(main_title).to eq 'The master and Margarita'
+    it '.main_title returns both title strings from parallel value' do
+      expect(main_title).to eq ['The master and Margarita', 'Мастер и Маргарита']
     end
 
-    it '.full_title returns the first title string from parallel value' do
-      expect(full_title).to eq 'The master and Margarita'
+    it '.full_title returns both title strings from parallel value' do
+      expect(full_title).to eq ['The master and Margarita', 'Мастер и Маргарита']
     end
 
-    it '.additional_titles returns the second title string from parallel value' do
-      expect(additional_titles).to eq ['Мастер и Маргарита']
+    it '.additional_titles returns empty array' do
+      expect(additional_titles).to eq []
     end
   end
 
@@ -82,29 +82,31 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       ]
     end
 
-    it '.main_title is first title' do
-      expect(main_title).to eq 'However am I going to be'
+    it '.main_title contains first title' do
+      expect(main_title).to eq ['However am I going to be']
     end
 
-    it '.full_title is first title' do
-      expect(full_title).to eq 'However am I going to be'
+    it '.full_title contains first title' do
+      expect(full_title).to eq ['However am I going to be']
     end
 
-    it '.additional_titles is second title' do
+    it '.additional_titles contains second title' do
       expect(additional_titles).to eq ['A second title']
     end
 
-    context 'with a :first strategy' do
-      it '.build returns the first title' do
-        expect(builder_build).to eq('However am I going to be')
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('However am I going to be')
+        end
       end
-    end
 
-    context 'with an :all strategy' do
-      let(:strategy) { :all }
+      context 'with :all strategy' do
+        let(:strategy) { :all }
 
-      it '.build returns an array with each title string' do
-        expect(builder_build).to eq(['However am I going to be', 'A second title'])
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['However am I going to be', 'A second title'])
+        end
       end
     end
   end
@@ -112,75 +114,79 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
   context 'with a primary title' do
     let(:titles) do
       [
-        { value: 'A very silly secondary title' },
-        { value: 'A very silly primary title', status: 'primary' }
+        { value: 'secondary title' },
+        { value: 'primary title', status: 'primary' }
       ]
     end
 
-    context 'with a :first strategy' do
-      it '.build returns primary title string' do
-        expect(builder_build).to eq('A very silly primary title')
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns primary title string' do
+          expect(builder_build).to eq('primary title')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['secondary title', 'primary title'])
+        end
       end
     end
 
-    context 'with an :all strategy' do
-      let(:strategy) { :all }
-
-      it '.build returns an array with each title string' do
-        expect(builder_build).to eq(['A very silly secondary title', 'A very silly primary title'])
-      end
+    it '.main_title contains primary title string' do
+      expect(main_title).to eq ['primary title']
     end
 
-    it '.main_title returns primary title string' do
-      expect(main_title).to eq 'A very silly primary title'
+    it '.full_title contains primary title string' do
+      expect(full_title).to eq ['primary title']
     end
 
-    it '.full_title returns primary title string' do
-      expect(full_title).to eq 'A very silly primary title'
-    end
-
-    it '.additional_titles returns non-primary title string(s)' do
-      expect(additional_titles).to eq ['A very silly secondary title']
+    it '.additional_titles contains non-primary title string(s)' do
+      expect(additional_titles).to eq ['secondary title']
     end
   end
 
-  context 'with a main title (but no structuredValue)' do
+  context 'with a main title (without structuredValue)' do
     let(:titles) do
       [
         # NOTE:  these should be in a structuredValue; because they are not, we get weird results
-        { value: 'A very silly subtitle', type: 'subtitle' },
-        { value: 'A very silly main title', type: 'main title' }
+        { value: 'zee subtitle', type: 'subtitle' },
+        { value: 'zer main title', type: 'main title' }
       ]
     end
 
-    context 'with a :first strategy' do
-      it '.build returns the first title' do
-        expect(builder_build).to eq('A very silly subtitle')
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('zee subtitle')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns the main title' do
+          expect(builder_build).to eq(['zee subtitle', 'zer main title'])
+        end
       end
     end
 
-    context 'with an :all strategy' do
-      let(:strategy) { :all }
-
-      it '.build returns the main title' do
-        expect(builder_build).to eq(['A very silly subtitle', 'A very silly main title'])
-      end
+    it 'main_title is first value' do
+      expect(main_title).to eq 'zee subtitle'
     end
 
-    it 'main_title is ... first value because this should be a structuredValue' do
-      expect(main_title).to eq 'A very silly subtitle'
+    it 'full_title is first value' do
+      expect(full_title).to eq 'zee subtitle'
     end
 
-    it 'full_title is ... first value because this should be a structuredValue' do
-      expect(full_title).to eq 'A very silly subtitle'
-    end
-
-    it 'additional_titles is second value because this should be a structuredValue' do
-      expect(additional_titles).to eq ['A very silly main title']
+    it 'additional_titles is second value' do
+      expect(additional_titles).to eq ['zer main title']
     end
   end
 
-  context 'when the title is in a structuredValue' do
+  context 'when structuredValue' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
     let(:titles) do
@@ -210,7 +216,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       ]
     end
 
-    it '.build returns the reconstructed title' do
+    it '.build returns the reconstructed title with punctuation' do
       expect(builder_build).to eq('ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName')
     end
 
@@ -227,7 +233,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when the titles are in nested structuredValues' do
+  context 'when nested structuredValues' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
     let(:titles) do
@@ -251,16 +257,16 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       ]
     end
 
-    it '.build returns the reconstructed nested structured title' do
-      expect(builder_build).to eq('ti1:nonSort brisk junket')
+    it '.build returns the reconstructed nested structuredValue' do
+      expect(builder_build).to eq 'brisk junket ti1:nonSort'
     end
 
-    it '.full_title returns the reconstructed nested structured title' do
-      expect(full_title).to eq('ti1:nonSort brisk junket')
+    it '.full_title returns the reconstructed nested structuredValue' do
+      expect(full_title).to eq 'brisk junket ti1:nonSort'
     end
 
-    it '.main_title returns the first main title starting with nonsorting characters' do
-      expect(main_title).to eq 'ti1:nonSort brisk junket'
+    it '.main_title returns the (first) main title with nonsorting characters' do
+      expect(main_title).to eq 'brisk junket ti1:nonSort'
     end
 
     it '.additional_titles is empty as there is only one title' do
@@ -287,7 +293,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     context 'when add punctuation is default true' do
-      it '.build returns the reconstructed structured title with punctuation' do
+      it '.build returns the reconstructed structuredValue with punctuation' do
         expect(builder_build).to eq('ti1:partNumber, ti1:partName')
       end
     end
@@ -295,12 +301,12 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     context 'when add punctuation is false' do
       let(:add_punctuation) { false }
 
-      it '.build returns the reconstructed structured title without punctuation' do
+      it '.build returns the reconstructed structuredValue without punctuation' do
         expect(builder_build).to eq('ti1:partNumber ti1:partName')
       end
     end
 
-    it '.full_title returns the reconstructed structured title without punctuation' do
+    it '.full_title returns the reconstructed structuredValue without punctuation' do
       expect(full_title).to eq 'ti1:partNumber ti1:partName'
     end
 
@@ -313,16 +319,16 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when a subtitle is in a structuredValue' do
+  context 'when structuredValue with subtitle' do
     let(:titles) do
       [
         structuredValue: [
           {
-            value: 'A random subtitle',
+            value: 'A starting subtitle',
             type: 'subtitle'
           },
           {
-            value: 'A random title',
+            value: 'A following title',
             type: 'title'
           }
         ]
@@ -330,33 +336,35 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it '.main_title returns the value for type "title"' do
-      expect(main_title).to eq 'A random title'
+      expect(main_title).to eq 'A following title'
     end
 
-    it '.full_title returns the reconstructed structured title without punctuation' do
-      expect(full_title).to eq('A random title A random subtitle')
+    it '.full_title returns the reconstructed structuredValue without punctuation' do
+      expect(full_title).to eq('A starting subtitle A following title')
     end
 
     it '.additional_titles is empty as there is only one title' do
       expect(additional_titles).to eq []
     end
 
-    context 'when add punctuation is default (true)' do
-      it '.build returns the reconstructed structured title' do
-        expect(builder_build).to eq('A random title : A random subtitle')
+    describe '.build' do
+      context 'when add punctuation is default (true)' do
+        it 'returns the reconstructed structuredValue' do
+          expect(builder_build).to eq('A starting subtitleA following title')
+        end
       end
-    end
 
-    context 'when add punctuation is false' do
-      let(:add_punctuation) { false }
+      context 'when add punctuation is false' do
+        let(:add_punctuation) { false }
 
-      it '.build returns the structured title without punctuation' do
-        expect(builder_build).to eq('A random title A random subtitle')
+        it 'returns the structuredValue without punctuation' do
+          expect(builder_build).to eq('A starting subtitle A following title')
+        end
       end
     end
   end
 
-  context 'when multiple subtitles are in a structuredValue' do
+  context 'when structuredValue with multiple subtitles' do
     let(:titles) do
       [
         structuredValue: [
@@ -381,29 +389,31 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it '.full_title returns value for type "title" without punctuation' do
-      expect(full_title).to eq 'A Title The first subtitle The second subtitle'
+      expect(full_title).to eq 'The first subtitle The second subtitle A Title '
     end
 
     it '.additional_titles is empty as there is only one title' do
       expect(additional_titles).to eq []
     end
 
-    context 'when add punctuation is default true' do
-      it '.build returns the reconstructed structured title with punctuation' do
-        expect(builder_build).to eq('A Title : The first subtitle : The second subtitle')
+    describe '.build' do
+      context 'when add punctuation is true (default)' do
+        it 'returns the reconstructed structuredValue with punctuation' do
+          expect(builder_build).to eq('The first subtitle : The second subtitleA Title')
+        end
       end
-    end
 
-    context 'when add punctuation is false' do
-      let(:add_punctuation) { false }
+      context 'when add punctuation is false' do
+        let(:add_punctuation) { false }
 
-      it '.build returns the reconstructed structured title without punctuation' do
-        expect(builder_build).to eq('A Title The first subtitle The second subtitle')
+        it 'returns the reconstructed structuredValue without punctuation' do
+          expect(builder_build).to eq('The first subtitle The second subtitle A Title')
+        end
       end
     end
   end
 
-  context 'when the titles are in a parallelValue' do
+  context 'when parallelValue, one of type subtitle' do
     let(:titles) do
       [
         parallelValue: [
@@ -456,15 +466,15 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       ]
     end
 
-    it '.build returns the title with non sorting characters included' do
+    it '.build returns the title with (count) non sorting characters included' do
       expect(builder_build).to eq('The  means to prosperity')
     end
 
-    it '.main_title returns the title with non sorting characters included' do
+    it '.main_title returns the title with (count) non sorting characters included' do
       expect(main_title).to eq 'The  means to prosperity'
     end
 
-    it '.full_title returns the title with non sorting characters included' do
+    it '.full_title returns the title with (count) non sorting characters included' do
       expect(full_title).to eq 'The  means to prosperity'
     end
   end
@@ -657,13 +667,13 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       expect(actual_result.size).to eq(5)
     end
 
-    context 'with a :first strategy' do
+    context 'with :first strategy' do
       it '.build returns the primary title' do
         expect(builder_build).to eq('Sefer Bet nadiv : sheʼelot u-teshuvot, ḥidushe Torah, derashot')
       end
     end
 
-    context 'with an :all strategy' do
+    context 'with :all strategy' do
       let(:strategy) { :all }
 
       # QUESTION:  shouldn't the uniform titles start with the associated name?
@@ -752,7 +762,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       expect(actual_result.size).to eq(7)
     end
 
-    context 'with a :first strategy' do
+    context 'with :first strategy' do
       # QUESTION:  should this be uniform title?
       # see https://github.com/sul-dlss/cocina-models/issues/657
       it '.build returns the first title' do
@@ -760,7 +770,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       end
     end
 
-    context 'with an :all strategy' do
+    context 'with :all strategy' do
       let(:strategy) { :all }
 
       it '.build returns an array with each title string' do


### PR DESCRIPTION
## Why was this change made? 🤔

On the way to better discovery in Argo (see sul-dlss/dor_indexing_app/issues/1044), I got more information from Arcadia on the correct way to implement title building (See #657).

This PR
- restores the reconstruction of structuredValue to _order of occurrence_
- for main_title and full_title, gets _BOTH_ parallel values (for equal weighting in search result ranking)

## How was this change tested? 🤨

specs.  Will test upcoming gem release with integration tests. 



