### PR TITLE
TitleBuilder gets detailed specs from dor_indexing gem

### DIFF
--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -201,6 +201,16 @@ module Cocina
         # @return [String] the title value from combining the pieces of the structured_values by type and order
         #   with desired punctuation per specs
         #
+        # - nonsorting characters value is followed by a space, unless the nonsorting
+        #   character count note has a numeric value equal to the length of the
+        #   nonsorting characters value, in which case no space is inserted
+        # - subtitle is preceded by space colon space, unless it is at the beginning
+        #   of the title string
+        # - partName and partNumber are always separated from each other by comma space
+        # - first partName or partNumber in the string is preceded by period space
+        # - partName or partNumber before nonsorting characters or main title is followed
+        #   by period space
+        #
         # for punctuaion funky town, thank MARC and catalog cards
         #
         # rubocop:disable Metrics/AbcSize
@@ -245,7 +255,7 @@ module Cocina
                        end
             when 'subtitle'
               result = if !add_punctuation?
-                         [result, value].select(&:presence).join(' ')
+                         [result, value.sub(/^:/, '').strip].select(&:presence).join(' ')
                        elsif result.present?
                          # subtitle is preceded by space colon space, unless it is at the beginning of the title string
                          "#{result.sub(/[. :]+$/, '')} : #{value.sub(/^:/, '').strip}"

