### PR TITLE
Drop Openapi3Parser dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     cocina-models (0.99.2)
       activesupport
-      commonmarker (~> 2.0, != 2.0.2)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -12,7 +11,6 @@ PATH
       i18n
       jsonpath
       nokogiri
-      openapi3_parser
       openapi_parser (~> 1.0)
       super_diff
       thor
@@ -44,8 +42,6 @@ GEM
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 1.0)
       rack (>= 1.5)
-    commonmarker (2.0.1)
-      rb_sys (~> 0.9)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     deprecation (1.1.0)
@@ -94,8 +90,6 @@ GEM
     nokogiri (1.18.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    openapi3_parser (0.10.0)
-      commonmarker (>= 1.0)
     openapi_parser (1.0.0)
     optimist (3.2.0)
     parallel (1.26.3)
@@ -108,7 +102,6 @@ GEM
     rack (3.1.8)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb_sys (0.9.105)
     regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -25,11 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'activesupport'
-  if RUBY_VERSION >= '3.4' # rubocop:disable Gemspec/RubyVersionGlobalsUsage
-    spec.add_dependency 'commonmarker', '>= 2.0.2' # commonmarker <= 2.0.1 is incompatible with Ruby 3.4
-  else
-    spec.add_dependency 'commonmarker', '~> 2.0', '!= 2.0.2' # commonmarker 2.0.2 includes a breaking change in Rubies < 3.4
-  end
   spec.add_dependency 'deprecation'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'
@@ -38,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'i18n' # for validating BCP 47 language tags, according to RFC 4646
   spec.add_dependency 'jsonpath' # used for date/time validation
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'openapi3_parser' # Parsing openapi doc
   # Match these version requirements to what committee wants,
   # so that our client (non-committee) users have the same dependencies.
   spec.add_dependency 'openapi_parser', '~> 1.0'

--- a/lib/cocina/generator/generator.rb
+++ b/lib/cocina/generator/generator.rb
@@ -96,7 +96,9 @@ module Cocina
       end
 
       def schemas
-        @schemas ||= Openapi3Parser.load_file(options[:openapi]).components.schemas
+        @schemas ||= OpenAPIParser.parse(YAML.load_file(options[:openapi]), strict_reference_validation: true)
+                                  .find_object('#/components')
+                                  .schemas
       end
 
       def schema_for(schema_name, lite: false)

--- a/lib/cocina/generator/schema.rb
+++ b/lib/cocina/generator/schema.rb
@@ -71,7 +71,7 @@ module Cocina
       end
 
       def validatable?
-        !schema_doc.node_context.document.paths["/validate/#{schema_doc.name}"].nil? && !lite
+        !schema_doc.root.paths.path["/validate/#{schema_doc.name}"].nil? && !lite
       end
 
       def properties
@@ -118,13 +118,13 @@ module Cocina
       end
 
       def schema_properties_for(doc)
-        doc.properties.map do |key, properties_doc|
+        Array(doc.properties).map do |key, properties_doc|
           clazz = property_class_for(properties_doc)
           clazz.new(properties_doc,
                     key: key,
-                    required: doc.requires?(key),
+                    required: doc.required&.include?(key),
                     relaxed: lite && clazz != SchemaValue,
-                    nullable: properties_doc.nullable?,
+                    nullable: properties_doc.nullable,
                     parent: self,
                     schemas: schemas)
         end

--- a/lib/cocina/generator/schema_array.rb
+++ b/lib/cocina/generator/schema_array.rb
@@ -4,12 +4,17 @@ module Cocina
   module Generator
     # Class for generating from an openapi array
     class SchemaArray < SchemaBase
+      GENERIC_ITEMS_NAME = 'items'
+
       def generate
         "attribute :#{name.camelize(:lower)}, Types::Strict::Array.of(#{array_of_type}).default([].freeze)"
       end
 
       def array_of_type
-        schema_doc.items.name || dry_datatype(schema_doc.items)
+        items_name = schema_doc.items.name
+        return items_name unless items_name == GENERIC_ITEMS_NAME
+
+        dry_datatype(schema_doc.items)
       end
     end
   end

--- a/lib/cocina/generator/schema_base.rb
+++ b/lib/cocina/generator/schema_base.rb
@@ -50,7 +50,7 @@ module Cocina
       end
 
       def deprecation
-        return '' unless schema_doc.deprecated?
+        return '' unless schema_doc.deprecated
 
         "# DEPRECATED\n"
       end

--- a/lib/cocina/generator/vocab.rb
+++ b/lib/cocina/generator/vocab.rb
@@ -51,7 +51,7 @@ module Cocina
       }.freeze
 
       def vocabs
-        type_properties = schemas.values.map { |schema| schema.properties['type'] }.compact
+        type_properties = schemas.values.map { |schema| schema.properties&.[]('type') }.compact
         type_properties.map(&:enum).flat_map(&:to_a)
                        .filter { |vocab| vocab.start_with?(BASE) }
                        .uniq


### PR DESCRIPTION
# Why was this change made?

Apparently we do not need it, and it is causing grief by way of commonmarker.

# How was this change tested?

CI
