### PR TITLE
Maps new H3 relatedResource types to MODS mapping.

### DIFF
--- a/lib/cocina/models/mapping/from_mods/related_resource.rb
+++ b/lib/cocina/models/mapping/from_mods/related_resource.rb
@@ -51,14 +51,18 @@ module Cocina
               item[:displayLabel] = related_item['displayLabel']
               if related_item['type']
                 item[:type] = normalized_type_for(related_item['type'])
-              elsif related_item['otherType']
-                item[:type] = 'related to'
-                item[:note] ||= []
-                item[:note] <<
-                  { type: 'other relation type', value: related_item['otherType'] }.tap do |note|
-                    note[:uri] = related_item['otherTypeURI'] if related_item['otherTypeURI']
-                    note[:source] = { value: related_item['otherTypeAuth'] } if related_item['otherTypeAuth']
-                  end
+              elsif (other_type = related_item['otherType'])
+                if Cocina::Models::Mapping::ToMods::RelatedResource::OTHER_TYPES.include?(other_type)
+                  item[:type] = other_type
+                else
+                  item[:type] = 'related to'
+                  item[:note] ||= []
+                  item[:note] <<
+                    { type: 'other relation type', value: related_item['otherType'] }.tap do |note|
+                      note[:uri] = related_item['otherTypeURI'] if related_item['otherTypeURI']
+                      note[:source] = { value: related_item['otherTypeAuth'] } if related_item['otherTypeAuth']
+                    end
+                end
               end
             end.compact
           end

--- a/lib/cocina/models/mapping/to_mods/related_resource.rb
+++ b/lib/cocina/models/mapping/to_mods/related_resource.rb
@@ -22,6 +22,15 @@ module Cocina
             'succeeded by' => 'succeeding'
           }.freeze
 
+          OTHER_TYPES = [
+            'supplement to',
+            'supplemented by',
+            'derived from',
+            'source of',
+            'version of record',
+            'identical to'
+          ].freeze
+
           DETAIL_TYPES = {
             'location within source' => 'part',
             'volume' => 'volume',
@@ -85,7 +94,13 @@ module Cocina
 
           def attributes_for(related, other_type_note)
             {}.tap do |attrs|
-              attrs[:type] = TYPES.fetch(related.type) if related.type
+              if related.type
+                if (mapped_type = TYPES[related.type])
+                  attrs[:type] = mapped_type
+                elsif OTHER_TYPES.include?(related.type)
+                  attrs[:otherType] = related.type
+                end
+              end
               attrs[:displayLabel] = related.displayLabel
 
               if other_type_note

--- a/spec/cocina/models/mapping/descriptive/h2/related_item_h2_spec.rb
+++ b/spec/cocina/models/mapping/descriptive/h2/related_item_h2_spec.rb
@@ -30,6 +30,37 @@ RSpec.describe 'Cocina --> MODS mappings for relatedItem' do
     end
   end
 
+  # Related resource types that does not map to MODS
+  # See https://github.com/sul-dlss/cocina-models/issues/773
+  describe 'OtherType related citation' do
+    it_behaves_like 'cocina MODS mapping' do
+      let(:mods) do
+        <<~XML
+          <relatedItem otherType="source of">
+            <titleInfo>
+              <title>A paper</title>
+            </titleInfo>
+          </relatedItem>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          relatedResource: [
+            {
+              title: [
+                {
+                  value: 'A paper'
+                }
+              ],
+              type: 'source of'
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Related link with title' do
     it_behaves_like 'cocina MODS mapping' do
       let(:mods) do


### PR DESCRIPTION
closes #773

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
For H3.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



