### PR TITLE
Add CHS barcode format

### DIFF
--- a/lib/cocina/models/barcode.rb
+++ b/lib/cocina/models/barcode.rb
@@ -3,6 +3,6 @@
 module Cocina
   module Models
     # A barcode
-    Barcode = BusinessBarcode | LaneMedicalBarcode | CatkeyBarcode | StandardBarcode
+    Barcode = BusinessBarcode | LaneMedicalBarcode | CatkeyBarcode | StandardBarcode | CaliforniaHistoricalSocietyBarcode
   end
 end

--- a/lib/cocina/models/business_barcode.rb
+++ b/lib/cocina/models/business_barcode.rb
@@ -2,7 +2,7 @@
 
 module Cocina
   module Models
-    # The barcode associated with a business library DRO object, prefixed with 2050
+    # The barcode associated with a business library DRO, prefixed with 2050
     # example: 20503740296
     BusinessBarcode = Types::String.constrained(format: /^2050[0-9]{7}$/)
   end

--- a/lib/cocina/models/california_historical_society_barcode.rb
+++ b/lib/cocina/models/california_historical_society_barcode.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    # The barcode associated with a CHS DRO, prefixed with 405
+    # example: 405000111956
+    CaliforniaHistoricalSocietyBarcode = Types::String.constrained(format: /^405[0-9]+$/)
+  end
+end

--- a/lib/cocina/models/catkey_barcode.rb
+++ b/lib/cocina/models/catkey_barcode.rb
@@ -2,8 +2,8 @@
 
 module Cocina
   module Models
-    # The barcode associated with a DRO object based on catkey, prefixed with a catkey
-    # followed by a hyphen
+    # The barcode associated with a DRO based on catkey, prefixed with a catkey followed
+    # by a hyphen
     # example: 6772719-1001
     CatkeyBarcode = Types::String.constrained(format: /^[0-9]+-[0-9]+$/)
   end

--- a/lib/cocina/models/lane_medical_barcode.rb
+++ b/lib/cocina/models/lane_medical_barcode.rb
@@ -2,7 +2,7 @@
 
 module Cocina
   module Models
-    # The barcode associated with a Lane Medical Library DRO object, prefixed with 245
+    # The barcode associated with a Lane Medical Library DRO, prefixed with 245
     # example: 24503259768
     LaneMedicalBarcode = Types::String.constrained(format: /^245[0-9]{8}$/)
   end

--- a/lib/cocina/models/standard_barcode.rb
+++ b/lib/cocina/models/standard_barcode.rb
@@ -2,7 +2,7 @@
 
 module Cocina
   module Models
-    # The standard barcode associated with a DRO object, prefixed with 36105
+    # The standard barcode associated with a DRO, prefixed with 36105
     # example: 36105010362304
     StandardBarcode = Types::String.constrained(format: /^36105[0-9]{9}$/)
   end

--- a/schema.json
+++ b/schema.json
@@ -241,7 +241,7 @@
       ]
     },
     "BusinessBarcode": {
-      "description": "The barcode associated with a business library DRO object, prefixed with 2050",
+      "description": "The barcode associated with a business library DRO, prefixed with 2050",
       "type": "string",
       "pattern": "^2050[0-9]{7}$",
       "example": "20503740296"
@@ -264,7 +264,7 @@
       ]
     },
     "CatkeyBarcode": {
-      "description": "The barcode associated with a DRO object based on catkey, prefixed with a catkey followed by a hyphen",
+      "description": "The barcode associated with a DRO based on catkey, prefixed with a catkey followed by a hyphen",
       "type": "string",
       "pattern": "^[0-9]+-[0-9]+$",
       "example": "6772719-1001"
@@ -1423,7 +1423,7 @@
       "required": ["sourceId"]
     },
     "LaneMedicalBarcode": {
-      "description": "The barcode associated with a Lane Medical Library DRO object, prefixed with 245",
+      "description": "The barcode associated with a Lane Medical Library DRO, prefixed with 245",
       "type": "string",
       "pattern": "^245[0-9]{8}$",
       "example": "24503259768"
@@ -2335,7 +2335,7 @@
       }
     },
     "StandardBarcode": {
-      "description": "The standard barcode associated with a DRO object, prefixed with 36105",
+      "description": "The standard barcode associated with a DRO, prefixed with 36105",
       "type": ["string", "null"],
       "pattern": "^36105[0-9]{9}$",
       "example": "36105010362304"

--- a/schema.json
+++ b/schema.json
@@ -234,6 +234,9 @@
         },
         {
           "$ref": "#/$defs/StandardBarcode"
+        },
+        {
+          "$ref": "#/$defs/CaliforniaHistoricalSocietyBarcode"
         }
       ]
     },
@@ -242,6 +245,12 @@
       "type": "string",
       "pattern": "^2050[0-9]{7}$",
       "example": "20503740296"
+    },
+    "CaliforniaHistoricalSocietyBarcode": {
+      "description": "The barcode associated with a CHS DRO, prefixed with 405",
+      "type": "string",
+      "pattern": "^405[0-9]{9}$",
+      "example": "405000111956"
     },
     "CatalogLink": {
       "description": "A linkage between an object and a catalog record",

--- a/spec/cocina/models/validators/json_schema_validator_spec.rb
+++ b/spec/cocina/models/validators/json_schema_validator_spec.rb
@@ -181,6 +181,14 @@ RSpec.describe Cocina::Models::Validators::JsonSchemaValidator do
         expect { validate }.not_to raise_error
       end
     end
+
+    context 'with a California Historical Society (CHS) barcode' do
+      let(:barcode) { '405000111956' }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
   end
 
   context 'when invalid' do


### PR DESCRIPTION
## Why was this change made? 🤔

* add barcode format for California Historical Society (CHS)
* opportunistic redundancy reduction (stumbled on "DRO object" in other barcode descriptions, but "DRO" = "Digital Repository Object")
  * left as a second commit for easier removal in case reviewer disagrees with this change

connects with #1036 (will need to cut a release to close the ticket)

## How was this change tested? 🤨

unit tests (expands space of valid barcodes, so running validation on existing cocina seemed unnecessary, but happy to test validation if others do think it's warranted)

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
