### PR TITLE
Add field for relatedResource.dataCiteRelationType

### DIFF
--- a/lib/cocina/models/related_resource.rb
+++ b/lib/cocina/models/related_resource.rb
@@ -6,6 +6,8 @@ module Cocina
     class RelatedResource < Struct
       # The relationship of the related resource to the described resource.
       attribute? :type, Types::Strict::String
+      # The DataCite relationType of the related resource to the described resource, as defined by DataCite https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
+      attribute? :dataCiteRelationType, Types::Strict::String.enum('IsCitedBy', 'Cites', 'IsSupplementTo', 'IsSupplementedBy', 'IsContinuedBy', 'Continues', 'Describes', 'IsDescribedBy', 'HasMetadata', 'IsMetadataFor', 'HasVersion', 'IsVersionOf', 'IsNewVersionOf', 'IsPreviousVersionOf', 'IsPartOf', 'HasPart', 'IsPublishedIn', 'IsReferencedBy', 'References', 'IsDocumentedBy', 'Documents', 'IsCompiledBy', 'Compiles', 'IsVariantFormOf', 'IsOriginalFormOf', 'IsIdenticalTo', 'IsReviewedBy', 'Reviews', 'IsDerivedFrom', 'IsSourceOf', 'IsRequiredBy', 'Requires', 'Obsoletes', 'IsObsoletedBy', 'IsCollectedBy', 'Collects', 'IsTranslationOf', 'HasTranslation')
       # Status of the related resource relative to other related resources.
       attribute? :status, Types::Strict::String
       # The preferred display label to use for the related resource in access systems.

--- a/openapi.yml
+++ b/openapi.yml
@@ -1460,6 +1460,49 @@ components:
         type:
           description: The relationship of the related resource to the described resource.
           type: string
+        dataCiteRelationType:
+          description: The DataCite relationType describing the relationship from the related resource to the described resource.
+            See https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
+          type: string
+          enum:
+            - 'IsCitedBy'
+            - 'Cites'
+            - 'IsSupplementTo'
+            - 'IsSupplementedBy'
+            - 'IsContinuedBy'
+            - 'Continues'
+            - 'Describes'
+            - 'IsDescribedBy'
+            - 'HasMetadata'
+            - 'IsMetadataFor'
+            - 'HasVersion'
+            - 'IsVersionOf'
+            - 'IsNewVersionOf'
+            - 'IsPreviousVersionOf'
+            - 'IsPartOf'
+            - 'HasPart'
+            - 'IsPublishedIn'
+            - 'IsReferencedBy'
+            - 'References'
+            - 'IsDocumentedBy'
+            - 'Documents'
+            - 'IsCompiledBy'
+            - 'Compiles'
+            - 'IsVariantFormOf'
+            - 'IsOriginalFormOf'
+            - 'IsIdenticalTo'
+            - 'IsReviewedBy'
+            - 'Reviews'
+            - 'IsDerivedFrom'
+            - 'IsSourceOf'
+            - 'IsRequiredBy'
+            - 'Requires'
+            - 'Obsoletes'
+            - 'IsObsoletedBy'
+            - 'IsCollectedBy'
+            - 'Collects'
+            - 'IsTranslationOf'
+            - 'HasTranslation'
         status:
           description: Status of the related resource relative to other related resources.
           type: string


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #808 to add dataCiteRelationType to relatedResources. Does not require mapping to MODS (or the reverse) and will not be rendered for display, at least at this time. 

Will require a minor-level release since `openapi.yml` was changed. 

## How was this change tested? 🤨
Ran `exe/generator generate`