--- a/spec/cocina/models/builders/title_builder_spec.rb
+++ b/spec/cocina/models/builders/title_builder_spec.rb
@@ -85,7 +85,115 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'with untyped titles' do
+  context 'with single untyped title with simple value' do
+    # Select (only) value; status primary may or may not be present
+    let(:titles) do
+      [
+        { value: 'Simple untyped' }
+      ]
+    end
+
+    it '.main_title contains title' do
+      expect(main_title).to eq ['Simple untyped']
+    end
+
+    it '.full_title contains title' do
+      expect(full_title).to eq ['Simple untyped']
+    end
+
+    it '.additional_titles is empty array' do
+      expect(additional_titles).to eq []
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the title' do
+          expect(builder_build).to eq('Simple untyped')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns single title string' do
+          expect(builder_build).to eq('Simple untyped')
+        end
+      end
+    end
+  end
+
+  context 'with single typed title with simple value' do
+    # Select (only) value; status primary may or may not be present
+    let(:titles) do
+      [
+        {
+          value: 'Simple typed',
+          type: 'translated'
+        }
+      ]
+    end
+
+    it '.main_title contains title' do
+      expect(main_title).to eq ['Simple typed']
+    end
+
+    it '.full_title contains title' do
+      expect(full_title).to eq ['Simple typed']
+    end
+
+    it '.additional_titles is empty array' do
+      expect(additional_titles).to eq []
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the title' do
+          expect(builder_build).to eq('Simple typed')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns single title string' do
+          expect(builder_build).to eq('Simple typed')
+        end
+      end
+    end
+  end
+
+  context 'with space/punctuation/space ending simple value' do
+    # strip one or more instances of .,;:/\ or whitespace at beginning or end of string
+    let(:titles) do
+      [{ value: 'Trailing / ' }]
+    end
+
+    it '.main_title strips trailing whitespace or punctuation of .,;:/\ ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+      expect(main_title).to eq ['Trailing']
+    end
+
+    it '.full_title strips trailing whitespace or punctuation of .,;:/\ ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+      expect(full_title).to eq ['Trailing']
+    end
+
+    describe '.build' do
+      context 'with add_punctuation true' do
+        it 'strips punctuation' do
+          expect(builder_build).to eq('Trailing')
+        end
+      end
+
+      context 'with add_punctuation false' do
+        let(:add_punctuation) { true }
+
+        it 'strips punctuation' do
+          expect(builder_build).to eq('Trailing')
+        end
+      end
+    end
+  end
+
+  context 'with multiple untyped titles with simple values, none primary' do
     let(:titles) do
       [
         { value: 'However am I going to be' },
@@ -117,6 +225,223 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
 
         it 'returns an array with each title string' do
           expect(builder_build).to eq(['However am I going to be', 'A second title'])
+        end
+      end
+    end
+  end
+
+  context 'with multiple untyped titles, last one status primary' do
+    # Select primary
+    let(:titles) do
+      [
+        { value: 'Not Primary' },
+        { value: 'Primary Title', status: 'primary' }
+      ]
+    end
+
+    it '.main_title contains primary title' do
+      expect(main_title).to eq ['Primary Title']
+    end
+
+    it '.full_title contains primary title' do
+      expect(full_title).to eq ['Primary Title']
+    end
+
+    it '.additional_titles contains non-primary title' do
+      expect(additional_titles).to eq ['Not Primary']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('Primary Title')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['Not Primary', 'Primary Title'])
+        end
+      end
+    end
+  end
+
+  context 'with multiple typed and untyped titles, one primary' do
+    # Select first without type
+    let(:titles) do
+      [
+        {
+          value: 'Not Primary'
+        },
+        {
+          value: 'Primary Title',
+          type: 'translated',
+          status: 'primary'
+        }
+      ]
+    end
+
+    it '.main_title contains primary title' do
+      expect(main_title).to eq ['Primary Title']
+    end
+
+    it '.full_title contains primary title' do
+      expect(full_title).to eq ['Primary Title']
+    end
+
+    it '.additional_titles contains non-primary title' do
+      expect(additional_titles).to eq ['Not Primary']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('Primary Title')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['Not Primary', 'Primary Title'])
+        end
+      end
+    end
+  end
+
+  context 'with multiple typed and untyped titles, none primary' do
+    # Select first without type
+    let(:titles) do
+      [
+        {
+          value: 'Title 1',
+          type: 'alternative'
+        },
+        {
+          value: 'Title 2'
+        },
+        {
+          value: 'Title 3'
+        }
+      ]
+    end
+
+    it '.main_title contains first value without type' do
+      expect(main_title).to eq ['Title 2']
+    end
+
+    it '.full_title contains first value without type' do
+      expect(full_title).to eq ['Title 2']
+    end
+
+    it '.additional_titles contains the other values' do
+      expect(additional_titles).to eq ['Title 1', 'Title 3']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first value without type' do
+          expect(builder_build).to eq('Title 2')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['Title 1', 'Title 2', 'Title 3'])
+        end
+      end
+    end
+  end
+
+  context 'with multiple typed titles, one primary' do
+    # Select primary
+    let(:titles) do
+      [
+        {
+          value: 'Not Primary',
+          type: 'alternative'
+        },
+        {
+          value: 'Primary Title',
+          type: 'translated',
+          status: 'primary'
+        }
+      ]
+    end
+
+    it '.main_title contains primary title' do
+      expect(main_title).to eq ['Primary Title']
+    end
+
+    it '.full_title contains primary title' do
+      expect(full_title).to eq ['Primary Title']
+    end
+
+    it '.additional_titles contains non-primary title' do
+      expect(additional_titles).to eq ['Not Primary']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('Primary Title')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['Not Primary', 'Primary Title'])
+        end
+      end
+    end
+  end
+
+  context 'with multiple typed titles, none primary' do
+    # Select first
+    let(:titles) do
+      [
+        {
+          value: 'Title 1',
+          type: 'translated'
+        },
+        {
+          value: 'Title 2',
+          type: 'alternative'
+        }
+      ]
+    end
+
+    it '.main_title contains first title' do
+      expect(main_title).to eq ['Title 1']
+    end
+
+    it '.full_title contains first title' do
+      expect(full_title).to eq ['Title 1']
+    end
+
+    it '.additional_titles contains second title' do
+      expect(additional_titles).to eq ['Title 2']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'returns the first title' do
+          expect(builder_build).to eq('Title 1')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns an array with each title string' do
+          expect(builder_build).to eq(['Title 1', 'Title 2'])
         end
       end
     end
