### PR TITLE
Add validator for language codes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,6 @@ GEM
     json (2.19.9)
     jsonschema_rs (0.46.5-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.5-x86_64-linux)
-      bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -207,7 +205,6 @@ GEM
 
 PLATFORMS
   arm64-darwin
-  x86_64-linux-gnu
 
 DEPENDENCIES
   bundler (>= 2.0, < 5)
@@ -262,7 +259,6 @@ CHECKSUMS
   janeway-jsonpath (1.0.0) sha256=c8293f009f2aea9487ddee3067ca735a1f758eb1c8834ff4fab3ffd06c56d0a3
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jsonschema_rs (0.46.5-arm64-darwin) sha256=e80414ed67f0956d3e06474a2fa076fc4a7b722f00e5d7142b70289c016ac6f1
-  jsonschema_rs (0.46.5-x86_64-linux) sha256=345c65ec7a5abf8879b9c9356752f0fdf4c9926f6480458fc32803a871b5cbb3
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     json (2.19.9)
     jsonschema_rs (0.46.5-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
+    jsonschema_rs (0.46.5-x86_64-linux)
+      bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -205,6 +207,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   bundler (>= 2.0, < 5)
@@ -259,6 +262,7 @@ CHECKSUMS
   janeway-jsonpath (1.0.0) sha256=c8293f009f2aea9487ddee3067ca735a1f758eb1c8834ff4fab3ffd06c56d0a3
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jsonschema_rs (0.46.5-arm64-darwin) sha256=e80414ed67f0956d3e06474a2fa076fc4a7b722f00e5d7142b70289c016ac6f1
+  jsonschema_rs (0.46.5-x86_64-linux) sha256=345c65ec7a5abf8879b9c9356752f0fdf4c9926f6480458fc32803a871b5cbb3
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/bin/validate-data
+++ b/bin/validate-data
@@ -260,9 +260,8 @@ def print_summary(total_lines, errors, elapsed_time) # rubocop:disable Metrics/M
   puts "Line numbers with errors: #{sorted_errors.map { |e| e[:line] }.join(', ')}"
 
   CSV.open('validate-data-errors.csv', 'w') do |csv|
-    csv << %w[line druid error]
     sorted_errors.each do |error|
-      csv << [error[:line], error[:druid], error[:error]]
+      csv << [error[:druid], error[:error]]
     end
   end
   puts 'Errors written to validate-data-errors.csv'

--- a/lib/cocina/models/validators/composite_description_validator.rb
+++ b/lib/cocina/models/validators/composite_description_validator.rb
@@ -11,6 +11,7 @@ module Cocina
           DescriptionRoleSourceCodeVisitorValidator,
           DescriptionNameSourceCodeVisitorValidator,
           DescriptionFormResourceTypeVisitorValidator,
+          DescriptionLanguageCodeVisitorValidator,
           DescriptionValuesVisitorValidator,
           DescriptionDateTimeVisitorValidator,
           DescriptionEventDateVisitorValidator,

--- a/lib/cocina/models/validators/description_language_code_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_language_code_visitor_validator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'cocina_display'
+
+module Cocina
+  module Models
+    module Validators
+      # Validates language.code values against searchworks_languages from cocina_display gem plus mul, und, zxx.
+      class DescriptionLanguageCodeVisitorValidator < BaseDescriptionVisitorValidator
+        EXTRA_VALID_CODES = %w[mul und zxx].freeze
+
+        def validate!
+          return if error_paths.empty?
+
+          raise ValidationError, "Unrecognized language codes in description: #{error_paths.join(', ')}"
+        end
+
+        def visit_hash(hash:, path:)
+          return unless language_path?(path)
+
+          code = hash[:code]
+          return unless code
+
+          error_paths << "#{path_to_s(path)}.code (#{code})" unless valid_codes.include?(code)
+        end
+
+        private
+
+        def error_paths
+          @error_paths ||= []
+        end
+
+        def language_path?(path)
+          path.length >= 2 && path[-1].is_a?(Integer) && path[-2].to_s == 'language'
+        end
+
+        # rubocop:disable Style/ClassVars
+        def valid_codes
+          @@valid_codes ||= begin
+            gem_codes = CocinaDisplay::Languages::Language.searchworks_languages.keys.to_set
+            gem_codes.merge(EXTRA_VALID_CODES)
+          end
+        end
+        # rubocop:enable Style/ClassVars
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/description_language_code_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_language_code_visitor_validator_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::DescriptionLanguageCodeVisitorValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:validate) { Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate }
+
+  let(:base_props) do
+    {
+      title: [{ value: 'Test Title' }],
+      purl: 'https://purl.stanford.edu/bc123df4567'
+    }.with_indifferent_access
+  end
+
+  describe 'when language has no code' do
+    let(:props) { base_props.merge(language: [{ value: 'English' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when language has a valid code' do
+    let(:props) { base_props.merge(language: [{ code: 'eng' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when language has a valid code with different case' do
+    let(:props) { base_props.merge(language: [{ code: 'ENG' }]) }
+
+    it 'raises ValidationError' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized language codes in description: language1.code (ENG)'
+      )
+    end
+  end
+
+  describe 'when language has code mul' do
+    let(:props) { base_props.merge(language: [{ code: 'mul' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when language has code und' do
+    let(:props) { base_props.merge(language: [{ code: 'und' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when language has code zxx' do
+    let(:props) { base_props.merge(language: [{ code: 'zxx' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when language has an invalid code' do
+    let(:props) { base_props.merge(language: [{ code: 'bogus' }]) }
+
+    it 'raises ValidationError with path and code' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized language codes in description: language1.code (bogus)'
+      )
+    end
+  end
+
+  describe 'when multiple languages have invalid codes' do
+    let(:props) { base_props.merge(language: [{ code: 'eng' }, { code: 'bogus' }, { code: 'fake' }]) }
+
+    it 'raises ValidationError listing all invalid codes' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized language codes in description: language2.code (bogus), language3.code (fake)'
+      )
+    end
+  end
+
+  describe 'when using RequestDescription class' do
+    let(:clazz) { Cocina::Models::RequestDescription }
+    let(:props) { base_props.except(:purl).merge(language: [{ code: 'bogus' }]) }
+
+    it 'raises ValidationError' do
+      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+end


### PR DESCRIPTION
closes #905

## Why was this change made? 🤔
Per ticket.


## How was this change tested? 🤨
`bin/validate-cocina`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
