### PR TITLE
allow factory to set reading order

### DIFF
--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -96,7 +96,7 @@ module Cocina
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def self.build_request_dro_properties(type:, version:, label:, title:, source_id:, admin_policy_id:,
+      def self.build_request_dro_properties(type:, version:, label:, title:, source_id:, admin_policy_id:, reading_order: nil,
                                             barcode: nil, catkeys: [], folio_instance_hrids: [], collection_ids: [])
         {
           type: type,
@@ -125,6 +125,7 @@ module Cocina
             end
           end
           props[:identification][:barcode] = barcode if barcode
+          props[:structural][:hasMemberOrders] = [{ viewingDirection: reading_order }] if reading_order.present?
         end
       end
       # rubocop:enable Metrics/ParameterLists


### PR DESCRIPTION
## Why was this change made? 🤔

Allow specs using factories to set the reading order when building a Dro.

Useful for cases like https://github.com/sul-dlss/pre-assembly/pull/1453


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



