### PR TITLE
Reference data for MARC mapping

### DIFF
--- a/spec/data/access.txt
+++ b/spec/data/access.txt
@@ -1,0 +1,66 @@
+// When multiple subfields are mapped together, concatenate with space in the order given
+
+//// Access
+
+// Local call number/shelfmark
+// 099
+// in00000067610
+{
+    "099": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "MSS CODEX 1556 F"
+            }
+        ]
+    }
+}
+{ access: { physicalLocation: [ { value: "MSS CODEX 1556 F", type: "shelf locator" } ] } }
+
+// URL
+// 856 $uyz3
+// a13290862
+{
+    "856": {
+        "ind1": "4",
+        "ind2": "0",
+        "subfields": [
+            {
+                "3": "Current issue"
+            },
+            {
+                "u": "https://purl.fdlp.gov/GPO/gpo121603"
+            }
+        ]
+    }
+}
+{ access: { url: [ { value: "https://purl.fdlp.gov/GPO/gpo121603", displayLabel: "Current issue" } ] } }
+
+// URL
+// 856 $uyz3
+// in00000845662
+{
+    "856": {
+        "ind1": "4",
+        "ind2": "0",
+        "subfields": [
+            {
+                "z": "Available to Stanford-affiliated users."
+            },
+            {
+                "u": "https://doi.org/10.1017/9781009675338"
+            },
+            {
+                "x": "WMS"
+            },
+            {
+                "y": "Cambridge University Press"
+            }
+        ]
+    }
+}
+{ access: { 
+    url: [ { value: "https://doi.org/10.1017/9781009675338", 
+    note: [ { value: "Available to Stanford-affiliated users." }, { value: "Cambridge University Press" } ] } ] } 
+}

--- a/spec/data/adminMetadata.txt
+++ b/spec/data/adminMetadata.txt
@@ -1,0 +1,66 @@
+//// Admin metadata
+// Original cataloging agency
+// 040 $a
+// Date record created
+// 008/00-05
+// Date record last updated
+// 005
+// Record identifier
+// 001
+// Conversion statement
+// generated - insert today's date
+{
+    "001": "in00000144356"
+},
+{
+    "008": "240703c20249999mnuuu         0    0eng d"
+},
+{
+    "005": "20250614160727.3"
+},
+{
+    "040": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "UCX"
+            },
+            {
+                "b": "eng"
+            },
+            {
+                "e": "rda"
+            },
+            {
+                "c": "UCX"
+            },
+            {
+                "d": "OCLCO"
+            },
+            {
+                "d": "RCJ"
+            },
+            {
+                "d": "UtOrBLW"
+            }
+        ]
+    }
+}
+ { adminMetadata: {
+  contributor: [ { 
+    type: "organization", 
+    name: [ { code: "UCX", source: { code: "marcorg" } } ]
+  } ],
+  event: [ {
+    type: "creation",
+    date: [ { value: "240703", encoding: { code: "marc" } } ]
+  }, {
+    type: "modification",
+    date: [ { value: "20250614", encoding: { code: "iso8601" } } ]
+  } ],
+  identifier: [ { value: "in00000144356", type: "FOLIO" } ],
+  note: [ { value: "Converted from MARC to Cocina {YYYY-MM-DD}", type: "record origin" } ]
+ } }
+
+

