### PR TITLE
Expose a method to get the loaded openapi.yml document

### DIFF
--- a/lib/cocina/models/validators/open_api_validator.rb
+++ b/lib/cocina/models/validators/open_api_validator.rb
@@ -14,18 +14,22 @@ module Cocina
             attributes['cocinaVersion'] = Cocina::Models::VERSION
           end
 
-          errors = document.ref("#/components/schemas/#{method_name}").validate(attributes.as_json).to_a
+          errors = openapi.ref("#/components/schemas/#{method_name}").validate(attributes.as_json).to_a
           return unless errors.any?
 
           raise ValidationError, "When validating #{method_name}: " + errors.map { |e| e['error'] }.uniq.join(', ')
         end
 
-        # rubocop:disable Style/ClassVars
+        # @return [Hash] a hash representation of the openapi document
         def self.document
-          @@document ||= JSONSchemer.openapi(YAML.load_file(openapi_path))
+          @document ||= YAML.load_file(openapi_path)
         end
-        # rubocop:enable Style/ClassVars
-        private_class_method :document
+
+        # @return [JSONSchemer::OpenAPI]
+        def self.openapi
+          @openapi ||= JSONSchemer.openapi(YAML.load_file(openapi_path))
+        end
+        private_class_method :openapi
 
         def self.openapi_path
           ::File.expand_path('../../../../openapi.yml', __dir__)

--- a/spec/cocina/models/validators/open_api_validator_spec.rb
+++ b/spec/cocina/models/validators/open_api_validator_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Cocina::Models::Validators::OpenApiValidator do
     }
   end
 
+  describe '#document' do
+    it 'returns a hash representation of the openapi document' do
+      expect(described_class.document).to be_a(Hash)
+    end
+  end
+
   # AdminPolicy.externalIdentifier must be a valid druid
   context 'when valid' do
     it 'does not raise' do


### PR DESCRIPTION
## Why was this change made? 🤔
This will be used by DSA/SDR-API so they can reference the cocina-models copy of the openapi.yml rather than having to keep a duplicate copy of all cocina structures

Ref https://github.com/sul-dlss/dor-services-app/issues/5700


## How was this change tested? 🤨
ci

