### PR TITLE
Bump rubocop ruby target version to 3.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.4
 
 # ----- Layout ------
 

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.4'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'deprecation'

--- a/lib/cocina/models/checkable.rb
+++ b/lib/cocina/models/checkable.rb
@@ -5,23 +5,23 @@ module Cocina
     # A common interface for interrogating a model instance's type
     module Checkable
       def admin_policy?
-        (self.class::TYPES & AdminPolicy::TYPES).any?
+        self.class::TYPES.intersect?(AdminPolicy::TYPES)
       end
 
       def collection?
-        (self.class::TYPES & Collection::TYPES).any?
+        self.class::TYPES.intersect?(Collection::TYPES)
       end
 
       def dro?
-        (self.class::TYPES & DRO::TYPES).any?
+        self.class::TYPES.intersect?(DRO::TYPES)
       end
 
       def file?
-        (self.class::TYPES & File::TYPES).any?
+        self.class::TYPES.intersect?(File::TYPES)
       end
 
       def file_set?
-        (self.class::TYPES & FileSet::TYPES).any?
+        self.class::TYPES.intersect?(FileSet::TYPES)
       end
     end
   end

--- a/lib/cocina/models/validatable.rb
+++ b/lib/cocina/models/validatable.rb
@@ -7,9 +7,9 @@ module Cocina
       extend ActiveSupport::Concern
 
       class_methods do
-        def new(attributes = default_attributes, safe = false, validate = true, &block)
+        def new(attributes = default_attributes, safe = false, validate = true, &)
           Validators::Validator.validate(self, attributes) if validate
-          super(attributes, safe, &block)
+          super(attributes, safe, &)
         end
       end
 

--- a/lib/cocina/models/validators/catalog_links_validator.rb
+++ b/lib/cocina/models/validators/catalog_links_validator.rb
@@ -61,13 +61,13 @@ module Cocina
         end
 
         def dro?
-          (clazz::TYPES & DRO::TYPES).any?
+          clazz::TYPES.intersect?(DRO::TYPES)
         rescue NameError
           false
         end
 
         def collection?
-          (clazz::TYPES & Collection::TYPES).any?
+          clazz::TYPES.intersect?(Collection::TYPES)
         rescue NameError
           false
         end

--- a/lib/cocina/models/validators/dark_validator.rb
+++ b/lib/cocina/models/validators/dark_validator.rb
@@ -33,7 +33,7 @@ module Cocina
         end
 
         def dro?
-          (clazz::TYPES & DRO::TYPES).any?
+          clazz::TYPES.intersect?(DRO::TYPES)
         rescue NameError
           false
         end

--- a/lib/cocina/models/validators/language_tag_validator.rb
+++ b/lib/cocina/models/validators/language_tag_validator.rb
@@ -32,7 +32,7 @@ module Cocina
         end
 
         def dro?
-          (clazz::TYPES & DRO::TYPES).any?
+          clazz::TYPES.intersect?(DRO::TYPES)
         rescue NameError
           false
         end

--- a/lib/cocina/models/validators/reserved_filename_validator.rb
+++ b/lib/cocina/models/validators/reserved_filename_validator.rb
@@ -28,7 +28,7 @@ module Cocina
         attr_reader :clazz, :attributes
 
         def dro?
-          (clazz::TYPES & DRO::TYPES).any? && attributes[:externalIdentifier].present?
+          clazz::TYPES.intersect?(DRO::TYPES) && attributes[:externalIdentifier].present?
         rescue NameError
           false
         end

--- a/lib/cocina/rspec/factories.rb
+++ b/lib/cocina/rspec/factories.rb
@@ -80,8 +80,8 @@ module Cocina
 
       REQUEST_ADMIN_POLICY_DEFAULTS = ADMIN_POLICY_DEFAULTS.except(:id)
 
-      def self.build_dro_properties(id:, **kwargs)
-        build_request_dro_properties(**kwargs)
+      def self.build_dro_properties(id:, **)
+        build_request_dro_properties(**)
           .merge(externalIdentifier: id)
           .tap do |props|
           props[:description][:purl] = "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
@@ -134,8 +134,8 @@ module Cocina
         Cocina::Models.build_request(build_request_dro_properties(**REQUEST_DRO_DEFAULTS.merge(attributes)))
       end
 
-      def self.build_collection_properties(id:, **kwargs)
-        build_request_collection_properties(**kwargs)
+      def self.build_collection_properties(id:, **)
+        build_request_collection_properties(**)
           .merge(externalIdentifier: id)
           .tap do |props|
           props[:description][:purl] = "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"
@@ -194,8 +194,8 @@ module Cocina
         Cocina::Models.build_request(build_request_admin_policy_properties(**REQUEST_ADMIN_POLICY_DEFAULTS.merge(attributes)))
       end
 
-      def self.build_admin_policy_properties(id:, **kwargs)
-        build_request_admin_policy_properties(**kwargs)
+      def self.build_admin_policy_properties(id:, **)
+        build_request_admin_policy_properties(**)
           .merge(externalIdentifier: id)
           .tap do |props|
           props[:description][:purl] = "https://purl.stanford.edu/#{id.delete_prefix('druid:')}"


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

A bit of style cleanup to catch up with ruby 3.4 styling.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



