### PR TITLE
Consistently use double quotes in openapi.yml

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -5,7 +5,7 @@ info:
   title: Cocina Models
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 paths:
   /validate/DRO:
     post:
@@ -15,9 +15,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DRO'
+              $ref: "#/components/schemas/DRO"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/RequestDRO:
     post:
@@ -27,9 +27,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestDRO'
+              $ref: "#/components/schemas/RequestDRO"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/DROWithMetadata:
     post:
@@ -39,9 +39,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DROWithMetadata'
+              $ref: "#/components/schemas/DROWithMetadata"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/Collection:
     post:
@@ -51,9 +51,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Collection'
+              $ref: "#/components/schemas/Collection"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/RequestCollection:
     post:
@@ -63,9 +63,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestCollection'
+              $ref: "#/components/schemas/RequestCollection"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/CollectionWithMetadata:
     post:
@@ -75,9 +75,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CollectionWithMetadata'
+              $ref: "#/components/schemas/CollectionWithMetadata"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/AdminPolicy:
     post:
@@ -87,9 +87,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AdminPolicy'
+              $ref: "#/components/schemas/AdminPolicy"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/RequestAdminPolicy:
     post:
@@ -99,9 +99,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestAdminPolicy'
+              $ref: "#/components/schemas/RequestAdminPolicy"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/AdminPolicyWithMetadata:
     post:
@@ -111,9 +111,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AdminPolicyWithMetadata'
+              $ref: "#/components/schemas/AdminPolicyWithMetadata"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/Description:
     post:
@@ -123,9 +123,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Description'
+              $ref: "#/components/schemas/Description"
       responses:
-        '200':
+        "200":
           description: noop
   /validate/RequestDescription:
     post:
@@ -135,9 +135,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestDescription'
+              $ref: "#/components/schemas/RequestDescription"
       responses:
-        '200':
+        "200":
           description: noop
 components:
   schemas:
@@ -145,13 +145,13 @@ components:
       type: object
       oneOf:
         # Being first, makes DarkAccess the default.
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/CitationOnlyAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/CitationOnlyAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
     AccessRole:
       description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
       type: object
@@ -161,22 +161,22 @@ components:
           description: Name of role
           type: string
           enum:
-            - 'dor-apo-depositor'
-            - 'dor-apo-manager'
-            - 'dor-apo-viewer'
-            - 'sdr-administrator'
-            - 'sdr-viewer'
-            - 'hydrus-collection-creator'
-            - 'hydrus-collection-manager'
-            - 'hydrus-collection-depositor'
-            - 'hydrus-collection-item-depositor'
-            - 'hydrus-collection-reviewer'
-            - 'hydrus-collection-viewer'
+            - "dor-apo-depositor"
+            - "dor-apo-manager"
+            - "dor-apo-viewer"
+            - "sdr-administrator"
+            - "sdr-viewer"
+            - "hydrus-collection-creator"
+            - "hydrus-collection-manager"
+            - "hydrus-collection-depositor"
+            - "hydrus-collection-item-depositor"
+            - "hydrus-collection-reviewer"
+            - "hydrus-collection-viewer"
         members:
           description: The users and groups that are members of the role
           type: array
           items:
-            $ref: '#/components/schemas/AccessRoleMember'
+            $ref: "#/components/schemas/AccessRoleMember"
       required:
         - members
         - name
@@ -189,8 +189,8 @@ components:
           description: Name of role
           type: string
           enum:
-            - 'sunetid'
-            - 'workgroup'
+            - "sunetid"
+            - "workgroup"
         identifier:
           type: string
       required:
@@ -201,21 +201,21 @@ components:
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/admin_policy'
+            - "https://cocina.sul.stanford.edu/models/admin_policy"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           type: string
         version:
           type: integer
         administrative:
-          $ref: '#/components/schemas/AdminPolicyAdministrative'
+          $ref: "#/components/schemas/AdminPolicyAdministrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
       required:
         - cocinaVersion
         - administrative
@@ -228,21 +228,21 @@ components:
       additionalProperties: false
       properties:
         hasAdminPolicy:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
       required:
         - hasAdminPolicy
     AdminPolicyAccessTemplate:
-      description: 'Provides the template of access settings that is copied to the items governed by an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo.'
+      description: "Provides the template of access settings that is copied to the items governed by an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo."
       type: object
       additionalProperties: false
       oneOf:
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/CitationOnlyAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/CitationOnlyAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
       properties:
         copyright:
           $ref: "#/components/schemas/Copyright"
@@ -256,7 +256,7 @@ components:
       additionalProperties: false
       properties:
         accessTemplate:
-          $ref: '#/components/schemas/AdminPolicyAccessTemplate'
+          $ref: "#/components/schemas/AdminPolicyAccessTemplate"
         registrationWorkflow:
           description: When you register an item with this admin policy, these are the workflows that are available.
           type: array
@@ -272,14 +272,14 @@ components:
           items:
             type: string
         hasAdminPolicy:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         hasAgreement:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         roles:
           description: The access roles conferred by this AdminPolicy (used by Argo)
           type: array
           items:
-            $ref: '#/components/schemas/AccessRole'
+            $ref: "#/components/schemas/AccessRole"
       required:
         - hasAdminPolicy
         - hasAgreement
@@ -293,7 +293,8 @@ components:
         - $ref: "#/components/schemas/AdminPolicy"
         - $ref: "#/components/schemas/ObjectMetadata"
     AppliesTo:
