### PR TITLE
Revert "Add Searchworks resource type to form"

### DIFF
--- a/lib/cocina/models/mapping/from_marc/form.rb
+++ b/lib/cocina/models/mapping/from_marc/form.rb
@@ -18,7 +18,7 @@ module Cocina
           end
 
           # @return [Array<Hash>] an array of form hashes
-          def build # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+          def build
             [
               [build_simple_form(marc['300'], %w[a b c e f g 3])],
               build_physical_medium(marc['340']),
@@ -28,14 +28,7 @@ module Cocina
               build_cartographic(marc['255']),
               marc.fields.select { it.tag == '336' }.map { build_content_type(it) },
               build_resource_types,
-              build_type_from006and008,
-              build_dataset_genre,
-              build_blu_ray(marc['538']),
-              build_searchworks_manuscript(marc['245']),
-              build_searchworks_video(marc['245']),
-              build_searchworks_image245(marc['245']),
-              build_searchworks_image,
-              build_searchworks_piano_roll(marc['338'])
+              build_dataset_genre
 
             ].flatten.compact
           end
@@ -61,66 +54,6 @@ module Cocina
           }.freeze
 
           private
-
-          def build_searchworks_image245(field) # rubocop:disable Metrics/PerceivedComplexity
-            return unless field && field['h']
-
-            image_terms = [
-              'art original', 'digital graphic', 'slide', 'slides', 'chart', 'art reproduction', 'graphic', 'technical drawing', 'flash card', 'transparency', 'activity card', 'picture', 'graphic/digital graphic', 'diapositives'
-            ]
-            return sw_type('Image') if image_terms.any? { |term| field['h'].match?(/#{term}/i) }
-
-            control007_byte0 = marc['007']&.value&.[](0)
-            sw_type('Image') if field['h'].match?(/kit/) && %w[k r].include?(control007_byte0)
-          end
-
-          def build_searchworks_image # rubocop:disable Metrics/MethodLength
-            control007 = marc['007']
-            return unless control007
-
-            control007_byte0 = control007.value[0]
-            control007_byte1 = control007.value[1]
-            case control007_byte0
-            when 'k'
-              if %w[g h r v].include?(control007_byte1)
-                sw_type('Image')
-                sw_type('Image|Photo')
-              elsif control007_byte1 == 'k'
-                sw_type('Image')
-                sw_type('Image|Poster')
-              end
-            when 'g'
-              if control007_byte1 == 's'
-                sw_type('Image')
-                sw_type('Image|Slide')
-              end
-            end
-          end
-
-          def build_searchworks_manuscript(field)
-            return unless field && %w[manuscript manuscript/digital].include?(field['h'])
-
-            sw_type('Archive / Manuscript')
-          end
-
-          def build_searchworks_video(field)
-            return unless field && field['n']
-
-            video_terms = ['videorecording', 'video recording', 'videorecordings', 'video recordings', 'motion picture', 'filmstrip', 'videodisc', 'videocassette']
-            return unless video_terms.any? { |term| field['n'].match?(/#{term}/i) }
-
-            sw_type('Video/Film')
-          end
-
-          def build_searchworks_piano_roll(field)
-            return unless field && field['a']
-
-            piano_roll_terms = ['piano roll', 'organ roll', 'audio roll']
-
-            return unless piano_roll_terms.any? { |term| field['a'].match?(/#{term}/i) }
-
-            sw_type('Sound recording') + sw_type('Sound recording|Piano/Organ roll')
-          end
 
           def build_simple_form(field, codes)
             return unless field
@@ -174,12 +107,6 @@ module Cocina
             }
           end
 
-          def build_blu_ray(field)
-            return unless field && field['a'] && ['Bluray', 'Blu-ray', 'Blu ray'].any? { |term| field['a'].match?(/#{term}/i) }
-
-            sw_type('Video/Film') + sw_type('Video/Film|Blu-ray')
-          end
-
           def build_cartographic(field)
             return unless field
 
@@ -189,18 +116,6 @@ module Cocina
             vals.compact
           end
 
-          def leader07
-            @leader07 ||= marc.leader&.[](7)
-          end
-
-          def leader06
-            @leader06 ||= marc.leader&.[](6)
-          end
-
-          def control008_byte26
-            @control008_byte26 ||= marc['008']&.value&.[](26)
-          end
-
           def build_content_type(field)
             return unless field
 
@@ -208,31 +123,18 @@ module Cocina
           end
 
           def build_dataset_genre
-            return unless control008_byte26 == 'a' && leader06 == 'm'
+            return unless marc['008'] && marc['008'].value[26] == 'a' && marc.leader[6] == 'm'
 
             { value: 'dataset', type: 'genre', source: { code: 'local' } }
-          end
-
-          def sw_type(value)
-            [{ value:, type: 'resource type', source: { value: 'SearchWorks resource types'} }]
-          end
-
-          def mods_resource_type(value)
-            { value:, type: 'resource type', source: { value: 'MODS resource types' } }
-          end
-
-          def lc_resource_type(value)
-            { value:, type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
           end
 
           def build_resource_types # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength
             return unless marc.leader
 
-            if leader07 == 'c'
-              results = build_collection_resource_type
-              results += sw_type('Archive / Manuscript') if leader06 == 'a'
-              return results
-            end
+            leader06 = marc.leader[6]
+            leader07 = marc.leader[7]
+
+            return build_collection_resource_type if leader07 == 'c'
 
             case leader06
             when 'a'
@@ -240,11 +142,11 @@ module Cocina
             when 'c'
               build_notated_music_resource_type
             when 'd'
-              build_manuscript_notated_music_resource_type + sw_type('Archive / Manuscript')
+              build_manuscript_notated_music_resource_type
             when 'e'
               build_cartographic_resource_type
             when 'f'
-              build_manuscript_cartographic_resource_type + sw_type('Archive / Manuscript')
+              build_manuscript_cartographic_resource_type
             when 'g'
               build_moving_image_resource_type
             when 'i'
@@ -264,146 +166,117 @@ module Cocina
             end
           end
 
-          def build_type_from006and008 # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-            result = []
-            control008_byte21 = marc['008']&.value&.[](21)
-            control006_byte0 = marc['006']&.value&.[](0)
-            control006_byte4 = marc['006']&.value&.[](4)
-
-            result << sw_type('Book') if (leader07 == 's' && control008_byte21 == 'm') || (control006_byte0 == 's' && control006_byte4 == 'm')
-            result << sw_type('Database') if (leader07 == 's' && control008_byte21 == 'd') || (control006_byte0 == 's' && control006_byte4 == 'd')
-            result
-          end
-
           def build_collection_resource_type
             [
-              mods_resource_type('collection'),
-              lc_resource_type('Collection')
+              { value: 'collection', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Collection', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_text_resource_type
             [
-              mods_resource_type('text'),
-              lc_resource_type('Text')
-            ].tap do |result|
-              result << sw_type('Book') if %w[a m].include?(leader07)
-            end
+              { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+            ]
           end
 
           def build_notated_music_resource_type
             [
-              mods_resource_type('notated music'),
-              lc_resource_type('Notated music')
+              { value: 'notated music', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Notated music', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_manuscript_notated_music_resource_type
             [
-              mods_resource_type('manuscript'),
-              mods_resource_type('notated music'),
-              lc_resource_type('Manuscript'),
-              lc_resource_type('Notated music')
+              { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'notated music', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
+              { value: 'Notated music', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_cartographic_resource_type
             [
-              mods_resource_type('cartographic'),
-              lc_resource_type('Cartographic')
+              { value: 'cartographic', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Cartographic', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_manuscript_cartographic_resource_type
             [
-              mods_resource_type('manuscript'),
-              mods_resource_type('cartographic'),
-              lc_resource_type('Manuscript'),
-              lc_resource_type('Cartographic')
+              { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'cartographic', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
+              { value: 'Cartographic', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_moving_image_resource_type
-            base = [
-              mods_resource_type('moving image'),
-              lc_resource_type('Moving image')
+            [
+              { value: 'moving image', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Moving image', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
-            control008_byte33 = marc['008']&.value&.[](33)
-            base << sw_type('Image') if /[aciklnopst 0-9|]/.match?(control008_byte33)
-            base
           end
 
           def build_sound_nonmusical_resource_type
             [
-              mods_resource_type('sound recording-nonmusical'),
-              lc_resource_type('Audio')
+              { value: 'sound recording-nonmusical', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Audio', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_sound_musical_resource_type
             [
-              mods_resource_type('sound recording-musical'),
-              lc_resource_type('Audio')
+              { value: 'sound recording-musical', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Audio', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_still_image_resource_type
-            base = [
-              mods_resource_type('still image'),
-              lc_resource_type('Still image')
+            [
+              { value: 'still image', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Still image', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
-            control008_byte33 = marc['008']&.value&.[](33)
-            base << sw_type('Image') if /[aciklnopst 0-9|]/.match?(control008_byte33)
-            base
           end
 
-          def build_software_multimedia_resource_type # rubocop:disable Metrics/MethodLength
+          def build_software_multimedia_resource_type
             base = [
-              mods_resource_type('software, multimedia')
+              { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } }
             ]
 
-            if control008_byte26 == 'a'
-              base << lc_resource_type('Dataset')
-              base << sw_type('Dataset')
-            else
-              base << lc_resource_type('Digital')
-            end
-
-            if control008_byte26 == 'j'
-              base << lc_resource_type('Database')
-              base << sw_type('Database')
-            end
-
-            base << (sw_type('Software/Multimedia') unless %w[a g j].include?(control008_byte26))
+            base << if marc['008'] && marc['008'].value[26] == 'a'
+                      { value: 'Dataset', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+                    else
+                      { value: 'Digital', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+                    end
 
             base
           end
 
           def build_manuscript_mixed_material_resource_type
             [
-              mods_resource_type('manuscript'),
-              mods_resource_type('mixed material'),
-              lc_resource_type('Manuscript'),
-              lc_resource_type('Mixed material')
-            ] + sw_type('Archive / Manuscript')
+              { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'mixed material', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
+              { value: 'Mixed material', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+            ]
           end
 
           def build_three_dimensional_object_resource_type
             [
-              mods_resource_type('three dimensional object'),
-              lc_resource_type('Artifact')
+              { value: 'three dimensional object', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Artifact', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
             ]
           end
 
           def build_manuscript_text_resource_type
             [
-              mods_resource_type('manuscript'),
-              mods_resource_type('text'),
-              lc_resource_type('Manuscript'),
-              lc_resource_type('Text')
-            ] + sw_type('Archive / Manuscript').tap do |result|
-              result << sw_type('Book') if %w[a m].include?(leader07)
-            end
+              { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
+              { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
+              { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+            ]
           end
 
           attr_reader :marc

--- a/spec/cocina/models/mapping/from_marc/form_spec.rb
+++ b/spec/cocina/models/mapping/from_marc/form_spec.rb
@@ -487,13 +487,12 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
         expect(build).to eq([
                               { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } },
                               { value: 'Dataset', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-                              { value: 'Dataset', type: 'resource type', source: { value: 'SearchWorks resource types' } },
                               { value: 'dataset', type: 'genre', source: { code: 'local' } }
                             ])
       end
     end
 
-    context 'with collection (Leader/07 = c & Leader/06 = p)' do
+    context 'with collection (Leader/07 = c)' do
       # see a6002746
       let(:marc_hash) do
         {
@@ -510,24 +509,6 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
       end
     end
 
-    context 'with collection (Leader/07 = c & Leader/06 = a)' do
-      # see a6002746
-      let(:marc_hash) do
-        {
-          'leader' => '02711cacaa22003617i 4500',
-          'fields' => []
-        }
-      end
-
-      it 'returns collection' do
-        expect(build).to eq [
-          { value: 'collection', type: 'resource type', source: { value: 'MODS resource types' } },
-          { value: 'Collection', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-        ]
-      end
-    end
-
     context 'with text (Leader/06 = a)' do
       # see a895166
       let(:marc_hash) do
@@ -540,8 +521,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
       it 'returns text' do
         expect(build).to eq [
           { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-          { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Book', type: 'resource type', source: { value: 'SearchWorks resource types' } }
+          { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
         ]
       end
     end
@@ -573,8 +553,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
           { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'notated music', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Notated music', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
+          { value: 'Notated music', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
         ]
       end
     end
@@ -606,8 +585,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
           { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'cartographic', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Cartographic', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
+          { value: 'Cartographic', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
         ]
       end
     end
@@ -672,23 +650,42 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
       end
     end
 
-    context 'when record is Software/Multimedia' do
-      context 'when Leader/06 = m and 008[26] is not a/g/j' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000m00000000000000000'
-            # 26th position (index 25) = 'z', which is not in excluded_values
-            r.append(MARC::ControlField.new('008', '00000000000000000000000000z00000000000'))
-          end
-        end
+    context 'with software/multimedia (Leader/06 = m and 008/26 not a)' do
+      let(:marc_hash) do
+        {
+          'leader' => '00584cmm a22001575  4500',
+          'fields' => [
+            { '008' => '181113m20149999miu        b  000 0 eng u' }
+          ]
+        }
+      end
 
-        it 'returns Software/Multimedia' do
-          expect(build).to eq([
-                                { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } },
-                                { value: 'Digital', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-                                { value: 'Software/Multimedia', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-                              ])
-        end
+      it 'returns software, multimedia' do
+        expect(build).to eq [
+          { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } },
+          { value: 'Digital', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
+        ]
+      end
+    end
+
+    context 'with software/multimedia, dataset (Leader/06 = m and 008/26 = a)' do
+      # a12827086
+      # updates dataset example from form mapping pt 1
+      let(:marc_hash) do
+        {
+          'leader' => '00584cmm a22001575  4500',
+          'fields' => [
+            { '008' => '181113m20149999miu        a  000 0 eng u' }
+          ]
+        }
+      end
+
+      it 'returns software, multimedia and dataset' do
+        expect(build).to eq [
+          { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } },
+          { value: 'Dataset', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
+          { value: 'dataset', type: 'genre', source: { code: 'local' } }
+        ]
       end
     end
 
@@ -704,8 +701,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
           { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'mixed material', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Mixed material', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
+          { value: 'Mixed material', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
         ]
       end
     end
@@ -737,318 +733,8 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Form do
           { value: 'manuscript', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
           { value: 'Manuscript', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } },
-          { value: 'Book', type: 'resource type', source: { value: 'SearchWorks resource types' } }
+          { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } }
         ]
-      end
-    end
-
-    context 'with 245$h manuscript' do
-      let(:marc_hash) do
-        {
-          'fields' => [
-            {
-              '245' => {
-                'ind1' => '1', 'ind2' => '0',
-                'subfields' => [{ 'h' => 'manuscript' }]
-              }
-            }
-          ]
-        }
-      end
-
-      it 'returns manuscript and text' do
-        expect(build).to eq [
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-        ]
-      end
-    end
-
-    context 'with 245$h manuscript/digital' do
-      let(:marc_hash) do
-        {
-          'fields' => [
-            {
-              '245' => {
-                'ind1' => '1', 'ind2' => '0',
-                'subfields' => [{ 'h' => 'manuscript/digital' }]
-              }
-            }
-          ]
-        }
-      end
-
-      it 'returns Archive / Manuscript' do
-        expect(build).to eq [
-          { value: 'Archive / Manuscript', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-        ]
-      end
-    end
-
-    context 'with leader/07 = s and 008 byte 21 = m' do
-      let(:marc_hash) do
-        {
-          'leader' => 'p1952c0s  2200457Ia 4500',
-          'fields' => [
-            { '008' => '000000000000000000000m000000000000000000'}
-          ]
-        }
-      end
-
-      it 'returns Book' do
-        expect(build).to eq [
-          { value: 'Book', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-        ]
-      end
-    end
-
-    context 'when 006[0] = s and 006[4] = m' do
-      let(:marc_hash) do
-        {
-          'leader' => '',
-          'fields' => [
-            { '006' => 's000m00000000000000'}
-          ]
-        }
-      end
-
-      it 'returns Book' do
-        expect(build).to eq [
-          { value: 'Book', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-        ]
-      end
-    end
-
-    context 'when record is a Database' do
-      context 'when leader[7] = s and 008[21] = d' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '0000000s0000000000000000'
-            r.append(MARC::ControlField.new('008', '000000000000000000000d000000000000000000'))
-          end
-        end
-
-        it 'returns Database' do
-          expect(build).to eq [
-            { value: 'Database', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when 006[0] = s and 006[4] = d' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.append(MARC::ControlField.new('006', 's000d00000000000000'))
-          end
-        end
-
-        it 'returns Database' do
-          expect(build).to eq [
-            { value: 'Database', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when Leader/06 = m and 008[26] = j' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000m00000000000000000'
-            r.append(MARC::ControlField.new('008', '00000000000000000000000000j00000000000'))
-          end
-        end
-
-        it 'returns Database' do
-          expect(build).to eq([
-                                { value: 'software, multimedia', type: 'resource type', source: { value: 'MODS resource types' } },
-                                { value: 'Digital', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-                                { value: 'Database', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-                                { value: 'Database', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-                              ])
-        end
-      end
-    end
-
-    context 'when record is an Image' do
-      context 'when Leader/06 = k and 008[33] matches [aciklnopst 0-9|]' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000k00000000000000000'
-            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000a0000'))
-          end
-        end
-
-        it 'returns Image' do
-          expect(build).to eq [
-            { value: 'still image', type: 'resource type', source: { value: 'MODS resource types' } },
-            { value: 'Still image', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-            { value: 'Image', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when Leader/06 = g and 008[33] matches [ aciklnopst]' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000g00000000000000000'
-            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000k0000'))
-          end
-        end
-
-        it 'returns Image' do
-          expect(build).to eq [
-            { value: 'moving image', type: 'resource type', source: { value: 'MODS resource types' } },
-            { value: 'Moving image', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-            { value: 'Image', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when record is an Image based on 245h terms' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000a00000000000000000'
-            r.append(MARC::DataField.new('245', '1', ' ',
-                                         MARC::Subfield.new('a', 'Example title'),
-                                         MARC::Subfield.new('h', 'This is a technical drawing')))
-          end
-        end
-
-        it 'returns Image' do
-          expect(build).to eq [
-            { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-            { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-            { value: 'Image', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when record is an Image based on 007[0] = k|r and 245h = kit' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000a00000000000000000'
-            r.append(MARC::ControlField.new('007', 'k0000000000'))
-            r.append(MARC::DataField.new('245', '1', ' ',
-                                         MARC::Subfield.new('a', 'Example kit title'),
-                                         MARC::Subfield.new('h', 'kit')))
-          end
-        end
-
-        it 'returns Image' do
-          expect(build).to eq [
-            { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-            { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-            { value: 'Image', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when record is an Image|Photo' do
-        context 'when 007[0] = k and 007[1] in [g, h, r, v]' do
-          let(:marc) do
-            MARC::Record.new.tap do |r|
-              r.leader = '000000a00000000000000000'
-              r.append(MARC::ControlField.new('007', 'kg0000000000'))
-            end
-          end
-
-          it 'returns Image|Photo' do
-            expect(build).to eq [
-              { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-              { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-              { value: 'Image|Photo', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-            ]
-          end
-        end
-      end
-
-      context 'when record is an Image|Poster' do
-        context 'when 007[0] = k and 007[1] = k' do
-          let(:marc) do
-            MARC::Record.new.tap do |r|
-              r.leader = '000000a00000000000000000'
-              r.append(MARC::ControlField.new('007', 'kk0000000000'))
-            end
-          end
-
-          it 'returns Image|Poster' do
-            expect(build).to eq [
-              { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-              { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-              { value: 'Image|Poster', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-            ]
-          end
-        end
-      end
-
-      context 'when record is an Image|Slide' do
-        context 'when 007[0] = g and 007[1] = s' do
-          let(:marc) do
-            MARC::Record.new.tap do |r|
-              r.leader = '000000a00000000000000000'
-              r.append(MARC::ControlField.new('007', 'gs0000000000'))
-            end
-          end
-
-          it 'returns Image|Slide' do
-            expect(build).to eq [
-              { value: 'text', type: 'resource type', source: { value: 'MODS resource types' } },
-              { value: 'Text', type: 'resource type', source: { value: 'LC Resource Types Scheme' } },
-              { value: 'Image|Slide', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-            ]
-          end
-        end
-      end
-    end
-
-    context 'when the match is based on regex matching in a MARC subfield' do
-      context 'when 338h term contains piano roll terms' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.append(MARC::DataField.new('338', '1', ' ',
-                                         MARC::Subfield.new('a', 'This is a sentence containing the phrase piano roll')))
-          end
-        end
-
-        it 'returns Sound recording|Piano/Organ roll' do
-          expect(build).to eq [
-            { value: 'Sound recording', type: 'resource type', source: { value: 'SearchWorks resource types' } },
-            { value: 'Sound recording|Piano/Organ roll', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when 245n contains video terms' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000000000000000000000'
-            r.append(MARC::DataField.new('245', '1', ' ',
-                                         MARC::Subfield.new('n', 'A set of video recordings')))
-          end
-        end
-
-        it 'returns Video/Film' do
-          expect(build).to eq [
-            { value: 'Video/Film', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
-      end
-
-      context 'when 538a contains blu-ray terms' do
-        let(:marc) do
-          MARC::Record.new.tap do |r|
-            r.leader = '000000000000000000000000'
-            r.append(MARC::DataField.new('538', '1', ' ',
-                                         MARC::Subfield.new('a', 'A set of blu-ray discs')))
-          end
-        end
-
-        it 'returns Video/Film|Blu-ray' do
-          expect(build).to eq [
-            { value: 'Video/Film', type: 'resource type', source: { value: 'SearchWorks resource types' } },
-            { value: 'Video/Film|Blu-ray', type: 'resource type', source: { value: 'SearchWorks resource types' } }
-          ]
-        end
       end
     end
   end


### PR DESCRIPTION
This reverts commit 3a4bb40ea1b0675928f40f993ca5e5fe553cfe7b.


## Why was this change made? 🤔
We don't need this now that DSA can index the searchworks format from MARC. https://github.com/sul-dlss/dor-services-app/pull/5716


## How was this change tested? 🤨
ci