@@ -154,43 +479,6 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'with a primary title' do
-    let(:titles) do
-      [
-        { value: 'secondary title' },
-        { value: 'primary title', status: 'primary' }
-      ]
-    end
-
-    describe '.build' do
-      context 'with :first strategy' do
-        it 'returns primary title string' do
-          expect(builder_build).to eq('primary title')
-        end
-      end
-
-      context 'with :all strategy' do
-        let(:strategy) { :all }
-
-        it 'returns an array with each title string' do
-          expect(builder_build).to eq(['secondary title', 'primary title'])
-        end
-      end
-    end
-
-    it '.main_title contains primary title string' do
-      expect(main_title).to eq ['primary title']
-    end
-
-    it '.full_title contains primary title string' do
-      expect(full_title).to eq ['primary title']
-    end
-
-    it '.additional_titles contains non-primary title string(s)' do
-      expect(additional_titles).to eq ['secondary title']
-    end
-  end
-
   context 'with a main title (without structuredValue)' do
     let(:titles) do
       [
@@ -216,11 +504,11 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       end
     end
 
-    it 'main_title is first value (weird due to lack of structuredValue)' do
+    it '.main_title is first value (weird due to lack of structuredValue)' do
       expect(main_title).to eq ['zee subtitle']
     end
 
-    it 'full_title is first value (weird due to lack of structuredValue)' do
+    it '.full_title is first value (weird due to lack of structuredValue)' do
       expect(full_title).to eq ['zee subtitle']
     end
 
@@ -229,30 +517,32 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when structuredValue' do
+  # ----- structuredValue tests -----
+
+  context 'with structuredValue with all parts in common order' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
     let(:titles) do
       [
         structuredValue: [
           {
-            value: 'ti1:nonSort',
+            value: 'A',
             type: 'nonsorting characters'
           },
           {
-            value: 'brisk junket',
+            value: 'title',
             type: 'main title'
           },
           {
-            value: 'ti1:subTitle',
+            value: 'a subtitle',
             type: 'subtitle'
           },
           {
-            value: 'ti1:partNumber',
+            value: 'Vol. 1',
             type: 'part number'
           },
           {
-            value: 'ti1:partName',
+            value: 'Supplement',
             type: 'part name'
           }
         ]
@@ -262,7 +552,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     describe '.build' do
       context 'with :first strategy' do
         it 'returns the reconstructed title with punctuation' do
-          expect(builder_build).to eq('ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName')
+          expect(builder_build).to eq('A title : a subtitle. Vol. 1, Supplement')
         end
       end
 
@@ -270,17 +560,17 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
         let(:strategy) { :all }
 
         it 'returns the reconstructed title with punctuation (as a String)' do
-          expect(builder_build).to eq('ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName')
+          expect(builder_build).to eq('A title : a subtitle. Vol. 1, Supplement')
         end
       end
     end
 
     it '.main_title returns the main title with nonsorting characters' do
-      expect(main_title).to eq ['ti1:nonSort brisk junket']
+      expect(main_title).to eq ['A title']
     end
 
     it '.full_title returns the reconstructed title without punctuation' do
-      expect(full_title).to eq ['ti1:nonSort brisk junket ti1:subTitle ti1:partNumber ti1:partName']
+      expect(full_title).to eq ['A title a subtitle Vol. 1 Supplement']
     end
 
     it '.additional_titles is empty as there is only one title' do
@@ -288,7 +578,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when nested structuredValues' do
+  context 'with nested structuredValues' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
     let(:titles) do
@@ -329,7 +619,41 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when the structuredValue has part name and part number only' do
+  context 'with structuredValue with associated name note for uniform title' do
+    # Omit author name from title
+    let(:titles) do
+      [
+        {
+          value: 'Title',
+          type: 'uniform',
+          note: [
+            {
+              value: 'Author, An',
+              type: 'associated name'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title returns the simple value' do
+      expect(main_title).to eq ['Title']
+    end
+
+    it '.full_title returns the simple value' do
+      expect(full_title).to eq ['Title']
+    end
+
+    it '.additional_titles is empty as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+
+    it '.build returns the simple value' do
+      expect(builder_build).to eq('Title')
+    end
+  end
+
+  context 'with the structuredValue has part name and part number only' do
     # from a spreadsheet upload integration test
     #   https://argo-stage.stanford.edu/view/sk561pf3505
     let(:titles) do
@@ -348,13 +672,13 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     describe '.build' do
-      context 'when add punctuation is default true' do
+      context 'with add punctuation is default true' do
         it 'returns the reconstructed value with punctuation' do
           expect(builder_build).to eq('ti1:partNumber, ti1:partName')
         end
       end
 
-      context 'when add punctuation is false' do
+      context 'with add punctuation is false' do
         let(:add_punctuation) { false }
 
         it 'returns the reconstructed value without punctuation' do
@@ -377,7 +701,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when structuredValue with subtitle' do
+  context 'with structuredValue with subtitle' do
     let(:titles) do
       [
         structuredValue: [
@@ -406,13 +730,13 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     describe '.build' do
-      context 'when add punctuation is default (true)' do
+      context 'with add punctuation is default (true)' do
         it 'returns the reconstructed structuredValue' do
           expect(builder_build).to eq('A starting subtitleA following title')
         end
       end
 
-      context 'when add punctuation is false' do
+      context 'with add punctuation is false' do
         let(:add_punctuation) { false }
 
         it 'returns the structuredValue without punctuation' do
@@ -422,7 +746,73 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when structuredValue with multiple subtitles' do
+  context 'with structuredValue only has subtitle' do
+    let(:titles) do
+      [
+        {
+          structuredValue: [
+            {
+              value: 'subtitle value',
+              type: 'subtitle'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title has no value' do
+      expect(main_title).to eq []
+    end
+
+    it '.full_title returns the subtitle value' do
+      expect(full_title).to eq ['subtitle value']
+    end
+
+    it '.additional_titles is empty as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+
+    it '.build returns the subtitle value' do
+      expect(builder_build).to eq('subtitle value')
+    end
+  end
+
+  context 'with structuredValue is subtitle, part name, part number' do
+    let(:titles) do
+      [
+        {
+          structuredValue: [
+            {
+              value: 'Nothing',
+              type: 'subtitle'
+            },
+            {
+              value: 'Series 666',
+              type: 'part name'
+            },
+            {
+              value: 'Vol. 1',
+              type: 'part number'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title has no value' do
+      expect(main_title).to eq []
+    end
+
+    it '.full_title returns the reconstructed title pieces without added punctuation' do
+      expect(full_title).to eq ['Nothing Series 666 Vol. 1']
+    end
+
+    it '.build returns the reconstructed value with punctuation' do
+      expect(builder_build).to eq('Nothing. Series 666, Vol. 1')
+    end
+  end
+
+  context 'with structuredValue with multiple subtitles' do
     let(:titles) do
       [
         structuredValue: [
@@ -455,13 +845,13 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     describe '.build' do
-      context 'when add punctuation is true (default)' do
+      context 'with add punctuation is true (default)' do
         it 'returns the reconstructed structuredValue with punctuation' do
           expect(builder_build).to eq('The first subtitle : The second subtitleA Title')
         end
       end
 
-      context 'when add punctuation is false' do
+      context 'with add punctuation is false' do
         let(:add_punctuation) { false }
 
         it 'returns the reconstructed structuredValue without punctuation' do
@@ -471,7 +861,64 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when structuredValue in strange order' do
+  context 'with structuredValue with parts in uncommon order' do
+    # it uses field order given, unlike stanford_mods
+    # based on ckey 9803970
+    let(:titles) do
+      [
+        {
+          structuredValue: [
+            {
+              value: 'The',
+              type: 'nonsorting characters'
+            },
+            {
+              value: 'title',
+              type: 'main title'
+            },
+            {
+              value: 'Vol. 1',
+              type: 'part number'
+            },
+            {
+              value: 'Supplement',
+              type: 'part name'
+            },
+            {
+              value: 'a subtitle',
+              type: 'subtitle'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title is nonsorting plus main title' do
+      expect(main_title).to eq ['The title']
+    end
+
+    it '.full_title respects order of occurrence (no punctuation)' do
+      expect(full_title).to eq ['The title Vol. 1 Supplement a subtitle']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'uses correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('The title. Vol. 1, Supplement : a subtitle')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns String using correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('The title. Vol. 1, Supplement : a subtitle')
+        end
+      end
+    end
+  end
+
+  context 'with structuredValue with non-sorting not first' do
     let(:titles) do
       [
         structuredValue: [
@@ -516,83 +963,187 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when parallelValue, one of type subtitle' do
+  context 'with structuredValue with multiple partName' do
+    # it uses field order given, unlike stanford_mods
     let(:titles) do
       [
-        parallelValue: [
-          {
-            value: 'subtitle',
-            type: 'subtitle'
-          },
-          {
-            value: 'A Random Title'
-          }
-        ]
+        {
+          structuredValue: [
+            {
+              value: 'Title',
+              type: 'main title'
+            },
+            {
+              value: 'Special series',
+              type: 'part name'
+            },
+            {
+              value: 'Vol. 1',
+              type: 'part number'
+            },
+            {
+              value: 'Supplement',
+              type: 'part name'
+            }
+          ]
+        }
       ]
     end
 
-    it '.build returns the untyped value (rather than subtitle)' do
-      expect(builder_build).to eq('A Random Title')
+    it '.main_title is main title' do
+      expect(main_title).to eq ['Title']
+    end
+
+    it '.full_title respects order of occurrence (no punctuation)' do
+      expect(full_title).to eq ['Title Special series Vol. 1 Supplement']
     end
 
     describe '.build' do
-      context 'with strategy first' do
-        it 'returns untyped title string from parallel value' do
-          expect(builder_build).to eq 'A Random Title'
+      context 'with :first strategy' do
+        it 'uses correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('Title. Special series, Vol. 1, Supplement')
         end
       end
 
-      context 'with strategy all' do
+      context 'with :all strategy' do
         let(:strategy) { :all }
 
-        it 'returns all parallel values' do
-          expect(builder_build).to eq ['subtitle', 'A Random Title']
+        it 'returns String using correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('Title. Special series, Vol. 1, Supplement')
         end
       end
-    end
-
-    it 'main_title returns both values' do
-      expect(main_title).to eq ['subtitle', 'A Random Title']
-    end
-
-    it 'full_title returns both values' do
-      expect(full_title).to eq ['subtitle', 'A Random Title']
-    end
-
-    it '.additional_titles returns empty array as there is only one title' do
-      expect(additional_titles).to eq []
     end
   end
 
-  context 'when multiple nonsorting characters with note' do
+  context 'with structuredValue with part before title' do
+    # it uses field order given, unlike stanford_mods
     let(:titles) do
       [
-        structuredValue: [
-          {
-            value: 'The',
-            type: 'nonsorting characters'
-          }, {
-            value: 'means to prosperity',
-            type: 'main title'
-          }
-        ],
-        note: [
-          {
-            value: '5',
-            type: 'nonsorting character count'
-          }
-        ]
+        {
+          structuredValue: [
+            {
+              value: 'Series 1',
+              type: 'part number'
+            },
+            {
+              value: 'Title',
+              type: 'main title'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title is main title' do
+      expect(main_title).to eq ['Title']
+    end
+
+    it '.full_title respects order of occurrence (no punctuation)' do
+      expect(full_title).to eq ['Series 1 Title']
+    end
+
+    describe '.build' do
+      context 'with :first strategy' do
+        it 'uses correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('Series 1. Title')
+        end
+      end
+
+      context 'with :all strategy' do
+        let(:strategy) { :all }
+
+        it 'returns String using correct punctuation and respects order of occurrence' do
+          expect(builder_build).to eq('Series 1. Title')
+        end
+      end
+    end
+  end
+
+  context 'with structuredValue parts beginning/ending with space/punctuation/space' do
+    # strip one or more instances of .,;:/\ plus whitespace at beginning or end of string
+    let(:titles) do
+      [
+        {
+          structuredValue: [
+            {
+              value: 'Title.',
+              type: 'main title'
+            },
+            {
+              value: ':subtitle ',
+              type: 'subtitle'
+            }
+          ]
+        }
+      ]
+    end
+
+    it '.main_title strips whitespace or punctuation of .,;:/\ from main title' do
+      expect(main_title).to eq ['Title']
+    end
+
+    it '.full_title strips whitespace or punctuation of .,;:/\ from values' do
+      expect(full_title).to eq ['Title subtitle']
+    end
+
+    describe '.build' do
+      context 'with add_punctuation true' do
+        it 'strips punctuation in values and adds combining punctuation' do
+          expect(builder_build).to eq('Title : subtitle')
+        end
+      end
+
+      context 'with add_punctuation false' do
+        let(:add_punctuation) { false }
+
+        it 'strips punctuation in values' do
+          expect(builder_build).to eq('Title subtitle')
+        end
+      end
+    end
+  end
+
+  # nonsorting characters value is followed by a space, unless the nonsorting
+  #   character count note has a numeric value equal to the length of the
+  #   nonsorting characters value, in which case no space is inserted
+  # subtitle is preceded by space colon space, unless it is at the beginning
+  #   of the title string
+  # partName and partNumber are always separated from each other by comma space
+  # first partName or partNumber in the string is preceded by period space
+  # partName or partNumber before nonsorting characters or main title is followed
+  #   by period space
+  context 'with nonsorting characters with count note' do
+    # it does not force a space separator, unlike stanford_mods
+    let(:titles) do
+      [
+        {
+          structuredValue: [
+            {
+              value: 'The',
+              type: 'nonsorting characters'
+            }, {
+              value: 'means to prosperity',
+              type: 'main title'
+            }
+          ],
+          note: [
+            {
+              value: '5',
+              type: 'nonsorting character count'
+            }
+          ]
+        }
       ]
     end
 
     describe '.build' do
-      context 'when add punctuation is default (true)' do
+      context 'with add punctuation is default (true)' do
         it 'returns the title with (count) non sorting characters included' do
           expect(builder_build).to eq('The  means to prosperity')
         end
       end
 
-      context 'when add punctuation is false' do
+      context 'with add punctuation is false' do
         let(:add_punctuation) { false }
 
         it 'returns the title with (count) non sorting characters included' do
@@ -610,7 +1161,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when multiple nonsorting characters without note' do
+  context 'with nonsorting characters without count note' do
     let(:titles) do
       [
         structuredValue: [
@@ -638,7 +1189,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when multiple nonsorting characters ends in dash, without note' do
+  context 'with nonsorting characters ends in dash, without count note' do
     let(:titles) do
       [
         structuredValue: [
@@ -654,13 +1205,13 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     describe '.build' do
-      context 'when add punctuation is default (true)' do
+      context 'with add punctuation is default (true)' do
         it 'returns the title with non sorting characters included, no space' do
           expect(builder_build).to eq('The-means to prosperity')
         end
       end
 
-      context 'when add punctuation is false' do
+      context 'with add punctuation is false' do
         let(:add_punctuation) { false }
 
         it 'returns the title with non sorting characters included, no space' do
@@ -678,7 +1229,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when multiple nonsorting characters without note, ends in apostrophe' do
+  context 'with nonsorting characters ends in apostrophe, without count note' do
     let(:titles) do
       [
         structuredValue: [
@@ -706,7 +1257,336 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
   end
 
-  context 'when multiple titles with parallel values, status primary on half of one parallel value' do
+  # ----- parallelValue tests -----
+
+  context 'with parallelValue with status primary on one value' do
+    # Select primary
+    let(:titles) do
+      [
+        {
+          parallelValue: [
+            {
+              value: 'Not Primary'
+            },
+            {
+              value: 'Primary Value',
+              status: 'primary'
+            }
+          ]
+        }
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        it 'returns value with primary status from parallel value' do
+          expect(builder_build).to eq 'Primary Value'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all parallel values' do
+          expect(builder_build).to eq ['Not Primary', 'Primary Value']
+        end
+      end
+    end
+
+    it '.main_title returns primary value' do
+      expect(main_title).to eq ['Primary Value']
+    end
+
+    it '.full_title returns both values as there is only one top level title' do
+      expect(full_title).to eq ['Not Primary', 'Primary Value']
+    end
+
+    it '.additional_titles returns empty array as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+  end
+
+  context 'with parallelValue of status primary' do
+    let(:titles) do
+      [
+        {
+          parallelValue: [
+            { value: 'First' },
+            { value: 'Second' }
+          ],
+          status: 'primary'
+        }
+      ]
+    end
+
+    describe '.build' do
+      # For display, select first value in primary parallelValue
+      context 'with strategy first' do
+        it 'returns first parallel value' do
+          expect(builder_build).to eq 'First'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all parallel values' do
+          expect(builder_build).to eq %w[First Second]
+        end
+      end
+    end
+
+    it '.main_title returns both values there is only one top level title' do
+      expect(main_title).to eq %w[First Second]
+    end
+
+    it '.full_title returns both values as there is only one top level title' do
+      expect(full_title).to eq %w[First Second]
+    end
+
+    it '.additional_titles returns empty array as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+  end
+
+  context 'with parallelValue of status primary and status primary on one value' do
+    let(:titles) do
+      [
+        {
+          parallelValue: [
+            {
+              value: 'Not Primary'
+            },
+            {
+              value: 'Primary',
+              status: 'primary'
+            }
+          ],
+          status: 'primary'
+        }
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        # Select primary value in primary parallelValue
+        it 'returns value with primary status from parallel value' do
+          expect(builder_build).to eq 'Primary'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all parallel values' do
+          expect(builder_build).to eq ['Not Primary', 'Primary']
+        end
+      end
+    end
+
+    it '.main_title returns single value of type primary' do
+      expect(main_title).to eq ['Primary']
+    end
+
+    it '.full_title returns both values as there is only one top level title' do
+      expect(full_title).to eq ['Not Primary', 'Primary']
+    end
+
+    it '.additional_titles returns empty array as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+  end
+
+  context 'with primary on both one of a parallelValue and on a simple value' do
+    # Select simple value with primary; the parallelValue is not itself the primary title,
+    # but one value is primary within the parallelValue
+    let(:titles) do
+      [
+        {
+          parallelValue: [
+            {
+              value: 'Primary Parallel',
+              status: 'primary'
+            },
+            {
+              value: 'Ordinary Parallel'
+            }
+          ]
+        },
+        {
+          value: 'Simple Primary',
+          status: 'primary'
+        }
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        # Select primary value in primary parallelValue
+        it 'returns simple top level value with primary status' do
+          expect(builder_build).to eq 'Simple Primary'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all values' do
+          expect(builder_build).to eq ['Primary Parallel', 'Ordinary Parallel', 'Simple Primary']
+        end
+      end
+    end
+
+    it '.main_title returns simple top level value with primary status' do
+      expect(main_title).to eq ['Simple Primary']
+    end
+
+    it '.full_title returns simple top level value with primary status' do
+      expect(full_title).to eq ['Simple Primary']
+    end
+
+    it '.additional_titles returns both values of parallelValue as they are not considered primary' do
+      expect(additional_titles).to eq ['Primary Parallel', 'Ordinary Parallel']
+    end
+  end
+
+  context 'with parallelValue (first) and simple value, no primary' do
+    # Select first value
+    let(:titles) do
+      [
+        {
+          parallelValue: [
+            {
+              value: 'Parallel 1'
+            },
+            {
+              value: 'Parallel 2'
+            }
+          ]
+        },
+        {
+          value: 'Simple'
+        }
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        it 'returns first value of parallelValue (which is first)' do
+          expect(builder_build).to eq 'Parallel 1'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all values' do
+          expect(builder_build).to eq ['Parallel 1', 'Parallel 2', 'Simple']
+        end
+      end
+    end
+
+    it '.main_title returns both values of parallelValue (which is first)' do
+      expect(main_title).to eq ['Parallel 1', 'Parallel 2']
+    end
+
+    it '.full_title returns both values of parallelValue (which is first)' do
+      expect(full_title).to eq ['Parallel 1', 'Parallel 2']
+    end
+
+    it '.additional_titles returns simple value (which is second)' do
+      expect(additional_titles).to eq ['Simple']
+    end
+  end
+
+  context 'with parallelValue with additional value, value first, no primary' do
+    # Select first value
+    let(:titles) do
+      [
+        { value: 'Simple' },
+        {
+          parallelValue: [
+            { value: 'Parallel 1' },
+            { value: 'Parallel 2' }
+          ]
+        }
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        it 'returns first value' do
+          expect(builder_build).to eq 'Simple'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all values' do
+          expect(builder_build).to eq ['Simple', 'Parallel 1', 'Parallel 2']
+        end
+      end
+    end
+
+    it '.main_title returns first value' do
+      expect(main_title).to eq ['Simple']
+    end
+
+    it '.full_title returns first value' do
+      expect(full_title).to eq ['Simple']
+    end
+
+    it '.additional_titles returns simple value (which is second)' do
+      expect(additional_titles).to eq ['Parallel 1', 'Parallel 2']
+    end
+  end
+
+  context 'with parallelValue, one of type subtitle' do
+    let(:titles) do
+      [
+        parallelValue: [
+          {
+            value: 'subtitle',
+            type: 'subtitle'
+          },
+          {
+            value: 'A Random Title'
+          }
+        ]
+      ]
+    end
+
+    describe '.build' do
+      context 'with strategy first' do
+        it 'returns untyped title string from parallel value' do
+          expect(builder_build).to eq 'A Random Title'
+        end
+      end
+
+      context 'with strategy all' do
+        let(:strategy) { :all }
+
+        it 'returns all parallel values' do
+          expect(builder_build).to eq ['subtitle', 'A Random Title']
+        end
+      end
+    end
+
+    it '.main_title returns both values' do
+      expect(main_title).to eq ['subtitle', 'A Random Title']
+    end
+
+    it '.full_title returns both values' do
+      expect(full_title).to eq ['subtitle', 'A Random Title']
+    end
+
+    it '.additional_titles returns empty array as there is only one title' do
+      expect(additional_titles).to eq []
+    end
+  end
+
+  context 'with multiple titles with parallel values, status primary on half of one parallel value' do
     # based on bb022pc9382
     let(:titles) do
       [


### PR DESCRIPTION
## Why was this change made? 🤔

specs should live with the code;  I suspect TitleBuilder was moved from dor_indexing_app to cocina-models at some point and all the specs didn't come over with it.

I discovered these specs when I started to use the new "main_title" and "full_title" and "additional_titles" fields in dor_indexing gem.


## How was this change tested? 🤨

CI.  Trivial code change;  it was just adding lots of specs.