-      description: Property model for indicating the parts, aspects, or versions of the resource to which a
+      description:
+        Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.
       type: object
       additionalProperties: false
@@ -303,27 +304,27 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveBasicValue"
     Barcode:
-      description: 'A barcode'
+      description: "A barcode"
       oneOf:
-        - $ref: '#/components/schemas/BusinessBarcode'
-        - $ref: '#/components/schemas/LaneMedicalBarcode'
-        - $ref: '#/components/schemas/CatkeyBarcode'
-        - $ref: '#/components/schemas/StandardBarcode'
+        - $ref: "#/components/schemas/BusinessBarcode"
+        - $ref: "#/components/schemas/LaneMedicalBarcode"
+        - $ref: "#/components/schemas/CatkeyBarcode"
+        - $ref: "#/components/schemas/StandardBarcode"
     BusinessBarcode:
       description: The barcode associated with a business library DRO object, prefixed with 2050
       type: string
-      pattern: '^2050[0-9]{7}$'
-      example: '20503740296'
+      pattern: "^2050[0-9]{7}$"
+      example: "20503740296"
     CatalogLink:
-      description: 'A linkage between an object and a catalog record'
+      description: "A linkage between an object and a catalog record"
       oneOf:
-        - $ref: '#/components/schemas/FolioCatalogLink'
-        - $ref: '#/components/schemas/SymphonyCatalogLink'
+        - $ref: "#/components/schemas/FolioCatalogLink"
+        - $ref: "#/components/schemas/SymphonyCatalogLink"
     CatkeyBarcode:
       description: The barcode associated with a DRO object based on catkey, prefixed with a catkey followed by a hyphen
       type: string
-      pattern: '^[0-9]+-[0-9]+$'
-      example: '6772719-1001'
+      pattern: "^[0-9]+-[0-9]+$"
+      example: "6772719-1001"
     CitationOnlyAccess:
       description: A type of access for an object wherein users can see the metadata and a list of files, but the files will not have view or download access
       type: object
@@ -337,7 +338,7 @@ components:
           description: Download access level.
           type: string
           enum:
-            - 'none'
+            - "none"
         location:
           description: Not used for this access type, must be null.
           type: string
@@ -356,25 +357,25 @@ components:
       description: The version of Cocina with which this object conforms.
       type: string
       pattern: '^\d+\.\d+\.\d+$'
-      example: '1.2.3'
+      example: "1.2.3"
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           description: The content type of the Collection. Selected from an established set of values.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/collection'
-            - 'https://cocina.sul.stanford.edu/models/curated-collection'
-            - 'https://cocina.sul.stanford.edu/models/user-collection'
-            - 'https://cocina.sul.stanford.edu/models/exhibit'
-            - 'https://cocina.sul.stanford.edu/models/series'
+            - "https://cocina.sul.stanford.edu/models/collection"
+            - "https://cocina.sul.stanford.edu/models/curated-collection"
+            - "https://cocina.sul.stanford.edu/models/user-collection"
+            - "https://cocina.sul.stanford.edu/models/exhibit"
+            - "https://cocina.sul.stanford.edu/models/series"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           description: Primary processing label (can be same as title) for a Collection.
           type: string
@@ -382,13 +383,13 @@ components:
           description: Version for the Collection within SDR.
           type: integer
         access:
-          $ref: '#/components/schemas/CollectionAccess'
+          $ref: "#/components/schemas/CollectionAccess"
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: "#/components/schemas/Administrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
         identification:
-          $ref: '#/components/schemas/CollectionIdentification'
+          $ref: "#/components/schemas/CollectionIdentification"
       required:
         - cocinaVersion
         - description
@@ -408,9 +409,9 @@ components:
           description: Access level
           type: string
           enum:
-            - 'world'
-            - 'dark'
-          default: 'dark'
+            - "world"
+            - "dark"
+          default: "dark"
         copyright:
           $ref: "#/components/schemas/Copyright"
         useAndReproductionStatement:
@@ -424,9 +425,9 @@ components:
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
     # CollectionWithMetadata schema should not be copied to sdr-api and dor-services-app.
     CollectionWithMetadata:
       description: Collection with addition object metadata.
@@ -436,7 +437,8 @@ components:
         - $ref: "#/components/schemas/Collection"
         - $ref: "#/components/schemas/ObjectMetadata"
     Contributor:
-      description: Property model for describing agents contributing in some way to
+      description:
+        Property model for describing agents contributing in some way to
         the creation and history of the resource.
       type: object
       additionalProperties: false
@@ -450,11 +452,13 @@ components:
           description: Entity type of the contributor (person, organization, etc.). See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.
           type: string
         status:
-          description: Status of the contributor relative to other parallel contributors
+          description:
+            Status of the contributor relative to other parallel contributors
             (e.g. the primary author among a group of contributors).
           type: string
         role:
-          description: Relationships of the contributor to the resource or to an event
+          description:
+            Relationships of the contributor to the resource or to an event
             in its history.
           type: array
           items:
@@ -517,47 +521,47 @@ components:
       description: A record identifier created in Folio
       type: string
       pattern: '^in\d+$'
