### PR TITLE
add useful context to cocina-models partial release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Before you release a major or minor change, think about if this release will inc
 If unsure, ask the team or ask for help to just run the validation report anyway (as described above).
 
 ### Partial release process
+
 NOTE: If dependency updates are about to be released, you have the option of shortening the process and stopping after Step 3. This is because Steps 4 onwards will be taken care of by the regular dependency updates process (basically the updating of cocina-models, dor-services-client and sdr-client as needed in the rest of the associated apps).  You still do need to manually bump some gems and the pinned version of cocina-models in the directly coupled apps and get those PRs approved and merged, as described in Steps 1-3 below.
 
 IMPORTANT: If you do opt to skip steps 4 onward, you should NOT merge the dor-services-app and sdr-api PRs you created in step 3 until you are ready to finish the dependency updates process.  You can have them reviewed and approved, but if you merge, you will greatly increase the risk of issues if the main branch of DSA or sdr-api are deployed after steps 1-3 are complete but before the rest of the apps are updated to use the new cocina-models via regular dependency updates. The fix for this is to either roll back DSA and sdr-api to the previous release tag, or proceed forwards with step 4-5.
@@ -150,6 +151,8 @@ Release new versions of [sdr-client](https://github.com/sul-dlss/sdr-client) and
 Applications such as [Argo](https://github.com/sul-dlss/argo) and [Dor-Services-App](https://github.com/sul-dlss/dor-services-app) depend on these gems using the same models.
 
 ### Step 3: Update services directly coupled to the models
+
+NOTE: This manual update step is necessary since we pin cocina-models in sdr-api and dor-services-app. The version pin makes it so that that we cannot assume that automated weekly dependency updates will create sdr-api and DSA PRs with the needed cocina-models version bump.
 
 This list of services is known to include:
 


### PR DESCRIPTION
## Why was this change made? 🤔

so that our future selves aren't tempted to make more work by trying to skip seemingly unnecessary work (that turned out to be necessary afterall).

see https://github.com/sul-dlss/cocina-models/pull/1038/changes#r3219032947 and https://stanfordlib.slack.com/archives/C09M7P91R/p1777911928123009?thread_ts=1777672353.975549&cid=C09M7P91R

## How was this change tested? 🤨

this was what worked when https://github.com/sul-dlss/cocina-models/pull/1038 didn't

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