--- a/spec/data/contributor.txt
+++ b/spec/data/contributor.txt
@@ -1,0 +1,480 @@
+// When multiple subfields are mapped together, concatenate with space in the order given
+// Linked 880 fields should be mapped the same as an instance of the main field given in the $6, 
+//   except for the title 245 which uses parallelValue - i.e., an 880 field with a $6 containing 
+//   246 should be mapped the same as a 100 field
+
+//// Contributor
+// For all contributors: 
+//   - Strip comma from end of name and period from end of role
+//   - Map role code to term and downcase: https://github.com/sul-dlss/SearchWorks/blob/main/lib/constants.rb
+//   - Ignore invalid role codes - do not map
+//   - Deduplicate role terms
+
+// Contributor - person, primary
+// 100 $abcdjq if ind1=0 or 1
+// a895166
+{
+    "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Sayers, Dorothy L."
+            },
+            {
+                "q": "(Dorothy Leigh),"
+            },
+            {
+                "d": "1893-1957."
+            },
+            {
+                "0": "(SIRSI)100978"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", status: "primary", name: [ { value: "Sayers, Dorothy L. (Dorothy Leigh), 1893-1957." } ] } ] }
+
+// Contributor - family, primary
+// 100 $abcdjq if ind1=3
+// a4090014
+{
+    "100": {
+        "ind1": "3",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Packard family."
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "family", status: "primary", name: [ { value: "Packard family." } ] } ] }
+
+// Contributor - organization, primary
+// 110 $abcdn
+// a9803970
+{
+    "110": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Ghana."
+            },
+            {
+                "0": "(SIRSI)168717"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "organization", status: "primary", name: [ { value: "Ghana." } ] } ] }
+
+// Contributor - event, primary
+// 111 $acdenq
+// a5171170
+{
+    "111": {
+        "ind1": "2",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "SIGGRAPH (Conference)"
+            },
+            {
+                "n": "(29th :"
+            },
+            {
+                "d": "2002 :"
+            },
+            {
+                "c": "San Antonio, Tex.)"
+            },
+            {
+                "0": "(SIRSI)566144"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "event", status: "primary", name: [ { value: "SIGGRAPH (Conference) (29th : 2002 : San Antonio. Tex.)" } ] } ] }
+
+// Contributor - person
+// 700 $abcdjq if ind1=0 or 1 and $t not present
+// based on a14185492
+{
+    "700": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Street, Stephen"
+            },
+            {
+                "c": "(Double bassist)."
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", name: [ { value: "Street, Stephen (Double bassist)." } ] } ] }
+
+// Contributor - family
+// 700 $abcdjq if ind1=3 and $t not present
+// a4090014
+{
+    "700": {
+        "ind1": "3",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Gouzigian family."
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "family", name: [ { value: "Gouzigian family." } ] } ] }
+
+// Contributor - organization
+// 710 $abcd if $t not present
+// a9803970
+{
+    "710": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Ghana"
+            },
+            {
+                "b": "Ministry of Tourism (2009-2013)"
+            },
+            {
+                "0": "(SIRSI)168717"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "organization", name: [ { value: "Ghana Ministry of Tourism (2009-2013)" } ] } ] }
+
+// Contributor - event
+// 711 $acdenq if $t not present
+// in00000381224
+{
+    "711": {
+        "ind1": "2",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Simulation Solutions Conference."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2005090352"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "event", name: [ { value: "Simulation Solutions Conference." } ] } ] }
+
+// Contributor - person
+// 720 $a if ind1=1
+// constructed
+{
+    "720": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Blacklock, Joseph"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", name: [ { value: "Blacklock, Joseph" } ] } ] }
+
+// Contributor
+// 720 $a if ind1 is blank
+// constructed
+{
+    "720": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Vonderrohe, Robert, 1934-"
+            }
+        ]
+    }
+}
+{ contributor: [ { name: [ { value: "Vonderrohe, Robert, 1934-" } ] } ] }
+
+// Contributor with role terms
+// 100 $abcdjq with $e
+// Strip comma from end of name and period from end of role
+// in00000723963
+{
+    "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Wagner, Richard,"
+            },
+            {
+                "d": "1813-1883,"
+            },
+            {
+                "e": "composer,"
+            },
+            {
+                "e": "librettist."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/n79089831"
+            },
+            {
+                "1": "https://id.oclc.org/worldcat/entity/E39PBJvMCYbW9m9kmHKrwph4MP"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", status: "primary", name: [ { value: "Wagner, Richard, 1813-1883", role: [ { value: "composer" }, { value: "librettist" } ] } ] } ] }
+
+// Contributor with different role term and code
+// 700 $abcdjq with $e4
+// Map role code to term
+// in00000714805
+{
+    "700": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Cao, Rosa,"
+            },
+            {
+                "e": "degree committee member."
+            },
+            {
+                "4": "ths"
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2019143165"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", name: [ { value: "Cao, Rosa", role: [ { value: "degree committee member" }, { value: "thesis advisor" } ] } ] } ] }
+
+// Contributor with same role term and code
+// 700 $abcdjq with $e4
+// Deduplicate role terms
+// based on in00000714805
+{
+    "700": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Cao, Rosa,"
+            },
+            {
+                "e": "degree committee member."
+            },
+            {
+                "4": "dgc"
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2019143165"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", name: [ { value: "Cao, Rosa", role: [ { value: "degree committee member" } ] } ] } ] }
+
+// Contributor with role term - event
+// 711 $acdenq with $j if $t not present
+// based on in00000381224
+{
+    "711": {
+        "ind1": "2",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Simulation Solutions Conference."
+            },
+            {
+                "j": "creator."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2005090352"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "event", name: [ { value: "Simulation Solutions Conference." } ], role: [ { value: "creator" } ] } ] }
+
+// Contributor with invalid role code
+// 700 $abcdjq with $e4
+// based on in00000714805
+{
+    "700": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Cao, Rosa,"
+            },
+            {
+                "e": "degree committee member."
+            },
+            {
+                "4": "tsh"
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2019143165"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", name: [ { value: "Cao, Rosa", role: [ { value: "degree committee member" } ] } ] } ] }
+
+// Contributor with ORCID identifier
+// 100 $a1 if $1 contains "orcid"
+// based on in00000870077
+// **see https://github.com/sul-dlss/cocina-models/issues/898
+{
+    "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Velez, Vannessa Naomi."
+            },
+            {
+                "1": "https://orcid.org/0009-0005-5256-569X"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "person", status: "primary", name: [ { value: "Velez, Vannessa Naomi." } ], identifier: [ { value: "0009-0005-5256-569X", type: "ORCID" } ] } ] }
+
+// Contributor with other identifier
+// 710 $a1 if $1 does not contain "orcid"
+// in00000870077
+// **see https://github.com/sul-dlss/cocina-models/issues/898
+{
+    "710": {
+        "ind1": "2",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Stanford University."
+            },
+            {
+                "b": "School of Humanities and Sciences."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2009155385"
+            },
+            {
+                "1": "https://ror.org/00f54p054"
+            }
+        ]
+    }
+}
+{ contributor: [ { type: "organization", name: [ { value: "Stanford University." } ], identifier: [ { uri: "https://ror.org/00f54p054" } ] } ] }
+
+// Contributor in multiple scripts
+// 100/880
+// a13162356
+{
+    "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "6": "880-01"
+            },
+            {
+                "a": "Smagina, S. A."
+            },
+            {
+                "e": "author."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/no2011031220"
+            },
+            {
+                "0": "(SIRSI)3726444"
+            }
+        ]
+    }
+},
+{
+    "880": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "6": "100-01"
+            },
+            {
+                "a": "Смагина, С. А,"
+            },
+            {
+                "e": "author."
+            }
+        ]
+    }
+}
+{ contributor: [ 
+    { type: "person", name: [ { value: "Smagina, S. A." } ], role: [ { value: "author" } ] },
+    { type: "person", name: [ { value: "Смагина, С. А" } ], role: [ { value: "author" } ] } 
+] }
+
+// Contributor in multiple scripts
+// 700/880
+// a13355277
+{
+    "700": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "6": "880-05"
+            },
+            {
+                "a": "Lukin, Alexander,"
+            },
+            {
+                "e": "editor."
+            },
+            {
+                "0": "http://id.loc.gov/authorities/names/nb99131940"
+            },
+            {
+                "0": "(SIRSI)1666028"
+            }
+        ]
+    }
+},
+{
+    "880": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "6": "700-05"
+            },
+            {
+                "a": "Лукин, Александр ,"
+            },
+            {
+                "e": "author."
+            }
+        ]
+    }
+}
+{ contributor: [ 
+    { type: "person", name: [ { value: "Lukin, Alexander" } ], role: [ { value: "editor" } ] },
+    { type: "person", name: [ { value: "Лукин, Александр" } ], role: [ { value: "author" } ] } 
+] }