-      example: 'in11403803'
+      example: "in11403803"
     DOI:
       description: Digital Object Identifier (https://www.doi.org)
       oneOf:
-        - $ref: '#/components/schemas/RepositoryDOI'
-        - $ref: '#/components/schemas/PreregisteredRepositoryDOI'
-        - $ref: '#/components/schemas/LibrariesDOI'
-        - $ref: '#/components/schemas/DOIExceptions'
+        - $ref: "#/components/schemas/RepositoryDOI"
+        - $ref: "#/components/schemas/PreregisteredRepositoryDOI"
+        - $ref: "#/components/schemas/LibrariesDOI"
+        - $ref: "#/components/schemas/DOIExceptions"
     DOIExceptions:
       type: string
       description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for objects in SDR that do not adhere to any of the other DOI patterns in the spec. This is a short list of known exceptions only. Please note that DOIs are *not* case-sensitive, so we allow for uppercase and lowercase letters with these exceptions."
       pattern: '^10\.25936\/[jJ][mM]709[hH][cC]8700|10\.18735\/4[nN][sS][eE]-8871|10\.18735\/952[xX]-[wW]447|10\.18735\/0[mM][wW]1-[qQ][qQ]72$'
-      example: '10.18735/0mw1-qq72'
+      example: "10.18735/0mw1-qq72"
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           description: The content type of the DRO. Selected from an established set of values.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/object'
-            - 'https://cocina.sul.stanford.edu/models/3d'
-            - 'https://cocina.sul.stanford.edu/models/agreement'
-            - 'https://cocina.sul.stanford.edu/models/book'
-            - 'https://cocina.sul.stanford.edu/models/document'
-            - 'https://cocina.sul.stanford.edu/models/geo'
-            - 'https://cocina.sul.stanford.edu/models/image'
-            - 'https://cocina.sul.stanford.edu/models/page'
-            - 'https://cocina.sul.stanford.edu/models/photograph'
-            - 'https://cocina.sul.stanford.edu/models/manuscript'
-            - 'https://cocina.sul.stanford.edu/models/map'
-            - 'https://cocina.sul.stanford.edu/models/media'
-            - 'https://cocina.sul.stanford.edu/models/track'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-binary'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+            - "https://cocina.sul.stanford.edu/models/object"
+            - "https://cocina.sul.stanford.edu/models/3d"
+            - "https://cocina.sul.stanford.edu/models/agreement"
+            - "https://cocina.sul.stanford.edu/models/book"
+            - "https://cocina.sul.stanford.edu/models/document"
+            - "https://cocina.sul.stanford.edu/models/geo"
+            - "https://cocina.sul.stanford.edu/models/image"
+            - "https://cocina.sul.stanford.edu/models/page"
+            - "https://cocina.sul.stanford.edu/models/photograph"
+            - "https://cocina.sul.stanford.edu/models/manuscript"
+            - "https://cocina.sul.stanford.edu/models/map"
+            - "https://cocina.sul.stanford.edu/models/media"
+            - "https://cocina.sul.stanford.edu/models/track"
+            - "https://cocina.sul.stanford.edu/models/webarchive-binary"
+            - "https://cocina.sul.stanford.edu/models/webarchive-seed"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           description: Primary processing label (can be same as title) for a DRO.
           type: string
@@ -565,17 +569,17 @@ components:
           description: Version for the DRO within SDR.
           type: integer
         access:
-          $ref: '#/components/schemas/DROAccess'
+          $ref: "#/components/schemas/DROAccess"
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: "#/components/schemas/Administrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
         identification:
-          $ref: '#/components/schemas/Identification'
+          $ref: "#/components/schemas/Identification"
         structural:
-          $ref: '#/components/schemas/DROStructural'
+          $ref: "#/components/schemas/DROStructural"
         geographic:
-          $ref: '#/components/schemas/Geographic'
+          $ref: "#/components/schemas/Geographic"
       required:
         - cocinaVersion
         - access
@@ -597,7 +601,7 @@ components:
             copyright:
               $ref: "#/components/schemas/Copyright"
             embargo:
-              $ref: '#/components/schemas/Embargo'
+              $ref: "#/components/schemas/Embargo"
             useAndReproductionStatement:
               $ref: "#/components/schemas/UseAndReproductionStatement"
             license:
@@ -611,17 +615,17 @@ components:
           description: Filesets that contain the digital representations (Files)
           type: array
           items:
-            $ref: '#/components/schemas/FileSet'
+            $ref: "#/components/schemas/FileSet"
         hasMemberOrders:
           description: Provided sequences or orderings of members, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).
           type: array
           items:
-            $ref: '#/components/schemas/Sequence'
+            $ref: "#/components/schemas/Sequence"
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array
           items:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     # DROWithMetadata schema should not be copied to sdr-api and dor-services-app.
     DROWithMetadata:
       description: DRO with addition object metadata.
@@ -636,15 +640,15 @@ components:
         view:
           description: Access level.
           type: string
-          default: 'dark'
+          default: "dark"
           enum:
             - dark
         download:
           description: Download access level.
           type: string
-          default: 'none'
+          default: "none"
           enum:
-            - 'none'
+            - "none"
         location:
           description: Not used for this access type, must be null.
           type: string
@@ -756,7 +760,7 @@ components:
             value:
               description: String or integer value of the descriptive element.
               oneOf:
-              - type: string
+                - type: string
               # Title note (nonsorting character count) was supposed to be able to accept an integer value,
               # but this triggered a bug in committee:
               # https://github.com/interagent/committee/issues/286
@@ -765,7 +769,8 @@ components:
               description: Type of value provided by the descriptive element. See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.
               type: string
             status:
-              description: Status of the descriptive element value relative to other instances
+              description:
+                Status of the descriptive element value relative to other instances
                 of the element.
               type: string
             code:
@@ -785,7 +790,7 @@ components:
               description: Identifiers and URIs associated with the descriptive element.
               type: array
               items:
