### PR TITLE
Import redocly from their CDN instead of jsdelivr

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,6 @@
   </head>
   <body>
     <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/cocina-models/main/openapi.yml'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
The docs weren't loading because requests to jsdelivr were failing.
