### PR TITLE
Add validator for structured dates without values.

### DIFF
--- a/lib/cocina/models/validators/composite_description_validator.rb
+++ b/lib/cocina/models/validators/composite_description_validator.rb
@@ -8,7 +8,8 @@ module Cocina
         VALIDATORS = [
           DescriptionTypesVisitorValidator,
           DescriptionValuesVisitorValidator,
-          DescriptionDateTimeVisitorValidator
+          DescriptionDateTimeVisitorValidator,
+          DescriptionEventDateVisitorValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/lib/cocina/models/validators/description_event_date_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_event_date_visitor_validator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that event date structuredValue entries with a type also have a value.
+      class DescriptionEventDateVisitorValidator < BaseDescriptionVisitorValidator
+        def visit_hash(hash:, path:)
+          return unless hash[:type] && !hash[:value]
+          return unless event_date_structured_value?(path)
+
+          error_paths << path_to_s(path)
+        end
+
+        def validate!
+          return if error_paths.empty?
+
+          raise ValidationError,
+                "Missing value for type in description: #{error_paths.join(', ')}"
+        end
+
+        private
+
+        def error_paths
+          @error_paths ||= []
+        end
+
+        def event_date_structured_value?(path)
+          return false unless path[0] == 'event' && path[2] == 'date'
+
+          # Direct: event.date.structuredValue, e.g. ["event", 0, "date", 0, "structuredValue", 0]
+          # Via parallelValue: event.date.parallelValue.structuredValue, e.g. ["event", 0, "date", 0, "parallelValue", 0, "structuredValue", 0]
+          path[4] == 'structuredValue' || (path[4] == 'parallelValue' && path[6] == 'structuredValue')
+        end
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/description_event_date_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_event_date_visitor_validator_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::DescriptionEventDateVisitorValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:props) { desc_props.with_indifferent_access }
+
+  describe '#validate' do
+    let(:validate) { Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate }
+
+    describe 'when event date structuredValue has type without value' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'A title' }],
+          purl: 'https://purl.stanford.edu/bc123df4567',
+          event: [
+            {
+              date: [
+                {
+                  structuredValue: [
+                    { value: '1920', type: 'start' },
+                    { type: 'end' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing value for type in description: event1.date1.structuredValue2')
+      end
+    end
+
+    describe 'when event date structuredValue within parallelValue has type without value' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'A title' }],
+          purl: 'https://purl.stanford.edu/bc123df4567',
+          event: [
+            {
+              date: [
+                {
+                  parallelValue: [
+                    {
+                      structuredValue: [
+                        { value: '1920', type: 'start' },
+                        { type: 'end' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'is not valid' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError, 'Missing value for type in description: event1.date1.parallelValue1.structuredValue2')
+      end
+    end
+
+    describe 'when event date structuredValue has both type and value' do
+      let(:desc_props) do
+        {
+          title: [{ value: 'A title' }],
+          purl: 'https://purl.stanford.edu/bc123df4567',
+          event: [
+            {
+              date: [
+                {
+                  structuredValue: [
+                    { value: '1920', type: 'start' },
+                    { value: '1925', type: 'end' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #842

## Why was this change made? 🤔
Per @arcadiafalcone 


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-12.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
