### PR TITLE
Validate openapi using JSONSchemer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,12 @@ orbs:
 workflows:
   build:
     jobs:
-      - ruby-rails/validate-api:
-          name: validate
       - ruby-rails/lint:
           name: lint
       - ruby-rails/test-gem:
           name: test
           context: dlss
+          before-test:
+            - run:
+                name: validate openapi
+                command: bin/validate-openapi openapi.yml

--- a/bin/validate-openapi
+++ b/bin/validate-openapi
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'cocina/models'
+
+filepath = ARGV[0]
+exit(1) unless JSONSchemer.valid_schema?(YAML.load_file(filepath))


### PR DESCRIPTION
## Why was this change made? 🤔
The openapi-enforcer npm package doesn't support the latest versions of OpenAPI


## How was this change tested? 🤨
ci