-                  $ref: "#/components/schemas/DescriptiveValue"
+                $ref: "#/components/schemas/DescriptiveValue"
             source:
               $ref: "#/components/schemas/Source"
             displayLabel:
@@ -942,13 +947,13 @@ components:
         - type: object
           properties:
             valueScript:
-              $ref: '#/components/schemas/Standard'
+              $ref: "#/components/schemas/Standard"
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
     Druid:
       type: string
-      pattern: '^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: 'druid:bc123df4567'
+      pattern: "^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$"
+      example: "druid:bc123df4567"
     Embargo:
       type: object
       additionalProperties: false
@@ -960,7 +965,7 @@ components:
               description: Date when the Collection is released from an embargo.
               type: string
               format: date-time
-              example: '2029-06-22T07:00:00.000+00:00'
+              example: "2029-06-22T07:00:00.000+00:00"
             useAndReproductionStatement:
               $ref: "#/components/schemas/UseAndReproductionStatement"
           required:
@@ -1022,7 +1027,7 @@ components:
           description: The content type of the File.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/file'
+            - "https://cocina.sul.stanford.edu/models/file"
         externalIdentifier:
           description: Identifier for the resource within the SDR architecture but outside of the repository. UUID. Constant across resource versions. What clients will use calling the repository.
           type: string
@@ -1042,9 +1047,9 @@ components:
           description: MIME Type of the File.
           type: string
         languageTag:
-          $ref: '#/components/schemas/LanguageTag'
+          $ref: "#/components/schemas/LanguageTag"
         use:
-          $ref: '#/components/schemas/FileUse'
+          $ref: "#/components/schemas/FileUse"
         sdrGeneratedText:
           description: Indicates if the text (OCR/captioning) was generated by SDR.
           type: boolean
@@ -1056,13 +1061,13 @@ components:
         hasMessageDigests:
           type: array
           items:
-            $ref: '#/components/schemas/MessageDigest'
+            $ref: "#/components/schemas/MessageDigest"
         access:
-          $ref: '#/components/schemas/FileAccess'
+          $ref: "#/components/schemas/FileAccess"
         administrative:
-          $ref: '#/components/schemas/FileAdministrative'
+          $ref: "#/components/schemas/FileAdministrative"
         presentation:
-          $ref: '#/components/schemas/Presentation'
+          $ref: "#/components/schemas/Presentation"
       required:
         - externalIdentifier
         - label
@@ -1078,12 +1083,12 @@ components:
       additionalProperties: false
       oneOf:
         # Being first, makes DarkAccess the default.
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
     FileAdministrative:
       type: object
       additionalProperties: false
@@ -1110,18 +1115,18 @@ components:
           description: The content type of the Fileset.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/resources/audio'
-            - 'https://cocina.sul.stanford.edu/models/resources/attachment'
-            - 'https://cocina.sul.stanford.edu/models/resources/document'
-            - 'https://cocina.sul.stanford.edu/models/resources/file'
-            - 'https://cocina.sul.stanford.edu/models/resources/image'
-            - 'https://cocina.sul.stanford.edu/models/resources/media'
-            - 'https://cocina.sul.stanford.edu/models/resources/object'
-            - 'https://cocina.sul.stanford.edu/models/resources/page'
-            - 'https://cocina.sul.stanford.edu/models/resources/preview'
-            - 'https://cocina.sul.stanford.edu/models/resources/3d'
-            - 'https://cocina.sul.stanford.edu/models/resources/thumb'
-            - 'https://cocina.sul.stanford.edu/models/resources/video'
+            - "https://cocina.sul.stanford.edu/models/resources/audio"
+            - "https://cocina.sul.stanford.edu/models/resources/attachment"
+            - "https://cocina.sul.stanford.edu/models/resources/document"
+            - "https://cocina.sul.stanford.edu/models/resources/file"
+            - "https://cocina.sul.stanford.edu/models/resources/image"
+            - "https://cocina.sul.stanford.edu/models/resources/media"
+            - "https://cocina.sul.stanford.edu/models/resources/object"
+            - "https://cocina.sul.stanford.edu/models/resources/page"
+            - "https://cocina.sul.stanford.edu/models/resources/preview"
+            - "https://cocina.sul.stanford.edu/models/resources/3d"
+            - "https://cocina.sul.stanford.edu/models/resources/thumb"
+            - "https://cocina.sul.stanford.edu/models/resources/video"
         externalIdentifier:
           type: string
         label:
@@ -1131,7 +1136,7 @@ components:
           description: Version for the Fileset within SDR.
           type: integer
         structural:
-          $ref: '#/components/schemas/FileSetStructural'
+          $ref: "#/components/schemas/FileSetStructural"
       required:
         - externalIdentifier
         - label
@@ -1146,7 +1151,7 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/File'
+            $ref: "#/components/schemas/File"
     FileUse:
       description: Use for the File (e.g. "transcription" for OCR).
       type: string
@@ -1164,7 +1169,8 @@ components:
             - previous folio
           example: folio
         refresh:
-          description: Only one of the Folio instance HRIDs should be designated for refreshing.
+          description:
+            Only one of the Folio instance HRIDs should be designated for refreshing.
             This means that this HRID is the one used to pull metadata from the catalog
             if there is more than one HRID present.
           type: boolean
@@ -1172,9 +1178,9 @@ components:
         catalogRecordId:
           description: Record identifier that is unique within the context of the linked record's catalog.
           oneOf:
