### PR TITLE
Add special EDTF validation

### DIFF
--- a/lib/cocina/models/validators/date_time_validator.rb
+++ b/lib/cocina/models/validators/date_time_validator.rb
@@ -64,6 +64,8 @@ module Cocina
         end
 
         def valid_edtf?(value)
+          return false if value == 'XXXX' # Not permitted by the spec, but allowed in the gem. https://github.com/inukshuk/edtf-ruby/issues/41
+
           Date.edtf!(value)
           true
         rescue StandardError


### PR DESCRIPTION

## Why was this change made? 🤔

The EDTF gem permits 'XXXX' although this is not something documented in the EDTF spec.  This is to be extra careful that we don't get this weird data. 


## How was this change tested? 🤨

We ran this as a report and found no instances of this.



