### PR TITLE
Zeitwerk inflection for MARC_RELATORS

### DIFF
--- a/lib/cocina/models.rb
+++ b/lib/cocina/models.rb
@@ -23,6 +23,7 @@ class CocinaModelsInflector < Zeitwerk::Inflector
     'dro_structural' => 'DROStructural',
     'dro_with_metadata' => 'DROWithMetadata',
     'libraries_doi' => 'LibrariesDOI',
+    'marc_relators' => 'MARC_RELATORS',
     'preregistered_repository_doi' => 'PreregisteredRepositoryDOI',
     'repository_doi' => 'RepositoryDOI',
     'request_dro' => 'RequestDRO',

--- a/lib/cocina/models/mapping/from_marc/contributor.rb
+++ b/lib/cocina/models/mapping/from_marc/contributor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'marc_relators'
-
 module Cocina
   module Models
     module Mapping


### PR DESCRIPTION
## Why was this change made? 🤔

Allow consumers to load MARC_RELATORS

## How was this change tested? 🤨
locally with sdr-api `bin/rails zeitwerk:check`