-            - $ref: '#/components/schemas/MigratedFromSymphonyIdentifier'
-            - $ref: '#/components/schemas/MigratedFromVoyagerIdentifier'
-            - $ref: '#/components/schemas/CreatedInFolioIdentifier'
+            - $ref: "#/components/schemas/MigratedFromSymphonyIdentifier"
+            - $ref: "#/components/schemas/MigratedFromVoyagerIdentifier"
+            - $ref: "#/components/schemas/CreatedInFolioIdentifier"
         partLabel:
           description: Label for use in display of serials via Folio record
           type: string
@@ -1200,24 +1206,25 @@ components:
       additionalProperties: false
       properties:
         barcode:
-          $ref: '#/components/schemas/Barcode'
+          $ref: "#/components/schemas/Barcode"
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         doi:
-          $ref: '#/components/schemas/DOI'
+          $ref: "#/components/schemas/DOI"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
       required:
         - sourceId
     LaneMedicalBarcode:
       description: The barcode associated with a Lane Medical Library DRO object, prefixed with 245
       type: string
-      pattern: '^245[0-9]{8}$'
-      example: '24503259768'
+      pattern: "^245[0-9]{8}$"
+      example: "24503259768"
     Language:
-      description: Languages, scripts, symbolic systems, and notations used in all
+      description:
+        Languages, scripts, symbolic systems, and notations used in all
         or part of a resource or its descriptive metadata.
       type: object
       additionalProperties: false
@@ -1254,7 +1261,7 @@ components:
           type: string
           description: present for mapping to additional schemas in the future and for consistency but not otherwise used
         script:
-          $ref: '#/components/schemas/DescriptiveValue'
+          $ref: "#/components/schemas/DescriptiveValue"
           # description: An alphabet or other notation used to represent a
           #   language or other symbolic system associated with the resource.
         source:
@@ -1291,44 +1298,44 @@ components:
       nullable: true
     LibrariesDOI:
       type: string
-      description: 'The DOI (Digital Object Identifier, https://www.doi.org) pattern for works registered by Stanford Libraries outside of SDR workflows. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted.'
+      description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for works registered by Stanford Libraries outside of SDR workflows. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted."
       pattern: '^10\.25936\/[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}$'
-      example: '10.25936/629T-bx79'
+      example: "10.25936/629T-bx79"
     License:
       description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
       type: string
       nullable: true
       enum:
-        - 'https://www.gnu.org/licenses/agpl.txt'
-        - 'https://www.apache.org/licenses/LICENSE-2.0'
-        - 'https://opensource.org/licenses/BSD-2-Clause'
-        - 'https://opensource.org/licenses/BSD-3-Clause'
-        - 'https://creativecommons.org/licenses/by/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nd/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-sa/4.0/legalcode'
-        - 'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
-        - 'https://opensource.org/licenses/cddl1'
-        - 'https://www.eclipse.org/legal/epl-2.0'
-        - 'https://www.gnu.org/licenses/gpl-3.0-standalone.html'
-        - 'https://www.isc.org/downloads/software-support-policy/isc-license/'
-        - 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html'
-        - 'https://opensource.org/licenses/MIT'
-        - 'https://www.mozilla.org/MPL/2.0/'
-        - 'https://opendatacommons.org/licenses/by/1-0/'
-        - 'http://opendatacommons.org/licenses/odbl/1.0/' # Non cannonical, but in some of our data
-        - 'https://opendatacommons.org/licenses/odbl/1-0/'
-        - 'https://creativecommons.org/publicdomain/mark/1.0/'
-        - 'https://opendatacommons.org/licenses/pddl/1-0/'
-        - 'https://creativecommons.org/licenses/by/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-sa/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nd/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
-        - 'https://cocina.sul.stanford.edu/licenses/none' # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
+        - "https://www.gnu.org/licenses/agpl.txt"
+        - "https://www.apache.org/licenses/LICENSE-2.0"
+        - "https://opensource.org/licenses/BSD-2-Clause"
+        - "https://opensource.org/licenses/BSD-3-Clause"
+        - "https://creativecommons.org/licenses/by/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+        - "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+        - "https://opensource.org/licenses/cddl1"
+        - "https://www.eclipse.org/legal/epl-2.0"
+        - "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+        - "https://www.isc.org/downloads/software-support-policy/isc-license/"
+        - "https://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+        - "https://opensource.org/licenses/MIT"
+        - "https://www.mozilla.org/MPL/2.0/"
+        - "https://opendatacommons.org/licenses/by/1-0/"
+        - "http://opendatacommons.org/licenses/odbl/1.0/" # Non cannonical, but in some of our data
+        - "https://opendatacommons.org/licenses/odbl/1-0/"
+        - "https://creativecommons.org/publicdomain/mark/1.0/"
+        - "https://opendatacommons.org/licenses/pddl/1-0/"
+        - "https://creativecommons.org/licenses/by/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+        - "https://cocina.sul.stanford.edu/licenses/none" # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
     LocationBasedAccess:
       type: object
       properties:
@@ -1347,12 +1354,12 @@ components:
           description: If access or download is "location-based", which location should have access.
           type: string
           enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+            - "spec"
+            - "music"
+            - "ars"
+            - "art"
+            - "hoover"
+            - "m&m"
         controlledDigitalLending:
           type: boolean
           default: false
@@ -1380,12 +1387,12 @@ components:
           description: Which location should have download access.
           type: string
           enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+            - "spec"
+            - "music"
+            - "ars"
+            - "art"
+            - "hoover"
+            - "m&m"
         controlledDigitalLending:
           type: boolean
           default: false
