### PR TITLE
[HOLD] Initial map coordinates validator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       dry-types (~> 1.1)
       edtf
       equivalent-xml
+      geo_coord
       i18n
       jsonpath
       nokogiri
@@ -72,6 +73,7 @@ GEM
       activesupport (>= 3.0, < 8.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    geo_coord (0.2.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -80,12 +82,12 @@ GEM
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
-    mini_portile2 (2.8.5)
     minitest (5.22.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
-    nokogiri (1.16.2)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
@@ -161,7 +163,8 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-types', '~> 1.1'
   spec.add_dependency 'edtf' # used for date/time validation
   spec.add_dependency 'equivalent-xml' # for diffing MODS
+  spec.add_dependency 'geo_coord' # for validating map coordinates
   spec.add_dependency 'i18n' # for validating BCP 47 language tags, according to RFC 4646
   spec.add_dependency 'jsonpath' # used for date/time validation
   spec.add_dependency 'nokogiri'

--- a/lib/cocina/models/validators/map_coordinates_validator.rb
+++ b/lib/cocina/models/validators/map_coordinates_validator.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'geo/coord'
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that geospatial coordinates are parseable in DMS notation
+      class MapCoordinatesValidator
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+        end
+
+        # Valid if no coordinates, or all coordinates are parseable
+        def validate
+          coordinates.map(&method(:parse))
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def druid
+          @druid ||= attributes[:externalIdentifier]
+        end
+
+        # Text of all 'subject' elements of type 'map coordinates', if any
+        def coordinates
+          @coordinates ||= (attributes.dig(:description, :subject) || [])
+                           .select { |subject| subject[:type] == 'map coordinates' }
+                           .map { |subject| subject[:value] }
+        end
+
+        # Coordinates are separated by -- or /
+        # Example: W 62°51ʹ00ʺ--W 62°04ʹ00ʺ--N 17°30ʹ20ʺ--N 16°32ʹ00ʺ
+        COORD_SEPARATOR = %r{ ?--|/}
+
+        # Attempt to parse coordinates in DMS notation
+        def parse(coordinate_text)
+          coordinate_parts = coordinate_text.split(COORD_SEPARATOR)
+          case coordinate_parts.length
+          when 2  # single point
+            [parse_coord(coordinate_parts[0], coordinate_parts[1])]
+          when 4  # bounding box
+            [parse_coord(coordinate_parts[0], coordinate_parts[2]), parse_coord(coordinate_parts[1], coordinate_parts[3])]
+          else
+            raise ValidationError, "Invalid map coordinates for #{druid}: #{coordinate_text}"
+          end
+        rescue ArgumentError, InvalidLatLongError
+          raise ValidationError, "Invalid map coordinates for #{druid}: #{coordinate_text}"
+        end
+
+        # Coordinate validation from:
+        # https://github.com/iiif-prezi/osullivan/blob/a2a53e1949660e71b0429d58c1224d85697b07df/lib/iiif/v3/presentation/nav_place.rb
+        COORD_REGEX = /(?<hemisphere>[NSEW]) (?<degrees>\d+)[°⁰*] ?(?<minutes>\d+)?[ʹ']? ?(?<seconds>\d+)?[ʺ"]?/
+
+        # Custom error type so we can catch it separately
+        class InvalidLatLongError < StandardError; end
+
+        # Attempt to parse a single coordinate from longitude/latitude strings
+        # Raises InvalidLatLongError if the lat/long aren't parseable
+        # Raises ArgumentError if the lat/long are out of bounds/invalid
+        def parse_coord(long_str, lat_str)
+          long = long_str.match(COORD_REGEX)
+          lat = lat_str.match(COORD_REGEX)
+          raise InvalidLatLongError unless long && lat
+
+          Geo::Coord.new(
+            latd: lat[:degrees], latm: lat[:minutes], lats: lat[:seconds], lath: lat[:hemisphere],
+            lngd: long[:degrees], lngm: long[:minutes], lngs: long[:seconds], lngh: long[:hemisphere]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -14,7 +14,8 @@ module Cocina
           DescriptionTypesValidator,
           DescriptionValuesValidator,
           DateTimeValidator,
-          LanguageTagValidator
+          LanguageTagValidator,
+          MapCoordinatesValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/spec/cocina/models/validators/map_coordinates_validator_spec.rb
+++ b/spec/cocina/models/validators/map_coordinates_validator_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::MapCoordinatesValidator do
+  subject(:validate) { described_class.validate(clazz, props) }
+
+  let(:clazz) { Cocina::Models::DRO }
+
+  context 'when valid' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:jq000jd3530',
+        description: {
+          subject: [
+            {
+              value: 'W 62°51ʹ00ʺ--W 62°04ʹ00ʺ--N 17°30ʹ20ʺ--N 16°32ʹ00ʺ',
+              type: 'map coordinates'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context 'when no subject with map coordinates' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:jq000jd3530',
+        description: {
+          subject: [
+            {
+              value: 'Some info about this item.',
+              type: 'abstract'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context 'when out of bounds invalid coordinates' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:xq000jd3530',
+        description: {
+          subject: [
+            {
+              value: '-W 450°00ʹ00ʺ--W -200°00ʹ00ʺ--N 150°00ʹ00ʺ--N 0°0ʹ00ʺ',
+              type: 'map coordinates'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'raises' do
+      expect do
+        validate
+      end.to raise_error(
+        Cocina::Models::ValidationError,
+        'Invalid map coordinates for druid:xq000jd3530: -W 450°00ʹ00ʺ--W -200°00ʹ00ʺ--N 150°00ʹ00ʺ--N 0°0ʹ00ʺ'
+      )
+    end
+  end
+
+  context 'when extra characters in coordinates' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:xq000jd3530',
+        description: {
+          subject: [
+            {
+              value: 'W 62°51ʹ00ʺ--W 62°04ʹ00ʺ--N 17°30ʹ20ʺ--N 16°32ʹ00ʺ).',
+              type: 'map coordinates'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context 'when coordinates contains non-coordinate data' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:xq000jd3530',
+        description: {
+          subject: [
+            {
+              value: 'W 62°51ʹ00ʺ--just kidding!!',
+              type: 'map coordinates'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'raises' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Invalid map coordinates for druid:xq000jd3530: W 62°51ʹ00ʺ--just kidding!!'
+      )
+    end
+  end
+
+  context 'when there are the wrong number of valid coordinates' do
+    let(:props) do
+      {
+        externalIdentifier: 'druid:xq000jd3530',
+        description: {
+          subject: [
+            {
+              value: 'W 62°51ʹ00ʺ--W 62°04ʹ00ʺ--N 17°30ʹ20ʺ',
+              type: 'map coordinates'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'raises' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Invalid map coordinates for druid:xq000jd3530: W 62°51ʹ00ʺ--W 62°04ʹ00ʺ--N 17°30ʹ20ʺ'
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Refs #663. 

<s>@thatbudakguy there's probably some room to improve the clarity of the code. I made a few tweaks to the NavPlace code for it to fit here. Note that the NavPlace logic can handle extra characters in the coordinates string (it has a regex to extract the coordinates), so this validator does not care about that either. 

Also probably good to add other invalid coordinates tests. </s>

## How was this change tested? 🤨
Unit tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



