### PR TITLE
Add a validator for was-seed objects

### DIFF
--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -15,7 +15,8 @@ module Cocina
           DescriptionValuesValidator,
           DateTimeValidator,
           LanguageTagValidator,
-          ReservedFilenameValidator
+          ReservedFilenameValidator,
+          WasSeedValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/lib/cocina/models/validators/was_seed_validator.rb
+++ b/lib/cocina/models/validators/was_seed_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that descriptive has a webarchive url
+      class WasSeedValidator
+        def self.validate(_, attributes)
+          new(_, attributes).validate
+        end
+
+        def initialize(_, attributes)
+          @attributes = attributes
+        end
+
+        def validate
+          return unless attributes[:type] == 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+
+          archived_website_url = attributes.dig(:description, :access, :url)&.
+            find { |url| url[:displayLabel] == 'Archived website' }&.fetch(:value)
+          return if archived_website_url&.include?('/*/')
+
+          raise ValidationError, 'Archived website url is not present'
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/was_seed_validator_spec.rb
+++ b/spec/cocina/models/validators/was_seed_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::WasSeedValidator do
+  let(:validate) { described_class.validate(Cocina::Models::DRO, props) }
+
+  let(:props) do
+    {
+      externalIdentifier: 'druid:bc123df4567',
+      type: Cocina::Models::ObjectType[:'webarchive-seed'],
+      access: { view: 'public', download: 'none' },
+      structural: { contains: [ ] },
+      description:
+    }
+  end
+
+
+  context 'when a valid webarchive' do
+    let(:description) do
+      {
+        access: {
+          url: [
+            {
+              displayLabel: 'Archived website',
+              value: 'https://swap.stanford.edu/was/*/http://markey.house.gov/content/letters-major-data-brokers'
+            }
+          ]
+        }
+      }
+    end
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  context 'when an malformed url' do
+    let(:description) do
+      {
+        access: {
+          url: [
+            {
+              displayLabel: 'Archived website',
+              value: 'https://swap.stanford.edu/was//http://markey.house.gov/content/letters-major-data-brokers'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'is not valid' do
+      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+
+  context 'when an no url' do
+    let(:description) do
+      { }
+    end
+
+    it 'is not valid' do
+      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

Prevent bad data from breaking the viewers in the access system.

## How was this change tested? 🤨
test suite.