@@ -1416,12 +1423,12 @@ components:
       description: A record identifier migrated from Symphony
       type: string
       pattern: '^a\d+$'
-      example: 'a11403803'
+      example: "a11403803"
     MigratedFromVoyagerIdentifier:
       description: A record identifier migrated from Voyager
       type: string
       pattern: '^L\d+$'
-      example: 'L11403803'
+      example: "L11403803"
     # ObjectMetadata schema should not be copied to sdr-api and dor-services-app.
     ObjectMetadata:
       description: Metadata for a cocina object.
@@ -1443,9 +1450,9 @@ components:
         - lock
     PreregisteredRepositoryDOI:
       type: string
-      description: 'The DOI (Digital Object Identifier, https://www.doi.org) pattern for DOIs registered before an SDR object has been registered---i.e., before it has a druid, which is a common pattern as of 2025. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted.'
+      description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for DOIs registered before an SDR object has been registered---i.e., before it has a druid, which is a common pattern as of 2025. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted."
       pattern: '^10\.(25740|80343)\/[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}$'
-      example: '10.80343/12qF-5243'
+      example: "10.80343/12qF-5243"
     Presentation:
       description: Presentation data for the File.
       type: object
@@ -1472,48 +1479,49 @@ components:
           description: The relationship of the related resource to the described resource.
           type: string
         dataCiteRelationType:
-          description: The DataCite relationType describing the relationship from the related resource to the described resource.
+          description:
+            The DataCite relationType describing the relationship from the related resource to the described resource.
             See https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
           type: string
           enum:
-            - 'IsCitedBy'
-            - 'Cites'
-            - 'IsSupplementTo'
-            - 'IsSupplementedBy'
-            - 'IsContinuedBy'
-            - 'Continues'
-            - 'Describes'
-            - 'IsDescribedBy'
-            - 'HasMetadata'
-            - 'IsMetadataFor'
-            - 'HasVersion'
-            - 'IsVersionOf'
-            - 'IsNewVersionOf'
-            - 'IsPreviousVersionOf'
-            - 'IsPartOf'
-            - 'HasPart'
-            - 'IsPublishedIn'
-            - 'IsReferencedBy'
-            - 'References'
-            - 'IsDocumentedBy'
-            - 'Documents'
-            - 'IsCompiledBy'
-            - 'Compiles'
-            - 'IsVariantFormOf'
-            - 'IsOriginalFormOf'
-            - 'IsIdenticalTo'
-            - 'IsReviewedBy'
-            - 'Reviews'
-            - 'IsDerivedFrom'
-            - 'IsSourceOf'
-            - 'IsRequiredBy'
-            - 'Requires'
-            - 'Obsoletes'
-            - 'IsObsoletedBy'
-            - 'IsCollectedBy'
-            - 'Collects'
-            - 'IsTranslationOf'
-            - 'HasTranslation'
+            - "IsCitedBy"
+            - "Cites"
+            - "IsSupplementTo"
+            - "IsSupplementedBy"
+            - "IsContinuedBy"
+            - "Continues"
+            - "Describes"
+            - "IsDescribedBy"
+            - "HasMetadata"
+            - "IsMetadataFor"
+            - "HasVersion"
+            - "IsVersionOf"
+            - "IsNewVersionOf"
+            - "IsPreviousVersionOf"
+            - "IsPartOf"
+            - "HasPart"
+            - "IsPublishedIn"
+            - "IsReferencedBy"
+            - "References"
+            - "IsDocumentedBy"
+            - "Documents"
+            - "IsCompiledBy"
+            - "Compiles"
+            - "IsVariantFormOf"
+            - "IsOriginalFormOf"
+            - "IsIdenticalTo"
+            - "IsReviewedBy"
+            - "Reviews"
+            - "IsDerivedFrom"
+            - "IsSourceOf"
+            - "IsRequiredBy"
+            - "Requires"
+            - "Obsoletes"
+            - "IsObsoletedBy"
+            - "IsCollectedBy"
+            - "Collects"
+            - "IsTranslationOf"
+            - "HasTranslation"
         status:
           description: Status of the related resource relative to other related resources.
           type: string
@@ -1526,7 +1534,8 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         contributor:
-          description: Agents contributing in some way to the creation and history of the
+          description:
+            Agents contributing in some way to the creation and history of the
             related resource.
           type: array
           items:
@@ -1537,13 +1546,15 @@ components:
           items:
             $ref: "#/components/schemas/Event"
         form:
-          description: Characteristics of the related resource's physical, digital, and intellectual
+          description:
+            Characteristics of the related resource's physical, digital, and intellectual
             form and genre, and of its process of creation.
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         language:
-          description: Languages, scripts, symbolic systems, and notations used in all or
+          description:
+            Languages, scripts, symbolic systems, and notations used in all or
             part of a related resource.
           type: array
           items:
@@ -1587,18 +1598,18 @@ components:
       type: string
       description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for SDR objects, based on the object's repository identifier. Permits both production and text prefixes to be used to account for objects in different SDR environments. Please note that while DOIs are *not* case-sensitive, we constrain the DOIs we mint for SDR to lowercase for consistency."
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: '10.25740/bc123df4567'
+      example: "10.25740/bc123df4567"
     RequestAdminPolicy:
       description: Same as an AdminPolicy, but doesn't have an externalIdentifier as one will be created
       type: object
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/admin_policy'
+            - "https://cocina.sul.stanford.edu/models/admin_policy"
         label:
           type: string
         version:
