### PR TITLE
Stop adding self-deposit resource types to ETDs when mapping from MODS

### DIFF
--- a/lib/cocina/models/mapping/from_mods/form.rb
+++ b/lib/cocina/models/mapping/from_mods/form.rb
@@ -201,12 +201,6 @@ module Cocina
                          },
                          type: 'resource type',
                          value: 'Dissertation'
-                       }, {
-                         source: {
-                           value: 'Stanford self-deposit resource types'
-                         },
-                         type: 'resource type',
-                         structuredValue: [{ type: 'subtype', value: 'Academic thesis' }]
                        })
           end
 

--- a/spec/cocina/models/mapping/from_mods/form_spec.rb
+++ b/spec/cocina/models/mapping/from_mods/form_spec.rb
@@ -188,13 +188,6 @@ RSpec.describe Cocina::Models::Mapping::FromMods::Form do
             },
             type: 'resource type',
             value: 'Dissertation'
-          },
-          {
-            source: {
-              value: 'Stanford self-deposit resource types'
-            },
-            type: 'resource type',
-            structuredValue: [{ type: 'subtype', value: 'Academic thesis' }]
           }
         ]
       end


### PR DESCRIPTION
# Why was this change made?

Connects to sul-dlss/heracles-etd#454
Connects to sul-dlss/dor-services-app#5719

This causes broken ETD objects in Purl.

# How was this change tested?

CI & stage