### PR TITLE
Add validator for temporal subject encoding.

### DIFF
--- a/lib/cocina/models/validators/composite_description_validator.rb
+++ b/lib/cocina/models/validators/composite_description_validator.rb
@@ -11,7 +11,8 @@ module Cocina
           DescriptionFormResourceTypeVisitorValidator,
           DescriptionValuesVisitorValidator,
           DescriptionDateTimeVisitorValidator,
-          DescriptionEventDateVisitorValidator
+          DescriptionEventDateVisitorValidator,
+          DescriptionSubjectTemporalEncodingVisitorValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/lib/cocina/models/validators/description_subject_temporal_encoding_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_subject_temporal_encoding_visitor_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates encoding.code for subject entries with type "time" against
+      # temporal_subject_encoding_codes.yml (union of LOC date-time and temporal source lists).
+      class DescriptionSubjectTemporalEncodingVisitorValidator < BaseDescriptionVisitorValidator
+        def validate!
+          return if error_paths.empty?
+
+          raise ValidationError, "Unrecognized subject temporal encoding codes in description: #{error_paths.join(', ')}"
+        end
+
+        def visit_hash(hash:, path:)
+          return unless in_subject_path?(path)
+          return unless hash[:type].to_s == 'time'
+
+          encoding_code = hash.dig(:encoding, :code)
+          return unless encoding_code
+
+          error_paths << "#{path_to_s(path)}.encoding.code (#{encoding_code})" unless valid_codes.include?(encoding_code.downcase)
+        end
+
+        private
+
+        def error_paths
+          @error_paths ||= []
+        end
+
+        def in_subject_path?(path)
+          path.any? { |part| part.to_s == 'subject' }
+        end
+
+        # rubocop:disable Style/ClassVars
+        def valid_codes
+          @@valid_codes ||= YAML.load_file(::File.expand_path('../../../../temporal_subject_encoding_codes.yml', __dir__)).to_set(&:downcase)
+        end
+        # rubocop:enable Style/ClassVars
+      end
+    end
+  end
+end

--- a/spec/cocina/models/validators/description_subject_temporal_encoding_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_subject_temporal_encoding_visitor_validator_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::DescriptionSubjectTemporalEncodingVisitorValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:validate) { Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate }
+
+  let(:base_props) do
+    {
+      title: [{ value: 'Test Title' }],
+      purl: 'https://purl.stanford.edu/bc123df4567'
+    }.with_indifferent_access
+  end
+
+  describe 'when subject has no encoding' do
+    let(:props) { base_props.merge(subject: [{ value: '1990', type: 'time' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject type is not time' do
+    let(:props) { base_props.merge(subject: [{ value: 'History', type: 'topic', encoding: { code: 'bogusenc' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with a valid encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: '1990', type: 'time', encoding: { code: 'iso8601' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with a valid encoding code (different case)' do
+    let(:props) { base_props.merge(subject: [{ value: '1990', type: 'time', encoding: { code: 'ISO8601' } }]) }
+
+    it 'is case-insensitive and does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with an invalid encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: '1990', type: 'time', encoding: { code: 'bogusenc' } }]) }
+
+    it 'raises ValidationError with path and code' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized subject temporal encoding codes in description: subject1.encoding.code (bogusenc)'
+      )
+    end
+  end
+
+  describe 'when subject has type time with edtf encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: '1990/2000', type: 'time', encoding: { code: 'edtf' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with w3cdtf encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: '1990-01-01', type: 'time', encoding: { code: 'w3cdtf' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with marc encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: '1990', type: 'time', encoding: { code: 'marc' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with temper encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: 'Bronze Age', type: 'time', encoding: { code: 'temper' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when subject has type time with periodo encoding code' do
+    let(:props) { base_props.merge(subject: [{ value: 'Early Medieval', type: 'time', encoding: { code: 'periodo' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when structuredValue within subject has type time with an invalid encoding code' do
+    let(:props) do
+      base_props.merge(
+        subject: [{
+          structuredValue: [
+            { value: '1990', type: 'time', encoding: { code: 'bogusenc' } },
+            { value: '2000', type: 'time', encoding: { code: 'iso8601' } }
+          ]
+        }]
+      )
+    end
+
+    it 'raises ValidationError with nested path' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized subject temporal encoding codes in description: subject1.structuredValue1.encoding.code (bogusenc)'
+      )
+    end
+  end
+
+  describe 'when structuredValue within subject has type time with valid encoding codes' do
+    let(:props) do
+      base_props.merge(
+        subject: [{
+          structuredValue: [
+            { value: '1990', type: 'time', encoding: { code: 'iso8601' } },
+            { value: '2000', type: 'time', encoding: { code: 'edtf' } }
+          ]
+        }]
+      )
+    end
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when using RequestDescription class' do
+    let(:clazz) { Cocina::Models::RequestDescription }
+    let(:props) { base_props.except(:purl).merge(subject: [{ value: '1990', type: 'time', encoding: { code: 'bogusenc' } }]) }
+
+    it 'raises ValidationError' do
+      expect { validate }.to raise_error(Cocina::Models::ValidationError)
+    end
+  end
+end

--- a/temporal_subject_encoding_codes.yml
+++ b/temporal_subject_encoding_codes.yml
@@ -1,0 +1,8 @@
+# Codes from https://www.loc.gov/standards/sourcelist/date-time.html
+- edtf
+- iso8601
+- marc
+- temper
+- w3cdtf
+# Codes from https://www.loc.gov/standards/sourcelist/temporal.html
+- periodo


### PR DESCRIPTION
closes #846

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-15.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
