### PR TITLE
Set the timezone in tests so that Time.zone is not nil

### DIFF
--- a/lib/cocina/models/mapping/from_marc/admin_metadata.rb
+++ b/lib/cocina/models/mapping/from_marc/admin_metadata.rb
@@ -66,7 +66,7 @@ module Cocina
           end
 
           def note
-            [{ value: "Converted from MARC to Cocina #{Date.today.iso8601}", type: 'record origin' }]
+            [{ value: "Converted from MARC to Cocina #{Time.zone.today.iso8601}", type: 'record origin' }]
           end
 
           attr_reader :marc

--- a/spec/cocina/models/mapping/from_marc/admin_metadata_spec.rb
+++ b/spec/cocina/models/mapping/from_marc/admin_metadata_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::AdminMetadata do
                                      date: [{ value: '20250614', encoding: { code: 'iso8601' } }]
                                    }],
                                    identifier: [{ value: 'in00000144356', type: 'FOLIO' }],
-                                   note: [{ value: "Converted from MARC to Cocina #{Date.today.iso8601}", type: 'record origin' }]
+                                   note: [{ value: "Converted from MARC to Cocina #{Time.zone.today.iso8601}", type: 'record origin' }]
                                  })
       end
     end

--- a/spec/cocina/models/mapping/from_marc/description_spec.rb
+++ b/spec/cocina/models/mapping/from_marc/description_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Cocina::Models::Mapping::FromMarc::Description do
                                     }
                                   ],
                                   adminMetadata: {
-                                    note: [{ value: "Converted from MARC to Cocina #{Date.today.iso8601}", type: 'record origin' }]
+                                    note: [{ value: "Converted from MARC to Cocina #{Time.zone.today.iso8601}", type: 'record origin' }]
                                   }
                                 })
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,13 @@ SimpleCov.start do
   end
 end
 
+# NOTE: This ensures that the test suite runs with a consistent timezone,
+# which is important for tests that involve date/time values.
+# If the timezone were not set, tests that rely on the current date or time
+# could fail when run in different environments or at different times of day.
+# If not set, Time.zone may be nil.
+Time.zone = 'UTC'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
**NOTE:  Changes to openapi.yml require updating openapi.yml for sdr-api and dor-services-app and generating models - see README.**

## Why was this change made? 🤔

I found a minor bug when running tests in DSA late in the evening that causes the existing use of `Date.today.iso8601` to not match `Time.zone.today.iso8601` since DSA tests use UTC and cocina uses the local system timezone.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



