### PR TITLE
Add datacite-ruby to the gems release process when updating cocina mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ which pushes the gem to rubygems.org.
 
 ### Step 2: Update client gems coupled to the models
 
-Release new versions of [sdr-client](https://github.com/sul-dlss/sdr-client) and [dor-services-client](https://github.com/sul-dlss/dor-services-client/):
+Release new versions of [sdr-client](https://github.com/sul-dlss/sdr-client), [dor-services-client](https://github.com/sul-dlss/dor-services-client/), [datacite-ruby](https://github.com/sul-dlss/datacite-ruby):
 1. Pin the new cocina-models version in the clients' `gemspec` files.
 2. Bump the version as described in each client's README release instructions.
 


### PR DESCRIPTION
…dels

now that `datacite-ruby` has a dependency on cocina-models, call it out in the gem release process.

**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



