### PR TITLE
Use partLabel and title parts if they are present

### DIFF
--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -39,8 +39,9 @@ module Cocina
         #   we can boost matches on it in search results (boost matching this string higher than other titles present)
         # @param [Array<Cocina::Models::Title,Cocina::Models::DescriptiveValue>] titles the titles to consider
         # @return [Array<String>] the full title value(s) for Solr - array due to possible parallelValue
-        def self.full_title(titles)
-          [new(strategy: :first, add_punctuation: false, only_one_parallel_value: false).build(titles)].flatten.compact
+        def self.full_title(titles, catalog_links: [])
+          part_label = catalog_links.find { |link| link.catalog == 'folio' }&.partLabel
+          [new(strategy: :first, add_punctuation: false, only_one_parallel_value: false, part_label: part_label).build(titles)].flatten.compact
         end
 
         # "additional titles" are all title data except for full_title.  We want to able able to index it separately so

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -245,7 +245,8 @@ module Cocina
               padding = non_sorting_padding(cocina_title, value)
               result = add_non_sorting_value(result, value, padding)
             when 'part name', 'part number'
-              if part_name_number.blank?
+              # if there is a partLabel, do not use structuredValue part name/number
+              if part_name_number.blank? && part_label.blank?
                 part_name_number = part_name_number(cocina_title.structuredValue)
                 result = if !add_punctuation?
                            [result, part_name_number].join(' ')

--- a/lib/cocina/models/builders/title_builder.rb
+++ b/lib/cocina/models/builders/title_builder.rb
@@ -38,6 +38,7 @@ module Cocina
         # the "full title" is the title WITH subtitle, part name, etc.  We want to able able to index it separately so
         #   we can boost matches on it in search results (boost matching this string higher than other titles present)
         # @param [Array<Cocina::Models::Title,Cocina::Models::DescriptiveValue>] titles the titles to consider
+        # @param [Array<Cocina::Models::FolioCatalogLink>] catalog_links the folio catalog links to check for digital serials part labels
         # @return [Array<String>] the full title value(s) for Solr - array due to possible parallelValue
         def self.full_title(titles, catalog_links: [])
           part_label = catalog_links.find { |link| link.catalog == 'folio' }&.partLabel
@@ -69,7 +70,6 @@ module Cocina
         end
 
         # @param [Array<Cocina::Models::Title>] cocina_titles the titles to consider
-        # @param [String, nil] part_label the partLabel to add to the title for digital serials
         # @return [String, Array] the title value for Solr - for :first strategy, a string; for :all strategy, an array
         #   (e.g. title displayed in blacklight search results vs boosting values for search result rankings)
         #
@@ -79,7 +79,8 @@ module Cocina
           cocina_title = other_title(cocina_titles) if cocina_title.blank?
           if strategy == :first
             result = extract_title(cocina_title)
-            add_part_label(result)
+            result = add_part_label(result) if part_label.present?
+            result
           else
             result = cocina_titles.map { |ctitle| extract_title(ctitle) }.flatten
             if only_one_parallel_value? && result.length == 1
@@ -107,8 +108,8 @@ module Cocina
 
         def add_part_label(title)
           # when a digital serial
-          title = "#{title.sub(/[ .,]*$/, '')}, #{part_label}" if part_label.present?
-          title
+          title = title.sub(/[ .,]*$/, '').to_s
+          add_punctuation? ? "#{title}, #{part_label}" : "#{title} #{part_label}"
         end
 
         def extract_title(cocina_title)
@@ -246,8 +247,9 @@ module Cocina
               padding = non_sorting_padding(cocina_title, value)
               result = add_non_sorting_value(result, value, padding)
             when 'part name', 'part number'
-              # if there is a partLabel, do not use structuredValue part name/number
-              if part_name_number.blank? && part_label.blank?
+              # even if there is a partLabel, use any existing structuredValue
+              # part name/number that remains for non-digital serials purposes
+              if part_name_number.blank?
                 part_name_number = part_name_number(cocina_title.structuredValue)
                 result = if !add_punctuation?
                            [result, part_name_number].join(' ')

