### PR TITLE
Add partLabel and sortKey to catalogLinks

### DIFF
--- a/lib/cocina/models/folio_catalog_link.rb
+++ b/lib/cocina/models/folio_catalog_link.rb
@@ -11,6 +11,10 @@ module Cocina
       attribute :refresh, Types::Strict::Bool.default(false)
       # Record identifier that is unique within the context of the linked record's catalog.
       attribute :catalogRecordId, MigratedFromSymphonyIdentifier | MigratedFromVoyagerIdentifier | CreatedInFolioIdentifier
+      # Label for use in display of serials via Folio record
+      attribute? :partLabel, Types::Strict::String
+      # Sorting information for use in display of serials via Folio record
+      attribute? :sortKey, Types::Strict::String
     end
   end
 end

--- a/lib/cocina/models/validators/catalog_links_validator.rb
+++ b/lib/cocina/models/validators/catalog_links_validator.rb
@@ -21,6 +21,7 @@ module Cocina
 
           validate_catalog('symphony')
           validate_catalog('folio')
+          validate_sort_key
         end
 
         private
@@ -34,6 +35,16 @@ module Cocina
 
           raise ValidationError, "Multiple catalog links have 'refresh' property set to true " \
                                  "(only one allowed) #{refresh_catalog_links}"
+        end
+
+        def validate_sort_key
+          serials_links = catalog_links.select { |catalog_link| catalog_link[:catalog] == 'folio' && catalog_link[:sortKey].present? }
+          serials_links.each do |catalog_link|
+            # If partLabel is present, skip validation
+            next if catalog_link[:partLabel].present?
+
+            raise ValidationError, "partLabel must also be present if a sortKey is used in catalog link #{catalog_link}"
+          end
         end
 
         def catalog_links

--- a/lib/cocina/models/validators/catalog_links_validator.rb
+++ b/lib/cocina/models/validators/catalog_links_validator.rb
@@ -38,9 +38,10 @@ module Cocina
         end
 
         def validate_sort_key
+          # TODO: remove this validation once we upgrade to OpenAPI 3.1 and can use dependentRequired in openapi.yml
           serials_links = catalog_links.select { |catalog_link| catalog_link[:catalog] == 'folio' && catalog_link[:sortKey].present? }
           serials_links.each do |catalog_link|
-            # If partLabel is present, skip validation
+            # If partLabel is present, catalog_link is valid
             next if catalog_link[:partLabel].present?
 
             raise ValidationError, "partLabel must also be present if a sortKey is used in catalog link #{catalog_link}"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1174,6 +1174,12 @@ components:
             - $ref: '#/components/schemas/MigratedFromSymphonyIdentifier'
             - $ref: '#/components/schemas/MigratedFromVoyagerIdentifier'
             - $ref: '#/components/schemas/CreatedInFolioIdentifier'
+        partLabel:
+          description: Label for use in display of serials via Folio record
+          type: string
+        sortKey:
+          description: Sorting information for use in display of serials via Folio record
+          type: string
       required:
         - catalog
         - catalogRecordId

--- a/spec/cocina/models/validators/catalog_links_validator_spec.rb
+++ b/spec/cocina/models/validators/catalog_links_validator_spec.rb
@@ -172,6 +172,44 @@ RSpec.describe Cocina::Models::Validators::CatalogLinksValidator do
           expect { validate }.not_to raise_error
         end
       end
+
+      context 'with a partLabel and sortKey' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'folio',
+              catalogRecordId: 'in111',
+              refresh: true,
+              partLabel: 'Part 1',
+              sortKey: '1'
+            }
+          ]
+        end
+
+        it 'validates' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'with a sortKey and no partLabel' do
+        let(:catalog_links) do
+          [
+            {
+              catalog: 'folio',
+              catalogRecordId: 'in111',
+              refresh: true,
+              sortKey: '1'
+            }
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { validate }.to raise_error(
+            Cocina::Models::ValidationError,
+            /partLabel must also be present if a sortKey is used in catalog link/
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Resolves #785 to add digital serials fields to catalogLinks. Models were generated. 

## How was this change tested? 🤨
Unit test added for validation. 