--- a/spec/data/event.txt
+++ b/spec/data/event.txt
@@ -1,0 +1,426 @@
+// When multiple subfields are mapped together, concatenate with space in the order given
+// Linked 880 fields should be mapped the same as an instance of the main field given in the $6, 
+//   except for the title 245 which uses parallelValue - i.e., an 880 field with a $6 containing 
+//   246 should be mapped the same as a 246 field
+
+//// Event
+// For both 260 and 264: Strip space and selected punctuation from end of each subfield: :,;/ (cf. MARC2MODS XSLT)
+// For both 260 and 264: Strip . from end of $c
+
+// Event - publication
+// 260 $abc
+// a3915375
+{
+    "260": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Basingstoke :"
+            },
+            {
+                "b": "Macmillan,"
+            },
+            {
+                "c": "1997."
+            }
+        ]
+    }
+}
+{ event: [ { 
+  type: "publication",
+  place: [ { value: "Basingstoke" } ],
+  contributor: [ { name: [ { value: "Macmillan" } ], role: [ { value: "publisher" } ] } ],
+  date: [ { value: "1997", type: "publication" } ]
+} ] }
+
+// Event - publication and manufacture
+// 260 $abcefg
+// example from LC
+{
+    "260": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "London :"
+            },
+            {
+                "b": "Arts Council of Great Britain,"
+            },
+            {
+                "c": "1976"
+            },
+            {
+                "e": "(Twickenham :"
+            },
+            {
+                "f": "CTD Printers,"
+            },
+            {
+                "g": "1974)"
+            }
+        ]
+    }
+}
+{ event: [ { 
+  type: "publication",
+  place: [ { value: "London" } ],
+  contributor: [ { name: [ { value: "Arts Council of Great Britain" } ], role: [ { value: "publisher" } ] } ],
+  date: [ { value: "1976", type: "publication" } ]
+}, {
+  type: "manufacture",
+  place: [ { value: "(Twickenham" } ],
+  contributor: [ { name: [ { value: "CTD Printers"} ] } ],
+  date: [ { value: "1974)", type: "manufacture"}]
+} ] }
+
+// Event - production
+// 264 $abc if ind2=0
+// a11739655
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "0",
+        "subfields": [
+            {
+                "c": "approximately 1905-1930."
+            }
+        ]
+    }
+}
+{ event: [ { type: "production", date: [ { value: "approximately 1905-1930", type: "production" } ] } ] }
+
+// Event - publication
+// 264 $abc if ind2=1
+// a12365535
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "1",
+        "subfields": [
+            {
+                "a": "[France] :"
+            },
+            {
+                "b": "Erato :"
+            },
+            {
+                "b": "Warner Classics,"
+            },
+            {
+                "c": "[2017]"
+            }
+        ]
+    }
+}
+{ event: [ {
+  type: "publication",
+  place: [ { value: "[France]" } ],
+  contributor: [ 
+    { name: [ { value: "Erato" } ], role: [ { value: "publisher" } ] },
+    { name: [ { value: "Warner Classics"} ], role: [ { value: "publisher" } ] } 
+  ],
+  date: [ { value: "[2017]", type: "publication" } ]
+} ] }
+
+// Event - distribution
+// 264 $abc if ind2=2
+// based on LC example
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "2",
+        "subfields": [
+            {
+                "a": "Seattle :"
+            },
+            {
+                "b": "Iverson Company,"
+            },
+            {
+                "c": "[2009]"
+            }
+        ]
+    }
+}
+{ event: [ {
+  type: "distribution",
+  place: [ { value: "Seattle" } ],
+  contributor: [ 
+    { name: [ { value: "Iverson Company" } ], role: [ { value: "distributor" } ] },
+  ],
+  date: [ { value: "[2009]", type: "distribution" } ]
+} ] }
+
+// Event - manufacture
+// 264 $abc if ind2=3
+// based on LC example
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "3",
+        "subfields": [
+            {
+                "a": "Cambridge :"
+            },
+            {
+                "b": "Kinsey Printing Company,"
+            },
+            {
+                "c": "[2010]"
+            }
+        ]
+    }
+}
+{ event: [ {
+  type: "manufacture",
+  place: [ { value: "Cambridge" } ],
+  contributor: [ 
+    { name: [ { value: "Kinsey Printing Company" } ], role: [ { value: "manufacturer" } ] },
+  ],
+  date: [ { value: "[2010]", type: "manufacture" } ]
+} ] }
+
+// Event - copyright
+// 264 $c if ind2=4
+// a12365535
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "4",
+        "subfields": [
+            {
+                "c": "℗2017"
+            }
+        ]
+    }
+}
+{ event: [ { type: "copyright notice", note: [ { value: "℗2017", type: "copyright statement" } ] } ] }
+
+// Event
+// 264 $abc if ind2 is blank
+// a12836911
+{
+    "264": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "New York :"
+            },
+            {
+                "b": "Fifty-three studio,"
+            },
+            {
+                "c": "2018."
+            }
+        ]
+    }
+}
+{ event: [ {
+  place: [ { value: "New York :"} ],
+  contributor: [ { name: [ { value: " Fifty-three studio," } ] } ],
+  date: [ { value: "2018." } ]
+} ] }
+
+// Event - edition
+// 250 $ab
+// in00000884911
+{
+    "250": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Ninth edition /"
+            },
+            {
+                "b": "Jonathan S. Abramowitz, University of North Carolina at Chapel Hill, Mitchell J. Prinstein, University of North Carolina at Chapel Hill, Timothy J. Trull, University of Missouri-Columbia."
+            }
+        ]
+    }
+}
+{ event: [ { type: "publication", note: [ { type: "edition", value: "Ninth edition / Jonathan S. Abramowitz, University of North Carolina at Chapel Hill, Mitchell J. Prinstein, University of North Carolina at Chapel Hill, Timothy J. Trull, University of Missouri-Columbia." } ] } ] }
+
+// Event - frequency
+// 310 $ab
+// a5566265
+// 260 ind1=3 $3 a5566265
+{
+    "310": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Annual"
+            }
+        ]
+    }
+}
+{ event: [ { type: "publication", note: [ { value: "Annual", type: "frequency" } ] } ] }
+
+// Event - issuance
+// 334 $a
+// LC example
+{
+    "334": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "single unit"
+            }
+        ]
+    }
+}
+{ event: [ { note: [ { value: "single unit", type: "issuance" } ] } ] }
+
+// Event - multiple scripts
+// 264/880
+// a13355277
+{
+    "264": {
+        "ind1": " ",
+        "ind2": "1",
+        "subfields": [
+            {
+                "6": "880-03"
+            },
+            {
+                "a": "Moskva :"
+            },
+            {
+                "b": "Izdatelʹstvo \"Vesʹ Mir\","
+            },
+            {
+                "c": "2019."
+            }
+        ]
+    }
+},
+{
+    "880": {
+        "ind1": " ",
+        "ind2": "1",
+        "subfields": [
+            {
+                "6": "264-03"
+            },
+            {
+                "a": "Москва :"
+            },
+            {
+                "b": "Издательство \"Весь Мир\","
+            },
+            {
+                "c": "2019."
+            }
+        ]
+    }
+}
+{ event: [ 
+    {
+        type: "publication",
+        place: [ { value: "Moskva" } ],
+        contributor: [ 
+            { name: [ { value: "Izdatelʹstvo \"Vesʹ Mir\"" } ], role: [ { value: "publisher" } ] },
+        ],
+        date: [ { value: "2019", type: "publication" } ]
+    },
+    {
+        type: "publication",
+        place: [ { value: "Москва" } ],
+        contributor: [ 
+            { name: [ { value: "Издательство \"Весь Мир\"" } ], role: [ { value: "publisher" } ] },
+        ],
+        date: [ { value: "2019", type: "publication" } ]
+    }
+    ] }
+
+// Encoded single publication date
+// 008/07-10 if 008/06 = e, p, r, s, or t and L06 not d, f, p, or t
+// a13355277
+{
+    "leader": "04057nam a2200601Ii 4500",
+    [
+        {
+            "008": "190904t20192018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "publication", date: [ 
+    { value: "2019", type: "publication", encoding: { code: "marc" } } 
+] } ] }
+
+// Encoded single creation date
+// 008/07-10 if 008/06 = e, p, r, s, or t and L06 = d, f, p, or t
+{
+    "leader": "04057ndm a2200601Ii 4500",
+    [
+        {
+            "008": "190904e20192018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "creation", date: [ 
+    { value: "2019", type: "creation", encoding: { code: "marc" } } 
+] } ] }
+
+// Encoded multiple publication date
+// 008/07-10 and 008/11-14 if 008/06 = m and L06 not d, f, p, or t
+{
+    "leader": "04057ncm a2200601Ii 4500",
+    [
+        {
+            "008": "190904m20172018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "publication", date: [ 
+    { value: "2017", type: "publication", encoding: { code: "marc" } },
+    { value: "2018", type: "publication", encoding: { code: "marc" } } 
+] } ] }
+
+// Encoded multiple creation date
+// 008/07-10 and 008/11-14 if 008/06 = m and L06 = d, f, p, or t
+{
+    "leader": "04057nfm a2200601Ii 4500",
+    [
+        {
+            "008": "190904m20172018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "creation", date: [ 
+    { value: "2017", type: "creation", encoding: { code: "marc" } },
+    { value: "2018", type: "creation", encoding: { code: "marc" } } 
+] } ] }
+
+// Encoded publication date range
+// 008/07-10 and 008/11-14 if 008/06 = c, d, i, k, or u and L06 not d, f, p, or t
+{
+    "leader": "04057nem a2200601Ii 4500",
+    [
+        {
+            "008": "190904c20172018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "publication", date: [ 
+    { structuredValue: [ { value: "2017", type: "start" }, { value: "2018", type: "end" } ], type: "publication", encoding: { code: "marc" } } 
+] } ] }
+
+// Encoded creation date range
+// 008/07-10 and 008/11-14 if 008/06 = c, d, i, k, or u and L06 = d, f, p, or t
+{
+    "leader": "04057ntm a2200601Ii 4500",
+    [
+        {
+            "008": "190904d20172018ru            000 0 rusod"
+        }
+    ]
+}
+{ event: [ { type: "creation", date: [ 
+    { structuredValue: [ { value: "2017", type: "start" }, { value: "2018", type: "end" } ], type: "creation", encoding: { code: "marc" } } 
+] } ] }