--- a/spec/cocina/models/builders/title_builder_spec.rb
+++ b/spec/cocina/models/builders/title_builder_spec.rb
@@ -583,7 +583,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
             type: 'subtitle'
           },
           {
-            value: 'Vol. 1',
+            value: 'First series',
             type: 'part number'
           },
           {
@@ -597,15 +597,15 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     describe '.build' do
       context 'with :first strategy' do
         it 'returns the reconstructed title with punctuation' do
-          expect(builder_build).to eq('A title : a subtitle. Vol. 1, Supplement')
+          expect(builder_build).to eq('A title : a subtitle. First series, Supplement')
         end
       end
 
-      context 'with a partLabel and an unmigrated part name part number' do
+      context 'with a partLabel and a part name / part number' do
         subject(:builder_build) { described_class.build(cocina_titles, catalog_links: links, strategy: strategy, add_punctuation: add_punctuation) }
 
         it 'returns the title with partLabel' do
-          expect(builder_build).to eq('A title : a subtitle, Part 1')
+          expect(builder_build).to eq('A title : a subtitle. First series, Supplement, Part 1')
         end
       end
 
@@ -613,7 +613,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
         let(:strategy) { :all }
 
         it 'returns the reconstructed title with punctuation (as a String)' do
-          expect(builder_build).to eq('A title : a subtitle. Vol. 1, Supplement')
+          expect(builder_build).to eq('A title : a subtitle. First series, Supplement')
         end
       end
     end
@@ -623,7 +623,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it '.full_title returns the reconstructed title without punctuation' do
-      expect(full_title).to eq ['A title a subtitle Vol. 1 Supplement']
+      expect(full_title).to eq ['A title a subtitle First series Supplement']
     end
 
     it '.additional_titles is empty as there is only one title' do
@@ -765,11 +765,11 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
             type: 'main title'
           },
           {
-            value: 'a part number',
+            value: 'First part number',
             type: 'part number'
           },
           {
-            value: 'a part label',
+            value: 'A part label',
             type: 'part name'
           }
         ]
@@ -777,7 +777,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it 'uses the partLabel from the catalogLinks' do
-      expect(builder_build).to eq('Some Title, Part 1')
+      expect(builder_build).to eq('Some Title. First part number, A part label, Part 1')
     end
   end
 
@@ -895,6 +895,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
   context 'with structuredValue is subtitle, part name, part number and partLabel' do
     subject(:builder_build) { described_class.build(cocina_titles, catalog_links: links, strategy: strategy, add_punctuation: add_punctuation) }
 
+    let(:full_title) { described_class.full_title(cocina_titles, catalog_links: links) }
     let(:titles) do
       [
         {
@@ -920,12 +921,12 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
       expect(main_title).to eq []
     end
 
-    it '.full_title returns the reconstructed title pieces without added punctuation' do
-      expect(full_title).to eq ['Nothing, Part 1']
+    it '.full_title returns the reconstructed title pieces without added punctuation and with partLabel' do
+      expect(full_title).to eq ['Nothing Series 666 Vol. 1 Part 1']
     end
 
     it '.build returns the reconstructed value with punctuation and uses partLabel' do
-      expect(builder_build).to eq('Nothing, Part 1')
+      expect(builder_build).to eq('Nothing. Series 666, Vol. 1, Part 1')
     end
   end
 

--- a/spec/cocina/models/builders/title_builder_spec.rb
+++ b/spec/cocina/models/builders/title_builder_spec.rb
@@ -921,7 +921,7 @@ RSpec.describe Cocina::Models::Builders::TitleBuilder do
     end
 
     it '.full_title returns the reconstructed title pieces without added punctuation' do
-      expect(full_title).to eq ['Nothing Series 666 Vol. 1']
+      expect(full_title).to eq ['Nothing, Part 1']
     end
 
     it '.build returns the reconstructed value with punctuation and uses partLabel' do


### PR DESCRIPTION
## Why was this change made? 🤔
I had missed a few places in the TitleBuilder where we need to account for the presence of a `partLabel` and use that data in the display title and full title. 

We also need to continue to add part name and part number title parts to the display title and full title for indexing. I learned that there will be situations (post-migration) with a part name and part number that do not hold the 856 data. So we need to continue to add that info as well to the title (music and some less common scenarios).

This may cause some display duplication if anyone adds a partLabel before the migration. The migration will delete the part name and part number fields so things will be clean after that has occurred. 

## How was this change tested? 🤨
Unit. 
