### PR TITLE
Allow for ETD-like form metadata to include datacite resource types

### DIFF
--- a/lib/cocina/models/mapping/to_mods/form.rb
+++ b/lib/cocina/models/mapping/to_mods/form.rb
@@ -226,7 +226,14 @@ module Cocina
 
           def datacite_resource_type
             self_deposit_types = forms.find do |candidate|
-              candidate.source.value == 'Stanford self-deposit resource types'
+              # Why do we need to verify that `candidate.source` is non-nil
+              # here? Before this change, our datacite resource-type handling
+              # could safely assume that the descriptive form metadata was
+              # constrained to the H2/H3 shape. As of August 2025, we're minting
+              # DOIs for ETDs which have their own descriptive form metadata
+              # (now including datacite resource types), and this assumption no
+              # longer holds. One of the ETD form values includes no source.
+              candidate.source&.value == 'Stanford self-deposit resource types'
             end
             return unless self_deposit_types
 

--- a/spec/cocina/models/mapping/to_mods/form_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/form_spec.rb
@@ -28,4 +28,117 @@ RSpec.describe Cocina::Models::Mapping::ToMods::Form do
       XML
     end
   end
+
+  context 'with typical self-deposit forms (i.e., with datacite metadata)' do
+    let(:forms) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          structuredValue: [
+            Cocina::Models::DescriptiveValue.new(
+              value: 'Image',
+              type: 'type'
+            )
+          ],
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'Stanford self-deposit resource types')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'still image',
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'MODS resource types')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'Image',
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'DataCite resource types')
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+         <genre type="H2 type">Image</genre>
+         <typeOfResource>still image</typeOfResource>
+         <extension displayLabel="datacite">
+           <resourceType resourceTypeGeneral="Image">Image</resourceType>
+         </extension>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with typical ETD forms (i.e., with datacite metadata)' do
+    let(:forms) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          value: 'text',
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'MODS resource types')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'theses',
+          type: 'genre',
+          source: Cocina::Models::Source.new(code: 'marcgt')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'electronic resource',
+          type: 'form',
+          source: Cocina::Models::Source.new(code: 'marccategory')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'computer',
+          type: 'media',
+          source: Cocina::Models::Source.new(code: 'rdamedia')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'online resource',
+          type: 'carrier',
+          source: Cocina::Models::Source.new(code: 'rdacarrier')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: '1 online resource',
+          type: 'extent'
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          structuredValue: [
+            Cocina::Models::DescriptiveValue.new(
+              value: 'Academic thesis',
+              type: 'type'
+            )
+          ],
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'Stanford self-deposit resource types')
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          value: 'Dissertation',
+          type: 'resource type',
+          source: Cocina::Models::Source.new(value: 'DataCite resource types')
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <genre type="H2 type">Academic thesis</genre>
+          <extension displayLabel="datacite">
+            <resourceType resourceTypeGeneral="Dissertation">Academic thesis</resourceType>
+          </extension>
+          <typeOfResource>text</typeOfResource>
+          <genre authority="marcgt">theses</genre>
+          <physicalDescription>
+            <form authority="marccategory">electronic resource</form>
+            <form type="media" authority="rdamedia">computer</form>
+            <form type="carrier" authority="rdacarrier">online resource</form>
+            <extent>1 online resource</extent>
+          </physicalDescription>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made?

Connects to sul-dlss/hydra_etd#1621

See title.

# How was this change tested?

CI, stage

