### PR TITLE
Remove depenency on RSS gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ PATH
       nokogiri
       openapi3_parser
       openapi_parser (~> 1.0)
-      rss
       super_diff
       thor
       zeitwerk (~> 2.1)
@@ -118,8 +117,6 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rss (0.3.0)
-      rexml
     rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   # Match these version requirements to what committee wants,
   # so that our client (non-committee) users have the same dependencies.
   spec.add_dependency 'openapi_parser', '~> 1.0'
-  spec.add_dependency 'rss' # used for date/time validation
   spec.add_dependency 'super_diff'
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.1'

--- a/lib/cocina/models/validators/date_time_validator.rb
+++ b/lib/cocina/models/validators/date_time_validator.rb
@@ -2,7 +2,6 @@
 
 require 'edtf'
 require 'jsonpath'
-require 'rss'
 
 module Cocina
   module Models
@@ -87,18 +86,7 @@ module Cocina
         end
 
         def valid_w3cdtf?(value)
-          Time.w3cdtf(value)
-          true
-        rescue StandardError
-          # NOTE: the upstream W3CDTF implementation in the `rss` gem does not
-          #       allow two patterns that should be valid per the specification:
-          #
-          # * YYYY
-          # * YYYY-MM
-          #
-          # This catches the false positives from the upstream gem and allow
-          # these two patterns to validate
-          /\A\d{4}(-0[1-9]|-1[0-2])?\Z/.match?(value)
+          W3cdtfValidator.validate(value)
         end
 
         def druid

--- a/lib/cocina/models/validators/w3cdtf_validator.rb
+++ b/lib/cocina/models/validators/w3cdtf_validator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates w3cdtf date
+      class W3cdtfValidator
+        REGEX = /\A(?<year>\d{4})(?:-(?<month>\d\d)(?:-(?<day>\d\d)(?<time>T\d\d:\d\d(?::\d\d(?:.\d+)?)?(?:Z|[+-]\d\d:\d\d))?)?)?\z/ix
+
+        def self.validate(date)
+          new(date).validate
+        end
+
+        def initialize(date)
+          @date = date
+        end
+
+        # The W3CDTF format is defined here: http://www.w3.org/TR/NOTE-datetime
+        #
+        # Year:
+        #    YYYY (eg 1997)
+        # Year and month:
+        #    YYYY-MM (eg 1997-07)
+        # Complete date:
+        #    YYYY-MM-DD (eg 1997-07-16)
+        # Complete date plus hours and minutes:
+        #    YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+        # Complete date plus hours, minutes and seconds:
+        #    YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+        # Complete date plus hours, minutes, seconds and a decimal fraction of a second
+        #    YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+        def validate
+          return false unless (matches = @date.match(REGEX))
+          return true unless matches[:month]
+          return (1..12).include? matches[:month].to_i unless matches[:day]
+
+          Date.parse(@date)
+
+          true
+        rescue Date::Error
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/w3cdtf_validator_spec.rb
+++ b/spec/cocina/models/validators/w3cdtf_validator_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::W3cdtfValidator do
+  subject(:validate) { described_class.validate(date) }
+
+  context 'with a bad date' do
+    let(:date) { '340' }
+
+    it { is_expected.to be false }
+  end
+
+  context 'with a year' do
+    let(:date) { '1997' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a year and month' do
+    let(:date) { '1997-07' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a year and month out of range' do
+    let(:date) { '1997-13' }
+
+    it { is_expected.to be false }
+  end
+
+  context 'with a complete date' do
+    let(:date) { '1997-07-16' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a compete date that has a day out of range' do
+    let(:date) { '1997-02-30' }
+
+    it { is_expected.to be false }
+  end
+
+  context 'with a complete date plus hours, minutes' do
+    let(:date) { '1997-07-16T19:20+01:00' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a complete date plus hours, minutes, seconds' do
+    let(:date) { '1997-07-16T19:20:30+01:00' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a complete date plus hours, minutes, seconds, and a decimal fraction of a second' do
+    let(:date) { '1997-07-16T19:20:30.45+01:00' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a complete date + time, and UTC zone' do
+    let(:date) { '1997-07-16T19:20Z' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with a complete date + time, but missing TZ' do
+    let(:date) { '1997-07-16T19:20' }
+
+    it { is_expected.to be false }
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Write our own (better) w3cdtf validator. Drop an unnecessary dependency.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



