### PR TITLE
Validate main value present for Source and Standard.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2995,6 +2995,17 @@
           "type": "string"
         }
       },
+      "anyOf": [
+        { "required": ["value"] },
+        { "required": ["code"] },
+        { "required": ["uri"] },
+        {
+          "required": ["note"],
+          "properties": {
+            "note": { "minItems": 1 }
+          }
+        }
+      ],
       "unevaluatedProperties": false
     },
     "SourceId": {
@@ -3034,6 +3045,17 @@
           "$ref": "#/$defs/Source"
         }
       },
+      "anyOf": [
+        { "required": ["value"] },
+        { "required": ["code"] },
+        { "required": ["uri"] },
+        {
+          "required": ["note"],
+          "properties": {
+            "note": { "minItems": 1 }
+          }
+        }
+      ],
       "unevaluatedProperties": false
     },
     "StandardBarcode": {


### PR DESCRIPTION
closes #1005

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
`bin/validate-data ../cocina-models/cocina-head-versions-prod-2026-06-16.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