@@ -1607,9 +1618,9 @@ components:
           enum:
             - 1
         administrative:
-          $ref: '#/components/schemas/AdminPolicyAdministrative'
+          $ref: "#/components/schemas/AdminPolicyAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
       required:
         - cocinaVersion
         - administrative
@@ -1634,15 +1645,15 @@ components:
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/collection'
-            - 'https://cocina.sul.stanford.edu/models/curated-collection'
-            - 'https://cocina.sul.stanford.edu/models/user-collection'
-            - 'https://cocina.sul.stanford.edu/models/exhibit'
-            - 'https://cocina.sul.stanford.edu/models/series'
+            - "https://cocina.sul.stanford.edu/models/collection"
+            - "https://cocina.sul.stanford.edu/models/curated-collection"
+            - "https://cocina.sul.stanford.edu/models/user-collection"
+            - "https://cocina.sul.stanford.edu/models/exhibit"
+            - "https://cocina.sul.stanford.edu/models/series"
         label:
           type: string
         version:
@@ -1651,13 +1662,13 @@ components:
           enum:
             - 1
         access:
-          $ref: '#/components/schemas/CollectionAccess'
+          $ref: "#/components/schemas/CollectionAccess"
         administrative:
-          $ref: '#/components/schemas/RequestAdministrative'
+          $ref: "#/components/schemas/RequestAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
         identification:
-          $ref: '#/components/schemas/CollectionIdentification'
+          $ref: "#/components/schemas/CollectionIdentification"
       required:
         - cocinaVersion
         - access
@@ -1671,25 +1682,25 @@ components:
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/object'
-            - 'https://cocina.sul.stanford.edu/models/3d'
-            - 'https://cocina.sul.stanford.edu/models/agreement'
-            - 'https://cocina.sul.stanford.edu/models/book'
-            - 'https://cocina.sul.stanford.edu/models/document'
-            - 'https://cocina.sul.stanford.edu/models/geo'
-            - 'https://cocina.sul.stanford.edu/models/image'
-            - 'https://cocina.sul.stanford.edu/models/page'
-            - 'https://cocina.sul.stanford.edu/models/photograph'
-            - 'https://cocina.sul.stanford.edu/models/manuscript'
-            - 'https://cocina.sul.stanford.edu/models/map'
-            - 'https://cocina.sul.stanford.edu/models/media'
-            - 'https://cocina.sul.stanford.edu/models/track'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-binary'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+            - "https://cocina.sul.stanford.edu/models/object"
+            - "https://cocina.sul.stanford.edu/models/3d"
+            - "https://cocina.sul.stanford.edu/models/agreement"
+            - "https://cocina.sul.stanford.edu/models/book"
+            - "https://cocina.sul.stanford.edu/models/document"
+            - "https://cocina.sul.stanford.edu/models/geo"
+            - "https://cocina.sul.stanford.edu/models/image"
+            - "https://cocina.sul.stanford.edu/models/page"
+            - "https://cocina.sul.stanford.edu/models/photograph"
+            - "https://cocina.sul.stanford.edu/models/manuscript"
+            - "https://cocina.sul.stanford.edu/models/map"
+            - "https://cocina.sul.stanford.edu/models/media"
+            - "https://cocina.sul.stanford.edu/models/track"
+            - "https://cocina.sul.stanford.edu/models/webarchive-binary"
+            - "https://cocina.sul.stanford.edu/models/webarchive-seed"
         label:
           type: string
         version:
@@ -1698,17 +1709,17 @@ components:
           enum:
             - 1
         access:
-          $ref: '#/components/schemas/DROAccess'
+          $ref: "#/components/schemas/DROAccess"
         administrative:
-          $ref: '#/components/schemas/RequestAdministrative'
+          $ref: "#/components/schemas/RequestAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
         identification:
-          $ref: '#/components/schemas/RequestIdentification'
+          $ref: "#/components/schemas/RequestIdentification"
         structural:
-          $ref: '#/components/schemas/RequestDROStructural'
+          $ref: "#/components/schemas/RequestDROStructural"
         geographic:
-          $ref: '#/components/schemas/Geographic'
+          $ref: "#/components/schemas/Geographic"
       required:
         - cocinaVersion
         - administrative
@@ -1724,16 +1735,16 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/RequestFileSet'
+            $ref: "#/components/schemas/RequestFileSet"
         hasMemberOrders:
           type: array
           items:
-            $ref: '#/components/schemas/Sequence'
+            $ref: "#/components/schemas/Sequence"
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array
           items:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     RequestDescription:
       description: Description that is included in a request to create a DRO. This is the same as a Description, except excludes PURL.
       type: object
@@ -1746,7 +1757,8 @@ components:
           items:
             $ref: "#/components/schemas/Title"
         contributor:
-          description: Agents contributing in some way to the creation and history of the
+          description:
+            Agents contributing in some way to the creation and history of the
             resource.
           type: array
           items:
@@ -1757,7 +1769,8 @@ components:
           items:
             $ref: "#/components/schemas/Event"
         form:
-          description: Characteristics of the resource's physical, digital, and intellectual
+          description:
+            Characteristics of the resource's physical, digital, and intellectual
             form and genre, and of its process of creation.
           type: array
           items:
@@ -1768,7 +1781,8 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveGeographicMetadata"
         language:
-          description: Languages, scripts, symbolic systems, and notations used in all or
+          description:
+            Languages, scripts, symbolic systems, and notations used in all or
             part of a resource.
           type: array
           items:
