### PR TITLE
Add additional context for logging to HB when title type is missing

### DIFF
--- a/lib/cocina/models/mapping/to_mods/title.rb
+++ b/lib/cocina/models/mapping/to_mods/title.rb
@@ -185,6 +185,8 @@ module Cocina
             else
               title_parts.each do |title_part|
                 title_type = tag_name_for(title_part)
+                raise "Unknown title type for: #{title_part.to_h}" unless title_type
+
                 title_value = title_value_for(title_part, title_type, title)
                 xml.public_send(title_type, title_value) if title_part.note.blank?
               end

--- a/spec/cocina/models/mapping/to_mods/title_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/title_spec.rb
@@ -404,4 +404,24 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Title do
       XML
     end
   end
+
+  context 'when it is missing type in a structured value' do
+    let(:titles) do
+      [
+        Cocina::Models::Title.new(
+          structuredValue: [
+            {
+              value: 'Concertos, recorder, string orchestra'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'raises an unknown title type error' do
+      expect { xml }.to raise_error('Unknown title type for: {structuredValue: [], parallelValue: [], ' \
+                                    'groupedValue: [], value: "Concertos, recorder, string orchestra", ' \
+                                    'identifier: [], note: [], appliesTo: []}')
+    end
+  end
 end


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

In order to improving debugging of indexing errors related to malformed titles, raise an error with the title_part structure for better honeybadger logging.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



