### PR TITLE
Adds MARC relator validator.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cocina-models (0.122.0)
       activesupport
+      cocina_display
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -36,6 +37,14 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
+    cocina_display (2.6.0)
+      activesupport (>= 7)
+      edtf (~> 3.2)
+      geo_coord (~> 0.2)
+      i18n
+      iso8601 (~> 0.13.0)
+      janeway-jsonpath (>= 0.6, < 2)
+      zeitwerk (~> 2.7)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     csv (3.3.5)
@@ -81,6 +90,7 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    geo_coord (0.2.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -90,6 +100,8 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    iso8601 (0.13.0)
+    janeway-jsonpath (1.0.0)
     json (2.19.9)
     jsonschema_rs (0.46.5-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
@@ -221,6 +233,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   cocina-models (0.122.0)
+  cocina_display (2.6.0) sha256=a30e4bd638023371985ab641164e4dbbb12fe9a669a168c1b8e2eac2e37739f4
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
@@ -240,10 +253,13 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  geo_coord (0.2.0) sha256=ae4e2dc5799deafa4db9138f3d7e85cf5e7dbd00b3b8395f1e1dbd34e007d7e8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   ice_nine (0.11.2) sha256=5d506a7d2723d5592dc121b9928e4931742730131f22a1a37649df1c1e2e63db
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  iso8601 (0.13.0) sha256=298c2b15b7be5fa95a1372813d36a2257656cd8e906dfbc1f5cb409851425aa2
+  janeway-jsonpath (1.0.0) sha256=c8293f009f2aea9487ddee3067ca735a1f758eb1c8834ff4fab3ffd06c56d0a3
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jsonschema_rs (0.46.5-arm64-darwin) sha256=e80414ed67f0956d3e06474a2fa076fc4a7b722f00e5d7142b70289c016ac6f1
   jsonschema_rs (0.46.5-x86_64-linux) sha256=345c65ec7a5abf8879b9c9356752f0fdf4c9926f6480458fc32803a871b5cbb3

--- a/cocina-models.gemspec
+++ b/cocina-models.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.4'
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'cocina_display'
   spec.add_dependency 'deprecation'
   spec.add_dependency 'dry-struct', '~> 1.0'
   spec.add_dependency 'dry-types', '~> 1.1'

--- a/lib/cocina/models/validators/marc_relator_role_validator.rb
+++ b/lib/cocina/models/validators/marc_relator_role_validator.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'cocina_display'
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that contributor role codes from the marcrelator vocabulary are valid MARC relator codes.
+      # Includes discontinued codes. See https://www.loc.gov/marc/relators/relacode.html
+      class MarcRelatorRoleValidator
+        MARCRELATOR_SOURCE_CODES = %w[marcrelator].freeze
+        MARCRELATOR_SOURCE_URI = 'http://id.loc.gov/vocabulary/relators/'
+
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+          @errors = []
+        end
+
+        def validate
+          return unless meets_preconditions?
+
+          resources.each { |resource| validate_resource(resource) }
+          raise ValidationError, "Invalid MARC relator codes in description: #{@errors.join(', ')}" if @errors.any?
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def meets_preconditions?
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
+        end
+
+        def resources
+          [description_attributes] + Array(description_attributes[:relatedResource])
+        end
+
+        def description_attributes
+          @description_attributes ||= if [Cocina::Models::Description,
+                                          Cocina::Models::RequestDescription].include?(clazz)
+                                        attributes
+                                      else
+                                        attributes[:description] || {}
+                                      end
+        end
+
+        def validate_resource(resource)
+          Array(resource[:contributor]).each_with_index do |contributor, contributor_index|
+            Array(contributor[:role]).each_with_index do |role, role_index|
+              validate_role(role, "contributor#{contributor_index + 1}.role#{role_index + 1}")
+            end
+          end
+        end
+
+        def validate_role(role, path)
+          return unless marc_relator_source?(role)
+
+          code = role[:code]
+          return if code.nil?
+
+          @errors << "#{path} (#{code})" unless valid_codes.include?(code)
+        end
+
+        def marc_relator_source?(role)
+          source = role[:source] || {}
+          MARCRELATOR_SOURCE_CODES.include?(source[:code]) ||
+            source[:uri]&.start_with?(MARCRELATOR_SOURCE_URI)
+        end
+
+        # rubocop:disable Style/ClassVars
+        def valid_codes
+          @@valid_codes ||= YAML.load_file(CocinaDisplay.root.join('config/marc_relators.yml')).keys
+        end
+        # rubocop:enable Style/ClassVars
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -11,7 +11,8 @@ module Cocina
           CompositeStructuralValidator,
           PurlValidator,
           CatalogLinksValidator,
-          AssociatedNameValidator
+          AssociatedNameValidator,
+          MarcRelatorRoleValidator
         ].freeze
 
         def self.validate(clazz, attributes, validators: VALIDATORS)

--- a/spec/cocina/models/validators/marc_relator_role_validator_spec.rb
+++ b/spec/cocina/models/validators/marc_relator_role_validator_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::MarcRelatorRoleValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:validate) { described_class.validate(clazz, props) }
+
+  let(:marc_relator_source) do
+    { code: 'marcrelator', uri: 'http://id.loc.gov/vocabulary/relators/' }
+  end
+
+  describe '#validate' do
+    context 'when no contributors' do
+      let(:props) { { title: [{ value: 'A title' }] } }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when contributor has no role' do
+      let(:props) do
+        {
+          contributor: [
+            { name: [{ value: 'Smith, John' }] }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has no code' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', source: marc_relator_source }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has a valid marcrelator code identified by source code' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'aut', source: { code: 'marcrelator' } }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has a valid marcrelator code identified by source URI' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'aut', source: { uri: 'http://id.loc.gov/vocabulary/relators/' } }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has a discontinued marcrelator code' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                # 'voc' (vocalist) is discontinued but must still be accepted
+                { value: 'vocalist', code: 'voc', source: marc_relator_source }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has an invalid marcrelator code' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'xyz', source: marc_relator_source }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'raises a ValidationError' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError,
+                                           /contributor1\.role1 \(xyz\)/)
+      end
+    end
+
+    context 'when role source is not marcrelator' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'xyz', source: { code: 'lcdgt' } }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when role has no source' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'xyz' }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when multiple contributors and roles with one bad code' do
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'author', code: 'aut', source: marc_relator_source },
+                { value: 'editor', code: 'edt', source: marc_relator_source }
+              ]
+            },
+            {
+              role: [
+                { value: 'bad', code: 'xyz', source: marc_relator_source }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'raises a ValidationError naming the specific path' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError,
+                                           /contributor2\.role1 \(xyz\)/)
+      end
+    end
+
+    context 'when relatedResource contributor role has an invalid code' do
+      let(:props) do
+        {
+          contributor: [],
+          relatedResource: [
+            {
+              contributor: [
+                {
+                  role: [
+                    { value: 'bad', code: 'xyz', source: marc_relator_source }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'raises a ValidationError' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError,
+                                           /contributor1\.role1 \(xyz\)/)
+      end
+    end
+
+    context 'when clazz is not Description or RequestDescription' do
+      let(:clazz) { Cocina::Models::DRO }
+      let(:props) do
+        {
+          contributor: [
+            {
+              role: [
+                { value: 'bad', code: 'xyz', source: marc_relator_source }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #848

## Why was this change made? 🤔
Per @arcadiafalcone 


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-12
.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
