### PR TITLE
Memoize JSONSchemer schema at class level

### DIFF
--- a/lib/cocina/models/validators/json_schema_validator.rb
+++ b/lib/cocina/models/validators/json_schema_validator.rb
@@ -39,6 +39,11 @@ module Cocina
           new(...).validate
         end
 
+        # @return [JSONSchemer::Schema]
+        def self.schema
+          @schema ||= JSONSchemer.schema(document)
+        end
+
         # @return [Hash] a hash representation of the schema.json document
         def self.document
           @document ||= begin
@@ -77,7 +82,7 @@ module Cocina
 
         # @return [JSONSchemer::Schema]
         def schema
-          @schema ||= JSONSchemer.schema(self.class.document)
+          self.class.schema
         end
 
         # @return [String] the method name derived from the class name


### PR DESCRIPTION
## Why was this change made? 🤔

Reduces the time to run `bin/validate-data` on prod data from 5.5 to 2.5 hours. Suggestion from Copilot with running StackProf. Since the schema doesn't change, seems safe to share across instances. 


## How was this change tested? 🤨
Ran `bin/validate-data` locally on prod data, unit tests.
