### PR TITLE
Vary commonmarker pin depending on Ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cocina-models (0.99.2)
       activesupport
+      commonmarker (~> 2.0, != 2.0.2)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -43,7 +44,7 @@ GEM
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 1.0)
       rack (>= 1.5)
-    commonmarker (2.0.2)
+    commonmarker (2.0.1)
       rb_sys (~> 0.9)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     cocina-models (0.99.2)
       activesupport
-      commonmarker (= 2.0.1)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -44,7 +43,7 @@ GEM
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 1.0)
       rack (>= 1.5)
-    commonmarker (2.0.1)
+    commonmarker (2.0.2)
       rb_sys (~> 0.9)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'commonmarker', '2.0.1' # There is a breaking change in 2.0.2 with openapi3_parser
   spec.add_dependency 'deprecation'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -25,6 +25,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'activesupport'
+  if RUBY_VERSION >= '3.4' # rubocop:disable Gemspec/RubyVersionGlobalsUsage
+    spec.add_dependency 'commonmarker', '>= 2.0.2' # commonmarker <= 2.0.1 is incompatible with Ruby 3.4
+  else
+    spec.add_dependency 'commonmarker', '~> 2.0', '!= 2.0.2' # commonmarker 2.0.2 includes a breaking change in Rubies < 3.4
+  end
   spec.add_dependency 'deprecation'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'


### PR DESCRIPTION
# Why was this change made?

To reproduce and troubleshoot the error that caused us to pin commonmarker to 2.0.1, which is currently preventing upgrades to Ruby 3.4 (since commonmarker 2.0.2 is the version that adds Ruby 3.4 support).

# How was this change tested?

CI
