### PR TITLE
Adds resource types validator.

### DIFF
--- a/lib/cocina/models/validators/composite_description_validator.rb
+++ b/lib/cocina/models/validators/composite_description_validator.rb
@@ -8,6 +8,7 @@ module Cocina
         VALIDATORS = [
           DescriptionTypesVisitorValidator,
           DescriptionIdentifierSourceCodeVisitorValidator,
+          DescriptionFormResourceTypeVisitorValidator,
           DescriptionValuesVisitorValidator,
           DescriptionDateTimeVisitorValidator,
           DescriptionEventDateVisitorValidator

--- a/lib/cocina/models/validators/description_form_resource_type_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_form_resource_type_visitor_validator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates form.value against allowed values when form.source.value is a known controlled vocabulary.
+      class DescriptionFormResourceTypeVisitorValidator < BaseDescriptionVisitorValidator
+        def validate!
+          return if error_paths.empty?
+
+          raise ValidationError, "Unrecognized resource type values in description: #{error_paths.join(', ')}"
+        end
+
+        def visit_hash(hash:, path:)
+          return unless form_entry_path?(path)
+          return unless hash[:type].to_s == 'resource type'
+
+          source_value = hash.dig(:source, :value)
+          return unless source_value && valid_values_by_source.key?(source_value)
+
+          value = hash[:value]
+          return unless value
+          return if valid_values_by_source[source_value].include?(value)
+
+          error_paths << "#{path_to_s(path)} (#{value})"
+        end
+
+        private
+
+        def error_paths
+          @error_paths ||= []
+        end
+
+        def form_entry_path?(path)
+          path.length >= 2 && path[-1].is_a?(Integer) && path[-2].to_s == 'form'
+        end
+
+        # rubocop:disable Style/ClassVars
+        def valid_values_by_source
+          @@valid_values_by_source ||= YAML.load_file(::File.expand_path('../../../../resource_type_values.yml', __dir__))
+        end
+        # rubocop:enable Style/ClassVars
+      end
+    end
+  end
+end

--- a/resource_type_values.yml
+++ b/resource_type_values.yml
@@ -1,0 +1,30 @@
+MODS resource type:
+  - text
+  - cartographic
+  - notated music
+  - sound recording
+  - sound recording-musical
+  - sound recording-nonmusical
+  - still image
+  - moving image
+  - three dimensional object
+  - software, multimedia
+  - mixed material
+  - collection
+  - manuscript
+LC Resource Type Scheme:
+  - Artifact
+  - Audio
+  - Cartographic
+  - Collection
+  - Dataset
+  - Digital
+  - Manuscript
+  - Mixed material
+  - Moving image
+  - Multimedia
+  - Notated music
+  - Still image
+  - Tactile
+  - Text
+  - Unspecified

--- a/spec/cocina/models/validators/description_form_resource_type_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_form_resource_type_visitor_validator_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::DescriptionFormResourceTypeVisitorValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:validate) { Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate }
+
+  let(:base_props) do
+    {
+      title: [{ value: 'Test Title' }],
+      purl: 'https://purl.stanford.edu/bc123df4567'
+    }.with_indifferent_access
+  end
+
+  describe 'when form has no type' do
+    let(:props) { base_props.merge(form: [{ value: 'text', source: { value: 'MODS resource type' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when form type is not resource type' do
+    let(:props) { base_props.merge(form: [{ value: 'book', type: 'genre', source: { value: 'MODS resource type' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when form has no source' do
+    let(:props) { base_props.merge(form: [{ value: 'bogus', type: 'resource type' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when form source value is unknown' do
+    let(:props) { base_props.merge(form: [{ value: 'bogus', type: 'resource type', source: { value: 'DataCite' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when form has no value' do
+    let(:props) { base_props.merge(form: [{ type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'MODS resource type' do
+    describe 'when value is valid' do
+      let(:props) { base_props.merge(form: [{ value: 'text', type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    describe 'when value is valid (sound recording-musical)' do
+      let(:props) { base_props.merge(form: [{ value: 'sound recording-musical', type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    describe 'when value is invalid' do
+      let(:props) { base_props.merge(form: [{ value: 'bogus value', type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+      it 'raises ValidationError with path and value' do
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          'Unrecognized resource type values in description: form1 (bogus value)'
+        )
+      end
+    end
+
+    describe 'when value uses wrong case' do
+      let(:props) { base_props.merge(form: [{ value: 'Text', type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+      it 'raises ValidationError' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+  end
+
+  describe 'LC Resource Type Scheme' do
+    describe 'when value is valid' do
+      let(:props) { base_props.merge(form: [{ value: 'Still image', type: 'resource type', source: { value: 'LC Resource Type Scheme' } }]) }
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    describe 'when value is invalid' do
+      let(:props) { base_props.merge(form: [{ value: 'bogus value', type: 'resource type', source: { value: 'LC Resource Type Scheme' } }]) }
+
+      it 'raises ValidationError with path and value' do
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          'Unrecognized resource type values in description: form1 (bogus value)'
+        )
+      end
+    end
+
+    describe 'when value uses wrong case' do
+      let(:props) { base_props.merge(form: [{ value: 'still image', type: 'resource type', source: { value: 'LC Resource Type Scheme' } }]) }
+
+      it 'raises ValidationError' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+  end
+
+  describe 'when multiple form entries have invalid values' do
+    let(:props) do
+      base_props.merge(
+        form: [
+          { value: 'bad1', type: 'resource type', source: { value: 'MODS resource type' } },
+          { value: 'bad2', type: 'resource type', source: { value: 'LC Resource Type Scheme' } }
+        ]
+      )
+    end
+
+    it 'raises ValidationError listing all invalid paths' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized resource type values in description: form1 (bad1), form2 (bad2)'
+      )
+    end
+  end
+
+  describe 'when using RequestDescription class' do
+    let(:clazz) { Cocina::Models::RequestDescription }
+    let(:props) { base_props.except(:purl).merge(form: [{ value: 'bogus', type: 'resource type', source: { value: 'MODS resource type' } }]) }
+
+    it 'raises ValidationError' do
+      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+end


### PR DESCRIPTION
closes #1085

## Why was this change made? 🤔
Per @arcadiafalcone 


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-15.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