@@ -1814,7 +1828,7 @@ components:
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/file'
+            - "https://cocina.sul.stanford.edu/models/file"
         label:
           type: string
         filename:
@@ -1826,11 +1840,11 @@ components:
         hasMimeType:
           type: string
         languageTag:
-          $ref: '#/components/schemas/LanguageTag'
+          $ref: "#/components/schemas/LanguageTag"
         externalIdentifier:
           type: string
         use:
-          $ref: '#/components/schemas/FileUse'
+          $ref: "#/components/schemas/FileUse"
         sdrGeneratedText:
           description: Indicates if the text (OCR/captioning) was generated by SDR.
           type: boolean
@@ -1842,13 +1856,13 @@ components:
         hasMessageDigests:
           type: array
           items:
-            $ref: '#/components/schemas/MessageDigest'
+            $ref: "#/components/schemas/MessageDigest"
         access:
-          $ref: '#/components/schemas/FileAccess'
+          $ref: "#/components/schemas/FileAccess"
         administrative:
-          $ref: '#/components/schemas/FileAdministrative'
+          $ref: "#/components/schemas/FileAdministrative"
         presentation:
-          $ref: '#/components/schemas/Presentation'
+          $ref: "#/components/schemas/Presentation"
       required:
         - label
         - type
@@ -1864,24 +1878,24 @@ components:
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/resources/audio'
-            - 'https://cocina.sul.stanford.edu/models/resources/attachment'
-            - 'https://cocina.sul.stanford.edu/models/resources/document'
-            - 'https://cocina.sul.stanford.edu/models/resources/file'
-            - 'https://cocina.sul.stanford.edu/models/resources/image'
-            - 'https://cocina.sul.stanford.edu/models/resources/media'
-            - 'https://cocina.sul.stanford.edu/models/resources/object'
-            - 'https://cocina.sul.stanford.edu/models/resources/page'
-            - 'https://cocina.sul.stanford.edu/models/resources/preview'
-            - 'https://cocina.sul.stanford.edu/models/resources/3d'
-            - 'https://cocina.sul.stanford.edu/models/resources/thumb'
-            - 'https://cocina.sul.stanford.edu/models/resources/video'
+            - "https://cocina.sul.stanford.edu/models/resources/audio"
+            - "https://cocina.sul.stanford.edu/models/resources/attachment"
+            - "https://cocina.sul.stanford.edu/models/resources/document"
+            - "https://cocina.sul.stanford.edu/models/resources/file"
+            - "https://cocina.sul.stanford.edu/models/resources/image"
+            - "https://cocina.sul.stanford.edu/models/resources/media"
+            - "https://cocina.sul.stanford.edu/models/resources/object"
+            - "https://cocina.sul.stanford.edu/models/resources/page"
+            - "https://cocina.sul.stanford.edu/models/resources/preview"
+            - "https://cocina.sul.stanford.edu/models/resources/3d"
+            - "https://cocina.sul.stanford.edu/models/resources/thumb"
+            - "https://cocina.sul.stanford.edu/models/resources/video"
         label:
           type: string
         version:
           type: integer
         structural:
-          $ref: '#/components/schemas/RequestFileSetStructural'
+          $ref: "#/components/schemas/RequestFileSetStructural"
       required:
         - label
         - type
@@ -1895,7 +1909,7 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/RequestFile'
+            $ref: "#/components/schemas/RequestFile"
     RequestIdentification:
       # Doesn't permit a DOI because our DOIs all use the DRUID as part of the DOI.
       # You have to register the object in order to get the DRUID before you can mint a DOI
@@ -1904,13 +1918,13 @@ components:
       additionalProperties: false
       properties:
         barcode:
-          $ref: '#/components/schemas/Barcode'
+          $ref: "#/components/schemas/Barcode"
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
       required:
         - sourceId
     Sequence:
@@ -1955,7 +1969,7 @@ components:
           type: string
     SourceId:
       type: string
-      pattern: '^.+:.+$'
+      pattern: "^.+:.+$"
       description: >
         Unique identifier in some other system. This is because a large proportion of what is deposited in SDR,
         historically and currently, are representations of objects that are also represented in other systems.
@@ -1963,9 +1977,10 @@ components:
         in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers
         and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to
         look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
-      example: 'sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026'
+      example: "sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026"
     Standard:
-      description: Property model for indicating the encoding, standard, or syntax
+      description:
+        Property model for indicating the encoding, standard, or syntax
         to which a value conforms (e.g. RDA).
       type: object
       additionalProperties: false
@@ -1994,8 +2009,8 @@ components:
       description: The standard barcode associated with a DRO object, prefixed with 36105
       type: string
       nullable: true
-      pattern: '^36105[0-9]{9}$'
-      example: '36105010362304'
+      pattern: "^36105[0-9]{9}$"
+      example: "36105010362304"
     StanfordAccess:
       type: object
       properties:
@@ -2036,7 +2051,8 @@ components:
             - previous symphony
           example: symphony
         refresh:
-          description: Only one of the catkeys should be designated for refreshing.
+          description:
+            Only one of the catkeys should be designated for refreshing.
             This means that this key is the one used to pull metadata from the catalog
             if there is more than one key present.
           type: boolean
@@ -2045,7 +2061,7 @@ components:
           description: Record identifier that is unique within the context of the linked record's catalog.
           type: string
           pattern: '^\d+$'
-          example: '11403803'
+          example: "11403803"
       required:
         - catalog
         - catalogRecordId


### PR DESCRIPTION
previously we used both single and double quotes
