### PR TITLE
Add broadcast event/date type

### DIFF
--- a/description_types.yml
+++ b/description_types.yml
@@ -102,6 +102,8 @@ contributor.note:
 event:
   - value: acquisition
     description: The transferral of ownership of a resource to a repository.
+  - value: broadcast
+    description: Live transmission of the resource to a wide audience.
   - value: capture
     description: A record of the resource in a fixed form at a specific time.
   - value: collection
@@ -154,6 +156,8 @@ event.date:
     status: deprecated
   - value: acquisition
     description: The transferral of ownership of a resource to a repository.
+  - value: broadcast
+    description: Live transmission of the resource to a wide audience.
   - value: capture
     description: A record of the resource in a fixed form at a specific time.
   - value: collection

--- a/docs/description_types.md
+++ b/docs/description_types.md
@@ -110,6 +110,8 @@ _Path: contributor.note.type_
 _Path: event.type_
   * acquisition
     * The transferral of ownership of a resource to a repository.
+  * broadcast
+    * Live transmission of the resource to a wide audience.
   * capture
     * A record of the resource in a fixed form at a specific time.
   * collection
@@ -163,6 +165,8 @@ _Path: event.date.type_
     * Deprecated.
   * acquisition
     * The transferral of ownership of a resource to a repository.
+  * broadcast
+    * Live transmission of the resource to a wide audience.
   * capture
     * A record of the resource in a fixed form at a specific time.
   * collection

--- a/lib/cocina/models/mapping/from_mods/event.rb
+++ b/lib/cocina/models/mapping/from_mods/event.rb
@@ -22,6 +22,7 @@ module Cocina
           # a preferred vocabulary, if you will
           EVENT_TYPES = [
             'acquisition',
+            'broadcast',
             'capture',
             'collection',
             'copyright',


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Fixes #825. This should be releasable as a patch release. The new type is not in use currently and does not need to be used immediately (i.e. after next week's dependency updates is fine). 


## How was this change tested? 🤨
Unit
