### PR TITLE
[HOLD] Bump dependencies to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cocina-models.gemspec
 gemspec
-
-gem 'byebug'
-gem 'rspec_junit_formatter' # For CircleCI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       i18n
       jsonpath
       nokogiri
-      openapi_parser (~> 1.0)
+      openapi_parser (~> 2.0)
       super_diff
       thor
       zeitwerk (~> 2.1)
@@ -37,13 +37,16 @@ GEM
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
-    byebug (12.0.0)
-    committee (5.0.0)
+    committee (5.5.3)
       json_schema (~> 0.14, >= 0.14.3)
-      openapi_parser (~> 1.0)
-      rack (>= 1.5)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5, < 3.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.1)
+    date (3.4.1)
+    debug (1.10.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.6.1)
@@ -78,6 +81,11 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    io-console (0.8.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.2)
     json_schema (0.21.0)
     jsonpath (1.1.5)
@@ -91,20 +99,30 @@ GEM
     nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    openapi_parser (1.0.0)
+    openapi_parser (2.2.6)
     optimist (3.2.1)
-    parallel (1.26.3)
+    parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     patience_diff (1.2.0)
       optimist (~> 3.0)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.4.0)
+    psych (5.2.3)
+      date
+      stringio
     racc (1.8.1)
     rack (3.1.13)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.13.1)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -148,6 +166,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    stringio (3.1.6)
     super_diff (0.15.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -166,9 +185,9 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  byebug
   cocina-models!
   committee
+  debug
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -35,15 +35,17 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri'
   # Match these version requirements to what committee wants,
   # so that our client (non-committee) users have the same dependencies.
-  spec.add_dependency 'openapi_parser', '~> 1.0'
+  spec.add_dependency 'openapi_parser', '~> 2.0'
   spec.add_dependency 'super_diff'
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'committee'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec_junit_formatter' # For CircleCI
   spec.add_development_dependency 'rubocop', '~> 1.24'
   spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'rubocop-rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'bundler/setup'
 require 'cocina/models'
 require 'cocina/rspec'
-require 'byebug'
+require 'debug'
 require 'equivalent-xml/rspec_matchers'
 require 'support/mods_mapping_spec_helper'
 require 'support/matchers/deep_ignore_order_matcher'


### PR DESCRIPTION
HOLD until we are confident this is a safe move to make. Note that the DSA build below fails apparently because committee's error behavior has changed.

# Why was this change made?

Why not?

# How was this change tested?

- [x] CI
- [ ] [DSA CI](https://app.circleci.com/pipelines/github/sul-dlss/dor-services-app/10942/workflows/6d727d72-f963-436c-9b56-3bbff1181c73)
- [x] [sdr-api CI](https://app.circleci.com/pipelines/github/sul-dlss/sdr-api/1883/workflows/450046c3-903a-4ccf-a0bd-8d0c5dc612f2)
