### PR TITLE
Add validator for date encoding code.

### DIFF
--- a/lib/cocina/models/validators/description_date_time_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_date_time_visitor_validator.rb
@@ -8,8 +8,9 @@ module Cocina
       # Validates that dates of known types are type-valid using the visitor pattern.
       class DescriptionDateTimeVisitorValidator < BaseDescriptionVisitorValidator
         VALIDATABLE_TYPES = %w[edtf iso8601 w3cdtf].freeze
+        VALID_ENCODING_CODES = %w[edtf iso8601 marc temper w3cdtf].freeze
 
-        def visit_hash(hash:, path:) # rubocop:disable Metrics/CyclomaticComplexity
+        def visit_hash(hash:, path:) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
           # Only dates nested under a `date` key are subject to validation.
           # For example, event.date is in scope but event.note is not.
           return unless in_date_path?(path)
@@ -32,7 +33,10 @@ module Cocina
           # recursing into its children, so the encoding is always registered
           # before any child value hashes are visited.
           code = hash.dig(:encoding, :code)
-          encoding_paths[path.dup] = code if code && VALIDATABLE_TYPES.include?(code)
+          if code
+            encoding_paths[path.dup] = code if VALIDATABLE_TYPES.include?(code)
+            invalid_encoding_codes << "#{path_to_s(path)}.encoding.code (#{code})" unless VALID_ENCODING_CODES.include?(code)
+          end
 
           value = hash[:value]
           return unless value.is_a?(String)
@@ -62,23 +66,28 @@ module Cocina
         end
 
         def validate!
-          return if invalid_groups.empty?
+          errors = []
 
-          invalid_dates = invalid_groups.filter_map do |path, values|
-            next if values.empty?
+          errors << "Unrecognized date encoding codes in description: #{invalid_encoding_codes.join(', ')}" if invalid_encoding_codes.any?
 
-            [*values, encoding_paths[path]]
+          unless invalid_groups.empty?
+            invalid_dates = invalid_groups.filter_map do |path, values|
+              [*values, encoding_paths[path]] unless values.empty?
+            end
+            errors << "Invalid date(s) in description: #{invalid_dates}" if invalid_dates.any?
           end
 
-          return if invalid_dates.empty?
-
-          raise ValidationError, "Invalid date(s) in description: #{invalid_dates}"
+          raise ValidationError, errors.join('; ') if errors.any?
         end
 
         private
 
         def encoding_paths
           @encoding_paths ||= {}
+        end
+
+        def invalid_encoding_codes
+          @invalid_encoding_codes ||= []
         end
 
         def invalid_groups

--- a/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
@@ -237,6 +237,75 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     end
   end
 
+  context 'with date encoding codes' do
+    context 'when code is valid' do
+      %w[edtf iso8601 marc temper w3cdtf].each do |code|
+        it "does not raise for #{code}" do
+          props = { event: [{ date: [{ value: '2021', encoding: { code: code } }] }] }
+          expect do
+            Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate
+          end.not_to raise_error
+        end
+      end
+    end
+
+    context 'when code is invalid' do
+      let(:props) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  value: '2021',
+                  encoding: {
+                    code: 'unknown'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'raises with an informative message' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError, /Unrecognized date encoding codes/)
+      end
+    end
+
+    context 'when an invalid code is nested in structuredValue' do
+      let(:props) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  structuredValue: [
+                    { value: '1996', type: 'start', encoding: { code: 'bad' } },
+                    { value: '1998', type: 'end' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'raises' do
+        expect { validate }.to raise_error(Cocina::Models::ValidationError, /Unrecognized date encoding codes/)
+      end
+    end
+
+    context 'when no encoding is present' do
+      let(:props) do
+        { event: [{ date: [{ value: '2021' }] }] }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+
   # NOTE: the intent of this test is to show that the validator correctly
   #       navigates the structure and picks out the right bits as invalid
   context 'with adminMetadata dates' do


### PR DESCRIPTION
closes #1115

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-17.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
