### PR TITLE
Don't delete utils.rb when re-generating

### DIFF
--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -127,11 +127,12 @@ module Cocina
         run("rubocop -a #{filepaths.join(' ')} > /dev/null")
       end
 
-      NO_CLEAN = [
-        'checkable.rb',
-        'validatable.rb',
-        'version.rb',
-        'vocabulary.rb'
+      NO_CLEAN = %w[
+        checkable.rb
+        utils.rb
+        validatable.rb
+        version.rb
+        vocabulary.rb
       ].freeze
 
       def clean_output


### PR DESCRIPTION
## Why was this change made? 🤔
Otherwise this file gets deleted.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



