### PR TITLE
Add ShelveOnlyVisitorValidator

### DIFF
--- a/lib/cocina/models/validators/composite_structural_validator.rb
+++ b/lib/cocina/models/validators/composite_structural_validator.rb
@@ -8,7 +8,8 @@ module Cocina
         VALIDATORS = [
           DarkVisitorValidator,
           LanguageTagVisitorValidator,
-          ReservedFilenameVisitorValidator
+          ReservedFilenameVisitorValidator,
+          ShelveOnlyVisitorValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/lib/cocina/models/validators/shelve_only_visitor_validator.rb
+++ b/lib/cocina/models/validators/shelve_only_visitor_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that no file is marked shelve-only (shelve=true, publish=false, sdrPreserve=false).
+      # SDR requires that any shelved file also be published or preserved; a shelve-only file
+      # would be sent to the content store but never retrievable or preserved anywhere else.
+      class ShelveOnlyVisitorValidator < BaseStructuralVisitorValidator
+        def visit_file(file_hash:)
+          admin = file_hash[:administrative]
+          return unless admin[:shelve] && !admin[:publish] && !admin[:sdrPreserve]
+
+          invalid_files << file_hash
+        end
+
+        def validate!
+          return if invalid_files.empty?
+
+          filenames = invalid_files.map { |file| file[:filename] || file[:label] }
+          raise ValidationError, "Files cannot be shelved without publish or sdrPreserve: #{filenames}"
+        end
+
+        private
+
+        def invalid_files
+          @invalid_files ||= []
+        end
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/shelve_only_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/shelve_only_visitor_validator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::ShelveOnlyVisitorValidator do
+  subject(:validator) { described_class.new({}) }
+
+  let(:file) do
+    {
+      filename: 'page1.txt',
+      administrative: { shelve: true, publish: false, sdrPreserve: false }
+    }
+  end
+
+  context 'when shelve=true, publish=false, sdrPreserve=false' do
+    it 'raises' do
+      validator.visit_file(file_hash: file)
+      expect { validator.validate! }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+end


### PR DESCRIPTION
*This is marked as a draft because I'm not sure it's a good idea. It would at
the very least require knowing how many items in the SDR would be in violation
of the validation rule before merging.*

---

## Why was this change made? 🤔

Adding a ShelveOnlyVisitorValidator to make files with shelve=yes,
publish=no and preserve=no invalid. THe resason for this is that those
will result in the file being deleted from all systems at the end of
accessioning.

Closes #1067 

## How was this change tested? 🤨

TBD
