### PR TITLE
Validate for title.structuredValue.value having a type

### DIFF
--- a/lib/cocina/models/validators/description_values_validator.rb
+++ b/lib/cocina/models/validators/description_values_validator.rb
@@ -68,7 +68,7 @@ module Cocina
         end
 
         def validate_title_type(hash, path)
-          # only apply to title.structuredValue or relatedResource.title.structuredValue with value
+          # only apply to title.structuredValue, title.parallelValue.structuredValue, or relatedResource.title with a value
           return unless hash[:value] && (path.first == :title || related_resource_title?(path)) && path.include?(:structuredValue)
 
           # if there is a "value" key, make sure there is also a "type" key, only for title.structuredValue
@@ -76,7 +76,8 @@ module Cocina
         end
 
         def related_resource_title?(path)
-          path.first == :relatedResource && path.third == :title
+          # title is directly within relatedResource, e.g [:relatedResource, 0, :title, 0, :structuredValue, 0])
+          path.first == :relatedResource && path[2] == :title
         end
 
         def path_to_s(path)

--- a/spec/cocina/models/validators/description_values_validator_spec.rb
+++ b/spec/cocina/models/validators/description_values_validator_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
         { value: 'A title' },
         { parallelValue: [{ value: 'A title' }, { value: 'Another title' }] },
         { groupedValue: [{ value: 'A title' }, { value: 'Another title' }] },
-        { structuredValue: [{ value: 'A title' }, { value: 'Another title' }] },
+        { structuredValue: [{ value: 'A title', type: 'main title' }, { value: 'Another title', type: 'subtitle' }] },
         { valueAt: 'abc123' }
       ],
       purl: 'https://purl.stanford.edu/bc123df4567',
       relatedResource: [
         {
           title: [
-            { value: 'A related title' }
+            { value: 'A related title' },
+            { structuredValue: [{ value: 'A related title', type: 'main title' }]}
           ],
           type: 'related to'
         }
@@ -65,6 +66,43 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
       }
     end
 
+    let(:no_title_type_props) do
+      {
+        title: [
+          {
+            structuredValue: [{ value: 'A title' }]
+          }
+        ]
+      }
+    end
+
+    let(:multiple_title_structured_value_props) do
+      {
+        title: [
+          {
+            structuredValue: [{ value: 'A title', type: 'main title' }, { value: 'Another title' }]
+          }
+        ]
+      }
+    end
+
+    let(:related_resource_no_title_type_props) do
+      {
+        title: [
+          { value: 'A title' }
+        ],
+        purl: 'https://purl.stanford.edu/bc123df4567',
+        relatedResource: [
+          {
+            title: [
+              { structuredValue: [{ value: 'A related title'}] }
+            ],
+            type: 'related to'
+          }
+        ]
+      }
+    end
+
     let(:request_desc_props) do
       desc_props.dup.tap do |props|
         props.delete(:purl)
@@ -103,6 +141,36 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
         expect do
           validate
         end.to raise_error(Cocina::Models::ValidationError, 'Blank value in description: title1')
+      end
+    end
+
+    describe 'when a no type for title structuredValue in description' do
+      let(:props) { no_title_type_props }
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.structuredValue1')
+      end
+    end
+
+    describe 'when no type for second structuredValue title in description' do
+      let(:props) { multiple_title_structured_value_props }
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.structuredValue2')
+      end
+    end
+
+    describe 'when no type for related resource structured value title in description' do
+      let(:props) { related_resource_no_title_type_props }
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: relatedResource1.title1.structuredValue1')
       end
     end
   end

--- a/spec/cocina/models/validators/description_values_validator_spec.rb
+++ b/spec/cocina/models/validators/description_values_validator_spec.rb
@@ -103,6 +103,56 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
       }
     end
 
+    let(:related_resource_parallel_value_no_type_props) do
+      {
+        title: [
+          { value: 'A title' }
+        ],
+        purl: 'https://purl.stanford.edu/bc123df4567',
+        relatedResource: [
+          { title: [
+            {
+              parallelValue: [
+                {
+                  structuredValue: [
+                    {
+                      value: 'Les',
+                      type: 'nonsorting characters'
+                    },
+                    {
+                      value: 'misérables'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]}
+        ]
+      }
+    end
+
+    let(:parallel_structured_props) do
+      {
+        title: [
+          {
+            parallelValue: [
+              {
+                structuredValue: [
+                  {
+                    value: 'Les',
+                    type: 'nonsorting characters'
+                  },
+                  {
+                    value: 'misérables'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    end
+
     let(:request_desc_props) do
       desc_props.dup.tap do |props|
         props.delete(:purl)
@@ -171,6 +221,26 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesValidator do
         expect do
           validate
         end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: relatedResource1.title1.structuredValue1')
+      end
+    end
+
+    describe 'when no type for related resource parallelValue structured value title in description' do
+      let(:props) { related_resource_parallel_value_no_type_props }
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: relatedResource1.title1.parallelValue1.structuredValue2')
+      end
+    end
+
+    describe 'when structuredValue with no type within parallelValue' do
+      let(:props) { parallel_structured_props }
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.parallelValue1.structuredValue2')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
Validator to address https://github.com/sul-dlss/argo/issues/4279. This goes down one level of nesting (`title.structuredValue`) and also validates one level of `relatedResource.title.structuredValue`. 

## How was this change tested? 🤨
Unit. Ran `bin/validate-cocina` on QA, stage, and prod and there were no existing objects with this problem. 

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



