### PR TITLE
Handle a single parallel name when mapping to MODS.

### DIFF
--- a/lib/cocina/models/mapping/to_mods/name_writer.rb
+++ b/lib/cocina/models/mapping/to_mods/name_writer.rb
@@ -97,7 +97,7 @@ module Cocina
             if parallel_name_values.size == 1
               contrib_name_value_slice = Cocina::Models::Builders::NameTitleGroupBuilder.value_slices(parallel_name_values.first)
               name_title_group = name_title_vals_index[contrib_name_value_slice]&.values&.first
-              write_name_from_parallel(contributor, contributor.name.first, parallel_name_values, name_title_group, nil)
+              write_name_from_parallel(contributor, contributor.name.first, parallel_name_values.first, name_title_group, nil)
             elsif parallel_name_values.size == 2 && display_type_parallel_name
               contrib_name_value_slice = Cocina::Models::Builders::NameTitleGroupBuilder.value_slices(parallel_name_values.first)
               name_title_group = name_title_vals_index[contrib_name_value_slice]&.values&.first

--- a/spec/cocina/models/mapping/to_mods/name_writer_spec.rb
+++ b/spec/cocina/models/mapping/to_mods/name_writer_spec.rb
@@ -100,4 +100,49 @@ RSpec.describe Cocina::Models::Mapping::ToMods::NameWriter do
       XML
     end
   end
+
+  context 'when there is a single parallel name value' do
+    let(:contributor) do
+      Cocina::Models::Contributor.new(
+        {
+          name: [
+            {
+              parallelValue: [
+                {
+                  value: 'Булгаков, Михаил Афанасьевич',
+                  status: 'primary',
+                  valueLanguage: {
+                    code: 'rus',
+                    source: {
+                      code: 'iso639-2b'
+                    },
+                    valueScript: {
+                      code: 'Cyrl',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          type: 'person',
+          status: 'primary'
+        }
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name usage="primary" type="personal" script="Cyrl" lang="rus">
+            <namePart>Булгаков, Михаил Афанасьевич</namePart>
+          </name>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/5582

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔
Avoid indexing error


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



