### PR TITLE
Don't return any descriptive unless MARC has a title

### DIFF
--- a/lib/cocina/models/mapping/from_marc/description.rb
+++ b/lib/cocina/models/mapping/from_marc/description.rb
@@ -15,30 +15,22 @@ module Cocina
           end
 
           # @param [MARC::Record] marc MARC record from FOLIO
-          # @param [String] label
           # @param [String] druid
           # @param [Cocina::Models::Mapping::ErrorNotifier] notifier
-          def initialize(marc:, label:, druid:, notifier: nil)
+          def initialize(marc:, druid:, notifier: nil)
             @marc = marc
-            @notifier = notifier || ErrorNotifier.new(druid: druid)
-            @druid = druid
-            @label = label
+            @notifier = notifier || ErrorNotifier.new(druid:)
+            @purl = Cocina::Models::Mapping::Purl.for(druid:) if druid
           end
 
           # @return [Hash] a hash that can be mapped to a Cocina Description model
           def props
-            return nil if marc.nil?
-
-            DescriptionBuilder.build(marc: marc,
-                                     notifier: notifier,
-                                     purl: druid ? Cocina::Models::Mapping::Purl.for(druid: druid) : nil).tap do |properties|
-              properties[:title] = [{ value: label }] unless properties.key?(:title)
-            end
+            DescriptionBuilder.build(marc:, notifier:, purl:) if marc
           end
 
           private
 
-          attr_reader :title_builder, :marc, :notifier, :druid, :label
+          attr_reader :marc, :notifier, :purl
         end
       end
     end

--- a/spec/cocina/models/mapping/from_marc/description_spec.rb
+++ b/spec/cocina/models/mapping/from_marc/description_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Mapping::FromMarc::Description do
   subject(:descriptive) do
-    described_class.props(marc:, druid: 'druid:bb196dd3409', notifier: notifier, label: 'test label')
+    described_class.props(marc:, druid: 'druid:bb196dd3409', notifier: notifier)
   end
 
   let(:notifier) { instance_double(Cocina::Models::Mapping::ErrorNotifier) }
@@ -46,13 +46,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Description do
       descriptive
       expect(notifier).to have_received(:warn).with('No title fields found')
       expect(notifier).to have_received(:error).with('Missing title')
-      expect(descriptive).to eq({
-                                  title: [{ value: 'test label' }],
-                                  purl: 'https://purl.stanford.edu/bb196dd3409',
-                                  adminMetadata: {
-                                    note: [{ value: "Converted from MARC to Cocina #{Date.today.iso8601}", type: 'record origin' }]
-                                  }
-                                })
+      expect(descriptive).to be_nil
     end
   end
 


### PR DESCRIPTION

## Why was this change made? 🤔
A lack of any title indicates a real problem.  We don't want to cover that problem up by returning stub metadata.



## How was this change tested? 🤨
Unit test


