### PR TITLE
README: minor tweak to release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Send a note to `#dlss-infra-chg-mgmt` on Slack to let people know what is changi
 
 ### Step 1: Cut the release
 
-The release process is much like any other gem. First bump the version in `lib/cocina/models/version.rb`, and commit the result. Then run:
+The release process is much like any other gem. First bump the version in `lib/cocina/models/version.rb`, then `bundle install` so that `Gemfile.lock` is updated, then commit and push those changes. Then run:
 ```
 bundle exec rake release
 ```


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

reminder to `bundle install` when bumping the gem version

i didn't forget to do it this time, but i have forgotten to do it in the past, so a reminder seemed nice 🙂 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