--- a/spec/data/identifier.txt
+++ b/spec/data/identifier.txt
@@ -1,0 +1,288 @@
+// When multiple subfields are mapped together, concatenate with space in the order given
+
+//// Identifier
+
+// For all identifiers: strip leading and trailing spaces
+
+// LCCN
+// 010 $a
+// a5566265
+{
+    "010": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "  2005203496"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "2005203496", type: "LCCN" } ] }
+
+// ISBN
+// 020 $aq
+// in00000872854
+{
+    "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "9783032051035"
+            },
+            {
+                "q": "(electronic bk.)"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "9783032051035 (electronic bk.)", type: "ISBN" } ] }
+
+// ISSN
+// 022 $a
+// in00000199573
+{
+    "022": {
+        "ind1": "0",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "3065-7024"
+            },
+            {
+                "2": "1"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "3065-7024", type: "ISSN" } ] }
+
+// ISRC
+// 024 $adq if ind1 = 0
+// constructed
+{
+    "022": {
+        "ind1": "0",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "3065-7024"
+            },
+            {
+                "d": "1"
+            },
+            {
+                "q": "(compact disc)"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "3065-7024 1 (compact disc)", type: "ISRC" } ] }
+
+
+// UPC
+// 024 $adq if ind1 = 1
+// a12365535
+{
+    "024": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "190295849016"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "190295849016", type: "UPC" } ] }
+
+// ISMN
+// 024 $adq if ind1 = 2
+// LC example
+{
+    "024": {
+        "ind1": "2",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "M570406210"
+            },
+            {
+                "q": "parts"
+            },
+            {
+                "q": "sewn"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "M570406210 parts sewn", type: "ISMN" } ] }
+
+// International Article Number
+// 024 $adq if ind1 = 3
+// a12365535
+{
+    "024": {
+        "ind1": "3",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "0190295849016"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "0190295849016", type: "International Article Number" } ] }
+
+// SICI
+// 024 $adq if ind1 = 4
+// LC example
+{
+    "024": {
+        "ind1": "4",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "a875623247541986340134QTP1"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "a875623247541986340134QTP1", type: "SICI" } ] }
+
+// DOI
+// 024 $adq if ind1 = 7 and $2 = doi
+// in00000872854
+{
+    "024": {
+        "ind1": "7",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "10.1007/978-3-032-05103-5"
+            },
+            {
+                "2": "doi"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "10.1007/978-3-032-05103-5", type: "DOI" } ] }
+
+// Source code in $2 (not DOI)
+// 024 $adq if ind1 = 7
+// LC example
+{
+    "024": {
+        "ind1": "7",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "0A3200912B4A1057"
+            },
+            {
+                "2": "istc"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "0A3200912B4A1057", source: { code: "istc" } } ] }
+
+// Issue number
+// 028 $abq if ind1 = 0
+// a12365535
+{
+    "028": {
+        "ind1": "0",
+        "ind2": "2",
+        "subfields": [
+            {
+                "a": "560930"
+            },
+            {
+                "b": "Erato/Warner Classics"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "ERA560930 Erato/Warner Classics ", type: "issue number" } ] }
+
+// Matrix number
+// 028 $abq if ind1 = 1
+// LC example
+{
+    "028": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "J-18961M-A"
+            },
+            {
+                "b": "Country Line"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "J-18961M-A Country Line", type: "matrix number" } ] }
+
+// Music plate number
+// 028 $abq if ind1 = 2
+// LC example
+{
+    "028": {
+        "ind1": "2",
+        "ind2": "2",
+        "subfields": [
+            {
+                "a": "B. & H. 8797"
+            },
+            {
+                "b": "Breitkopf & Hartel"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "B. & H. 8797 Breitkopf & Hartel", type: "music plate" } ] }
+
+// Music publisher number
+// 028 $abq if ind1 = 3
+// constructed
+{
+    "028": {
+        "ind1": "3",
+        "ind2": "2",
+        "subfields": [
+            {
+                "a": "12345"
+            },
+            {
+                "b": "Columbia"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "12345 Columbia", type: "music publisher" } ] }
+
+// Videorecording publisher number
+// 028 $abq if ind1 = 4
+// based on a5703972
+{
+    "028": {
+        "ind1": "4",
+        "ind2": "2",
+        "subfields": [
+            {
+                "a": "440 073 032-9"
+            },
+            {
+                "b": "Deutsche Grammophon"
+            },
+            {
+                "q": "(set and guide)"
+            }
+        ]
+    }
+}
+{ identifier: [ { value: "440 073 032-9 Deutsche Grammophon (set and guide)" } ] }

--- a/spec/data/language.txt
+++ b/spec/data/language.txt
@@ -1,0 +1,56 @@
+//// Language
+
+// Language - multiple with deduplication
+// 008/35-37, 041 $a, $b, $d, $e, $f, $g, $h, $j
+// a12365535
+{
+    "008": "170419p20172015fr opnn  di       n fre d"
+},
+{
+    "041": {
+        "ind1": "0",
+        "ind2": " ",
+        "subfields": [
+            {
+                "d": "fre"
+            },
+            {
+                "d": "ger"
+            },
+            {
+                "d": "ita"
+            },
+            {
+                "e": "fre"
+            },
+            {
+                "e": "eng"
+            },
+            {
+                "e": "ger"
+            },
+            {
+                "e": "ita"
+            },
+            {
+                "n": "fre"
+            },
+            {
+                "n": "ger"
+            },
+            {
+                "n": "ita"
+            },
+            {
+                "g": "eng"
+            },
+            {
+                "g": "fre"
+            },
+            {
+                "g": "ger"
+            }
+        ]
+    }
+}
+{ language: [ { code: "fre" }, { code: "ger" }, { code: "ita"}, { code: "eng" } ] }

--- a/spec/data/title.txt
+++ b/spec/data/title.txt
@@ -1,0 +1,420 @@
+// When multiple subfields are mapped together, concatenate with space in the order given
+// Linked 880 fields should be mapped the same as an instance of the main field given in the $6, 
+//   except for the title 245 which uses parallelValue - i.e., an 880 field with a $6 containing 
+//   246 should be mapped the same as a 246 field
+
+
+//// Title
+// For all 245:
+//   - Strip space and selected punctuation from end of 245 $a: :;/[,
+//   - Include space in nonsorting character count but drop from value
+
+// Basic title
+// 245 $a if ind2=0 and only $a present of $abfgknps
+// For all 245: Strip space and selected punctuation from end of 245 $a: :;/[,
+// a895166
+{
+    "245": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "Gaudy night /"
+            },
+            {
+                "c": "by Dorothy L. Sayers."
+            }
+        ]
+    }
+}
+{ title: [ { value: "Gaudy night" } ] }
+
+// Title with nonsorting characters
+// 245 $a with nonsorting character count from ind2
+// For all 245: Include space in nonsorting character count but drop from value
+// a1341490
+{
+    "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+            {
+                "a": "The unpleasantness at the Bellona Club."
+            }
+        ]
+    }
+}
+{ title: [ { structuredValue: [ 
+    { value: "The", type: "nonsorting characters" }, 
+    { value: "unpleasantness at the Bellona Club.", type: "main title" }
+] } ] }
+
+// Title with subtitle
+// 245 $abfgknps
+// a9803970
+{
+    "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+            {
+                "a": "The medium term expenditure framework (MTEF) for ... and the annual estimates for ..."
+            },
+            {
+                "n": "016,"
+            },
+            {
+                "p": "Ministry of Tourism :"
+            },
+            {
+                "b": "expenditure to be met out of moneys granted and drawn from the consolidated fund, central government budget."
+            }
+        ]
+    }
+}
+{ title: [ { structuredValue: [
+    { value: "The", type: "nonsorting characters" },
+    { value: "medium term expenditure framework (MTEF) for ... and the annual estimates for ...", type: "main title" },
+    { value: "016, Ministry of Tourism : expenditure to be met out of moneys granted and drawn from the consolidated fund, central government budget.", type: "subtitle" }
+] } ] }
+
+// Title with parts
+// 245 $abfgknps
+// constructed
+{
+    "245": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "Main title :"
+            },
+            {
+                "b": "subtitle,"
+            },
+            {
+                "f": "inclusive dates,"
+            },
+            {
+                "g": "bulk dates,"
+            },
+            {
+                "k": "form,"
+            },
+            {
+                "n": "part name,"
+            },
+            {
+                "p": "part number,"
+            },
+            {
+                "s": "version."
+            }
+        ]
+    }
+}
+{ title: [ { structuredValue: [
+    { value: "Main title", type: "main title" },
+    { value: "subtitle", type: "subtitle, inclusive dates, bulk dates, form, part name, part number, version." }
+] } ] }
+
+// Title with multiple scripts
+// 245/880
+// a13162356
+{
+    "245": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "6": "880-02"
+            },
+            {
+                "a": "Publichnai͡a zhenshchina ili publichnai͡a lichnostʹ? :"
+            },
+            {
+                "b": "zhenskie obrazy v kino /"
+            },
+            {
+                "c": "S.A. Smagina."
+            }
+        ]
+    }
+},
+{
+    "880": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "6": "245-02"
+            },
+            {
+                "a": "Публичная женщина или публичная личность:"
+            },
+            {
+                "b": "женские образы в кино /"
+            },
+            {
+                "c": "С.А. Смагина."
+            }
+        ]
+    }
+}
+{ title: [ { parallelValue: [
+    { structuredValue: [
+        { value: "Publichnai͡a zhenshchina ili publichnai͡a lichnostʹ?", type: "main title" },
+        { value: "zhenskie obrazy v kino", type: "subtitle" }
+    ] },
+    { structuredValue: [
+        { value: "Публичная женщина или публичная личность", type: "main title" },
+        { value: "женские образы в кино", type: "subtitle" }
+    ] }
+] } ] }
+
+// Alternative title with display label
+// 246 $abfgnp - all concatenated with space for title, not broken into structuredValue, punctuation retained
+// based on a11351916
+{
+    "246": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+            {
+                "i": "Title should read:"
+            },
+            {
+                "a": "Valses nobles et sentimentales :"
+            },
+            {
+                "b": "danses,"
+            },
+            {
+                "f": "1905,"
+            },
+            {
+                "g": "manuscripts,"
+            },
+            {
+                "n": "op. 5,"
+            },
+            {
+                "p": "L'oiseau."
+            }
+        ]
+    }
+}
+{ title: [ { 
+    value: "Valses nobles et sentimentales : danses, 1905, manuscripts, op. 5, L'oiseau.", 
+    displayLabel: "Title should read:", 
+    type: "alternative" } ] }
+
+// Uniform title
+// 240 $adfklmnoprs
+// a11925733
+{
+    "240": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "Beowulf."
+            },
+            {
+                "l": "English"
+            }
+        ]
+    }
+}
+{ title: [ { value: "Beowulf. English", type: "uniform" } ] }
+
+// Uniform title
+// 240 $adfklmnoprs
+// constructed
+{
+    "240": {
+        "ind1": "1",
+        "ind2": "0",
+        "subfields": [
+            {
+                "a": "Uniform title."
+            },
+            {
+                "d": "Date of treaty,"
+            },
+            {
+                "f": "date of a work,"
+            },
+            {
+                "g": "misc info,"
+            },
+            {
+                "k": "form,"
+            },
+            {
+                "l": "language,"
+            },
+            {
+                "m": "medium of performance,"
+            },
+            {
+                "n": "part number,"
+            },
+            {
+                "o": "arranged music,"
+            },
+            {
+                "p": "part name,"
+            },
+            {
+                "r": "music key,"
+            },
+            {
+                "s": "version."
+            }
+        ]
+    }
+}
+{ title: [ {
+    value: "Uniform title. Date of treaty, date of a work, misc info, form, language, medium of performance, part number, arranged music, part name, music key, version.",
+    type: "uniform"
+} ] }
+
+// Uniform title
+// 130 $adfklmnoprst
+// a13298967
+{
+    "130": {
+        "ind1": "0",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Bible."
+            },
+            {
+                "l": "Kituba (Congo (Democratic Republic))."
+            },
+            {
+                "f": "1990."
+            },
+            {
+                "0": "(SIRSI)4061207"
+            }
+        ]
+    }
+}
+{ title: [ { value: "Bible. Kituba (Congo (Democratic Republic)). 1990.", type: "uniform" } ] }
+
+// Uniform title
+// 130 $adfklmnoprst
+// constructed
+{
+    "130": {
+        "ind1": "0",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "Uniform title."
+            },
+            {
+                "d": "Date of treaty,"
+            },
+            {
+                "f": "date of a work,"
+            },
+            {
+                "g": "misc info,"
+            },
+            {
+                "k": "form,"
+            },
+            {
+                "l": "language,"
+            },
+            {
+                "m": "medium of performance,"
+            },
+            {
+                "n": "part number,"
+            },
+            {
+                "o": "arranged music,"
+            },
+            {
+                "p": "part name,"
+            },
+            {
+                "r": "music key,"
+            },
+            {
+                "s": "version,"
+            },
+            {
+                "t": "title."
+            }
+        ]
+    }
+}
+{ title: [ {
+    value: "Uniform title. Date of treaty, date of a work, misc info, form, language, medium of performance, part number, arranged music, part name, music key, version, title.",
+    type: "uniform"
+} ] }
+
+// Alternative title
+// 740 $anp if ind2 is not 2
+// based on a2254049
+{
+    "740": {
+        "ind1": "4",
+        "ind2": " ",
+        "subfields": [
+            {
+                "a": "The five red herrings."
+            },
+            {
+                "p": "Prologue,"
+            },
+            {
+                "n": "chapter 1."
+            }
+        ]
+    }
+}
+{ title: [ { value: "The five red herrings. Prologue, chapter 1.", type: "alternative" } ] }
+
+// Alternative title with multiple scripts
+// 246/880
+// a13355277
+// Treated as separate titles, not parallelValue
+{
+    "246": {
+        "ind1": "3",
+        "ind2": "0",
+        "subfields": [
+            {
+                "6": "880-02"
+            },
+            {
+                "a": "Nat͡sionalʹnye i mezhdunarodnye proekty razvitii͡a na evraziĭskom prostranstve i perspektivy ikh sopri͡azhenii͡a"
+            }
+        ]
+    }
+},
+{
+    "880": {
+        "ind1": "3",
+        "ind2": "0",
+        "subfields": [
+            {
+                "6": "246-02"
+            },
+            {
+                "a": "Национальные и международные проекты развития на евразийском пространстве и перспективы их сопряжения"
+            }
+        ]
+    }
+}
+{ title: [
+  { value: "Nat͡sionalʹnye i mezhdunarodnye proekty razvitii͡a na evraziĭskom prostranstve i perspektivy ikh sopri͡azhenii͡a", type: "alternative" },
+  { value: "Национальные и международные проекты развития на евразийском пространстве и перспективы их сопряжения", type: "alternative" }
+] }


### PR DESCRIPTION
## Why was this change made? 🤔
Provides reference data for building the MARC>Cocina mapping. Once all of the mapping is completed, including specs, we will likely be able to remove this. Version control of the reference data will be helpful for tracking changes as we implement. 




