### PR TITLE
Update barcode format constraint for CHS

### DIFF
--- a/lib/cocina/models/california_historical_society_barcode.rb
+++ b/lib/cocina/models/california_historical_society_barcode.rb
@@ -4,6 +4,6 @@ module Cocina
   module Models
     # The barcode associated with a CHS DRO, prefixed with 405
     # example: 405000111956
-    CaliforniaHistoricalSocietyBarcode = Types::String.constrained(format: /^405[0-9]+$/)
+    CaliforniaHistoricalSocietyBarcode = Types::String.constrained(format: /^405[0-9]{9}$/)
   end
 end


### PR DESCRIPTION
The string should have a fixed length (12).
