### PR TITLE
[HOLD] Map MODS tableOfContents with double-hyphens as simple (not structured) Cocina value

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -494,3 +494,7 @@ RSpec/SpecFilePathFormat: # new in 2.24
   Enabled: true
 RSpec/SpecFilePathSuffix: # new in 2.24
   Enabled: true
+RSpec/IsExpectedSpecify: # new in 2.27
+  Enabled: true
+RSpec/RepeatedSubjectCall: # new in 2.27
+  Enabled: true

--- a/lib/cocina/models/mapping/from_mods/note.rb
+++ b/lib/cocina/models/mapping/from_mods/note.rb
@@ -141,12 +141,7 @@ module Cocina
             }.tap do |attributes|
               value_language = LanguageScript.build(node: node)
               attributes[:valueLanguage] = value_language if value_language
-              value_parts = node.content.split(' -- ')
-              if value_parts.size == 1
-                attributes[:value] = node.content
-              elsif value_parts.present?
-                attributes[:structuredValue] = value_parts.map { |value_part| { value: value_part } }
-              end
+              attributes[:value] = node.content if node.content.present?
             end.compact
           end
 

--- a/spec/cocina/models/mapping/descriptive/mods/table_of_contents_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/mods/table_of_contents_spec.rb
@@ -36,17 +36,7 @@ RSpec.describe 'MODS tableOfContents <--> cocina mappings' do
         {
           note: [
             {
-              structuredValue: [
-                {
-                  value: 'Chapter 1.'
-                },
-                {
-                  value: 'Chapter 2.'
-                },
-                {
-                  value: 'Chapter 3.'
-                }
-              ],
+              value: 'Chapter 1. -- Chapter 2. -- Chapter 3.',
               type: 'table of contents'
             }
           ]


### PR DESCRIPTION
# Why was this change made?

Fixes #687

* Map MODS tableOfContents with double-hyphens as simple (not structured) Cocina value

Also includes:

* Add missing linter rules

# How was this change tested?

- [ ] CI
- [ ] [prod validation](https://github.com/sul-dlss/cocina-models#testing-validation-changes)
