### PR TITLE
Allow running with Bundler 4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (>= 2.0, < 5)
   cocina-models!
   committee
   debug

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.1'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '>= 2.0', '< 5'
   spec.add_development_dependency 'committee'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION

## Why was this change made? 🤔

Bundler 4 has been released

## How was this change tested? 🤨
ci

