### PR TITLE
Validate main value present for DescriptiveAdminMetadata.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1020,6 +1020,56 @@
           }
         }
       },
+      "anyOf": [
+        {
+          "properties": {
+            "contributor": {
+              "minItems": 1
+            }
+          },
+          "required": ["contributor"]
+        },
+        {
+          "properties": {
+            "event": {
+              "minItems": 1
+            }
+          },
+          "required": ["event"]
+        },
+        {
+          "properties": {
+            "language": {
+              "minItems": 1
+            }
+          },
+          "required": ["language"]
+        },
+        {
+          "properties": {
+            "note": {
+              "minItems": 1
+            }
+          },
+          "required": ["note"]
+        },
+        {
+          "properties": {
+            "metadataStandard": {
+              "minItems": 1
+            }
+          },
+          "required": ["metadataStandard"]
+        },
+        {
+          "properties": {
+            "identifier": {
+              "minItems": 1
+            }
+          },
+          "required": ["identifier"]
+        }
+      ],
       "unevaluatedProperties": false
     },
     "DescriptiveBasicValue": {


### PR DESCRIPTION
closes #1114

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-17.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
