### PR TITLE
Add required source_id to rspec collection factory

### DIFF
--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -62,7 +62,8 @@ module Cocina
         version: 1,
         label: 'factory collection label',
         title: 'factory collection title',
-        admin_policy_id: 'druid:hv992ry2431'
+        admin_policy_id: 'druid:hv992ry2431',
+        source_id: 'sulcollection:1234'
       }.freeze
 
       REQUEST_COLLECTION_DEFAULTS = COLLECTION_DEFAULTS.except(:id)


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

SourceID is required in collections, so any tests that use the factory to build a collection will fail when validating the collection record with a missing source_id.


## How was this change tested? 🤨

unit tests using this builder

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



