### PR TITLE
Enable new cops and update violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -303,7 +303,7 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true
 Style/NestedFileDirname: # new in 1.26
   Enabled: true
@@ -343,7 +343,7 @@ RSpec/ChangeByZero: # new in 2.11.0
   Enabled: true
 Capybara/SpecificMatcher: # new in 2.12
   Enabled: false
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: false
 
 RSpec/ClassCheck: # new in 2.13
@@ -394,9 +394,9 @@ FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
 FactoryBot/FactoryNameStyle: # new in 2.16
   Enabled: true
-RSpec/Rails/InferredSpecType: # new in 2.14
+RSpecRails/InferredSpecType: # new in 2.14
   Enabled: true
-RSpec/Rails/MinitestAssertions: # new in 2.17
+RSpecRails/MinitestAssertions: # new in 2.17
   Enabled: true
 Style/RedundantHeredocDelimiterQuotes: # new in 1.45
   Enabled: true
@@ -411,7 +411,7 @@ RSpec/RedundantAround: # new in 2.19
   Enabled: true
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
-RSpec/Rails/TravelAround: # new in 2.19
+RSpecRails/TravelAround: # new in 2.19
   Enabled: true
 
 Lint/DuplicateMatchPattern: # new in 1.50
@@ -457,7 +457,7 @@ Style/YAMLFileRead: # new in 1.53
   Enabled: true
 RSpec/ReceiveMessages: # new in 2.23
   Enabled: true
-RSpec/Rails/NegationBeValid: # new in 2.23
+RSpecRails/NegationBeValid: # new in 2.23
   Enabled: true
 
 Lint/ItWithoutArgumentsInBlock: # new in 1.59
@@ -497,4 +497,17 @@ RSpec/SpecFilePathSuffix: # new in 2.24
 RSpec/IsExpectedSpecify: # new in 2.27
   Enabled: true
 RSpec/RepeatedSubjectCall: # new in 2.27
+  Enabled: true
+
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+RSpec/ExpectInLet: # new in 2.30
+  Enabled: true
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
   Enabled: true

--- a/lib/cocina/models/builders/name_title_group_builder.rb
+++ b/lib/cocina/models/builders/name_title_group_builder.rb
@@ -71,11 +71,7 @@ module Cocina
         def self.contributor_name_value_slices(contributor)
           return if contributor&.name.blank?
 
-          slices = []
-          Array(contributor.name).each do |contrib_name|
-            slices << value_slices(contrib_name)
-          end
-          slices.flatten
+          Array(contributor.name).map { |contrib_name| value_slices(contrib_name) }.flatten
         end
 
         # @params [Cocina::Models::DescriptiveValue] desc_value

--- a/lib/cocina/models/mapping/from_mods/admin_metadata.rb
+++ b/lib/cocina/models/mapping/from_mods/admin_metadata.rb
@@ -73,9 +73,8 @@ module Cocina
           end
 
           def build_note
-            notes = []
-            record_origins.each do |record_origin|
-              notes << {
+            notes = record_origins.map do |record_origin|
+              {
                 type: 'record origin',
                 value: record_origin.text
               }

--- a/lib/cocina/models/mapping/from_mods/event.rb
+++ b/lib/cocina/models/mapping/from_mods/event.rb
@@ -196,9 +196,8 @@ module Cocina
           end
 
           def build_date_values(origin_info_node)
-            date_values = []
-            DATE_ELEMENTS_2_TYPE.each do |mods_el_name, cocina_type|
-              date_values << build_date_desc_values(mods_el_name, origin_info_node, cocina_type)
+            date_values = DATE_ELEMENTS_2_TYPE.map do |mods_el_name, cocina_type|
+              build_date_desc_values(mods_el_name, origin_info_node, cocina_type)
             end
             date_values.flatten.compact
           end

--- a/lib/cocina/models/validatable.rb
+++ b/lib/cocina/models/validatable.rb
@@ -15,7 +15,7 @@ module Cocina
 
       def new(*args)
         validate = args.first.delete(:validate) if args.present?
-        new_model = super(*args)
+        new_model = super
         Validators::Validator.validate(new_model.class, new_model) if validate || validate.nil?
         new_model
       end


### PR DESCRIPTION
Just a rubocop update to enable new cops and quiet the warnings/violations

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



