### PR TITLE
Fix typo in method that builds objects with metadata

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -85,7 +85,7 @@ module Cocina
               when *DRO::TYPES
                 has_metadata?(dyn) ? DROWithMetadata : DRO
               when *Collection::TYPES
-                has_metadata?(dyn) ? ColectionWithMetadata : Collection
+                has_metadata?(dyn) ? CollectionWithMetadata : Collection
               when *AdminPolicy::TYPES
                 has_metadata?(dyn) ? AdminPolicyWithMetadata : AdminPolicy
               else


### PR DESCRIPTION
# Why was this change made?

So we can build collections with metadata.

# How was this change tested?

CI. It's only a typo fix.


