### PR TITLE
Makes DescriptiveValue based on DescriptiveBasicValue. Reverts requiring that groupedValue has multiple children.

### DIFF
--- a/lib/cocina/models/admin_policy_access_template.rb
+++ b/lib/cocina/models/admin_policy_access_template.rb
@@ -6,6 +6,17 @@ module Cocina
     # an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults
     # and has no embargo.
     class AdminPolicyAccessTemplate < Struct
+      # Access level.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :view, Types::Strict::String.optional.default('dark')
+      # Download access level.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :download, Types::Strict::String.optional.default('none')
+      # Not used for this access type, must be null.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :location, Types::Strict::String.optional
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute? :copyright, Copyright.optional
@@ -18,17 +29,6 @@ module Cocina
       # The license governing reuse of the DRO. Should be an IRI for known licenses (i.e.
       # CC, RightsStatement.org URI, etc.).
       attribute? :license, License.optional.enum(nil, 'https://www.gnu.org/licenses/agpl.txt', 'https://www.apache.org/licenses/LICENSE-2.0', 'https://opensource.org/licenses/BSD-2-Clause', 'https://opensource.org/licenses/BSD-3-Clause', 'https://creativecommons.org/licenses/by/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode', 'https://creativecommons.org/licenses/by-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-sa/4.0/legalcode', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode', 'https://opensource.org/licenses/cddl1', 'https://www.eclipse.org/legal/epl-2.0', 'https://www.gnu.org/licenses/gpl-3.0-standalone.html', 'https://www.isc.org/downloads/software-support-policy/isc-license/', 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html', 'https://opensource.org/licenses/MIT', 'https://www.mozilla.org/MPL/2.0/', 'https://opendatacommons.org/licenses/by/1-0/', 'http://opendatacommons.org/licenses/odbl/1.0/', 'https://opendatacommons.org/licenses/odbl/1-0/', 'https://creativecommons.org/publicdomain/mark/1.0/', 'https://opendatacommons.org/licenses/pddl/1-0/', 'https://creativecommons.org/licenses/by/3.0/legalcode', 'https://creativecommons.org/licenses/by-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nd/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode', 'https://cocina.sul.stanford.edu/licenses/none')
-      # Access level.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :view, Types::Strict::String.optional.default('dark')
-      # Download access level.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :download, Types::Strict::String.optional.default('none')
-      # Not used for this access type, must be null.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :location, Types::Strict::String.optional
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
     end
   end
 end

--- a/lib/cocina/models/applies_to.rb
+++ b/lib/cocina/models/applies_to.rb
@@ -2,10 +2,44 @@
 
 module Cocina
   module Models
-    # Property model for indicating the parts, aspects, or versions of the resource to
-    # which a descriptive element is applicable.
+    # Value model for appliesTo property.
     class AppliesTo < Struct
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
+      attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
+      attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
+      attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
+      # String or integer value of the descriptive element.
+      attribute? :value, Types::Nominal::Any
+      # Type of value provided by the descriptive element. See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md
+      # for valid types.
+      attribute? :type, Types::Strict::String
+      # Status of the descriptive element value relative to other instances of the element.
+      attribute? :status, Types::Strict::String
+      # Code value of the descriptive element.
+      attribute? :code, Types::Strict::String
+      # URI value of the descriptive element.
+      attribute? :uri, Types::Strict::String
+      # Property model for indicating the encoding, standard, or syntax to which a value
+      # conforms (e.g. RDA).
+      attribute? :standard, Standard.optional
+      # Property model for indicating the encoding, standard, or syntax to which a value
+      # conforms (e.g. RDA).
+      attribute? :encoding, Standard.optional
+      # Property model for indicating the vocabulary, authority, or other origin for a term,
+      # code, or identifier.
+      attribute? :source, Source.optional
+      # The preferred display label to use for the descriptive element in access systems.
+      attribute? :displayLabel, Types::Strict::String.optional
+      # A term providing information about the circumstances of the statement (e.g., approximate
+      # dates).
+      attribute? :qualifier, Types::Strict::String
+      # Other information related to the descriptive element.
+      attribute :note, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
+      # Language of the descriptive element value
+      attribute? :valueLanguage, DescriptiveValueLanguage.optional
+      # URL or other pointer to the location of the value of the descriptive element.
+      attribute? :valueAt, Types::Strict::String
+      # Identifiers and URIs associated with the descriptive element.
+      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
     end
   end
 end

--- a/lib/cocina/models/descriptive_basic_value.rb
+++ b/lib/cocina/models/descriptive_basic_value.rb
@@ -3,7 +3,7 @@
 module Cocina
   module Models
     # Basic value model for descriptive elements. Can only have one of value, parallelValue,
-    # groupedValue, or structuredValue.
+    # groupedValue, or structuredValue. Does not have identifier or appliesTo properties.
     class DescriptiveBasicValue < Struct
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
@@ -25,8 +25,6 @@ module Cocina
       # Property model for indicating the encoding, standard, or syntax to which a value
       # conforms (e.g. RDA).
       attribute? :encoding, Standard.optional
-      # Identifiers and URIs associated with the descriptive element.
-      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
       # Property model for indicating the vocabulary, authority, or other origin for a term,
       # code, or identifier.
       attribute? :source, Source.optional

--- a/lib/cocina/models/descriptive_identifier.rb
+++ b/lib/cocina/models/descriptive_identifier.rb
@@ -2,10 +2,8 @@
 
 module Cocina
   module Models
-    # Value model for descriptive identifiers. Same as DescriptiveValue but omits the identifier
-    # property to prevent infinite recursion.
+    # Default value model for identifiers.
     class DescriptiveIdentifier < Struct
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
@@ -40,6 +38,7 @@ module Cocina
       attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
       attribute? :valueAt, Types::Strict::String
+      attribute :appliesTo, Types::Strict::Array.of(AppliesTo).default([].freeze)
     end
   end
 end

--- a/lib/cocina/models/descriptive_value.rb
+++ b/lib/cocina/models/descriptive_value.rb
@@ -4,7 +4,6 @@ module Cocina
   module Models
     # Default value model for descriptive elements.
     class DescriptiveValue < Struct
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
@@ -25,8 +24,6 @@ module Cocina
       # Property model for indicating the encoding, standard, or syntax to which a value
       # conforms (e.g. RDA).
       attribute? :encoding, Standard.optional
-      # Identifiers and URIs associated with the descriptive element.
-      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
       # Property model for indicating the vocabulary, authority, or other origin for a term,
       # code, or identifier.
       attribute? :source, Source.optional
@@ -41,6 +38,9 @@ module Cocina
       attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
       attribute? :valueAt, Types::Strict::String
+      attribute :appliesTo, Types::Strict::Array.of(AppliesTo).default([].freeze)
+      # Identifiers and URIs associated with the descriptive element.
+      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
     end
   end
 end

--- a/lib/cocina/models/dro_access.rb
+++ b/lib/cocina/models/dro_access.rb
@@ -3,6 +3,17 @@
 module Cocina
   module Models
     class DROAccess < Struct
+      # Access level.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :view, Types::Strict::String.optional.default('dark')
+      # Download access level.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :download, Types::Strict::String.optional.default('none')
+      # Not used for this access type, must be null.
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :location, Types::Strict::String.optional
+      # Validation of this property is relaxed. See the schema.json for full validation.
+      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
       # The human readable copyright statement that applies
       # example: Copyright World Trade Organization
       attribute? :copyright, Copyright.optional
@@ -16,17 +27,6 @@ module Cocina
       # The license governing reuse of the DRO. Should be an IRI for known licenses (i.e.
       # CC, RightsStatement.org URI, etc.).
       attribute? :license, License.optional.enum(nil, 'https://www.gnu.org/licenses/agpl.txt', 'https://www.apache.org/licenses/LICENSE-2.0', 'https://opensource.org/licenses/BSD-2-Clause', 'https://opensource.org/licenses/BSD-3-Clause', 'https://creativecommons.org/licenses/by/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode', 'https://creativecommons.org/licenses/by-nd/4.0/legalcode', 'https://creativecommons.org/licenses/by-sa/4.0/legalcode', 'https://creativecommons.org/publicdomain/zero/1.0/legalcode', 'https://opensource.org/licenses/cddl1', 'https://www.eclipse.org/legal/epl-2.0', 'https://www.gnu.org/licenses/gpl-3.0-standalone.html', 'https://www.isc.org/downloads/software-support-policy/isc-license/', 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html', 'https://opensource.org/licenses/MIT', 'https://www.mozilla.org/MPL/2.0/', 'https://opendatacommons.org/licenses/by/1-0/', 'http://opendatacommons.org/licenses/odbl/1.0/', 'https://opendatacommons.org/licenses/odbl/1-0/', 'https://creativecommons.org/publicdomain/mark/1.0/', 'https://opendatacommons.org/licenses/pddl/1-0/', 'https://creativecommons.org/licenses/by/3.0/legalcode', 'https://creativecommons.org/licenses/by-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nd/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode', 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode', 'https://cocina.sul.stanford.edu/licenses/none')
-      # Access level.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :view, Types::Strict::String.optional.default('dark')
-      # Download access level.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :download, Types::Strict::String.optional.default('none')
-      # Not used for this access type, must be null.
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :location, Types::Strict::String.optional
-      # Validation of this property is relaxed. See the schema.json for full validation.
-      attribute? :controlledDigitalLending, Types::Strict::Bool.optional.default(false)
     end
   end
 end

--- a/lib/cocina/models/language.rb
+++ b/lib/cocina/models/language.rb
@@ -5,7 +5,7 @@ module Cocina
     # Languages, scripts, symbolic systems, and notations used in all or part of a resource
     # or its descriptive metadata.
     class Language < Struct
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
+      attribute :appliesTo, Types::Strict::Array.of(AppliesTo).default([].freeze)
       # Code value of the descriptive element.
       attribute? :code, Types::Strict::String
       # The preferred display label to use for the descriptive element in access systems.

--- a/lib/cocina/models/title.rb
+++ b/lib/cocina/models/title.rb
@@ -3,7 +3,6 @@
 module Cocina
   module Models
     class Title < Struct
-      attribute :appliesTo, Types::Strict::Array.of(DescriptiveBasicValue).default([].freeze)
       attribute :structuredValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :parallelValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
       attribute :groupedValue, Types::Strict::Array.of(DescriptiveValue).default([].freeze)
@@ -24,8 +23,6 @@ module Cocina
       # Property model for indicating the encoding, standard, or syntax to which a value
       # conforms (e.g. RDA).
       attribute? :encoding, Standard.optional
-      # Identifiers and URIs associated with the descriptive element.
-      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
       # Property model for indicating the vocabulary, authority, or other origin for a term,
       # code, or identifier.
       attribute? :source, Source.optional
@@ -40,6 +37,9 @@ module Cocina
       attribute? :valueLanguage, DescriptiveValueLanguage.optional
       # URL or other pointer to the location of the value of the descriptive element.
       attribute? :valueAt, Types::Strict::String
+      attribute :appliesTo, Types::Strict::Array.of(AppliesTo).default([].freeze)
+      # Identifiers and URIs associated with the descriptive element.
+      attribute :identifier, Types::Strict::Array.of(DescriptiveIdentifier).default([].freeze)
     end
   end
 end

--- a/schema.json
+++ b/schema.json
@@ -155,19 +155,22 @@
       "allOf": [
         {
           "$ref": "#/$defs/Access"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "copyright": {
+              "$ref": "#/$defs/Copyright"
+            },
+            "useAndReproductionStatement": {
+              "$ref": "#/$defs/UseAndReproductionStatement"
+            },
+            "license": {
+              "$ref": "#/$defs/License"
+            }
+          }
         }
       ],
-      "properties": {
-        "copyright": {
-          "$ref": "#/$defs/Copyright"
-        },
-        "useAndReproductionStatement": {
-          "$ref": "#/$defs/UseAndReproductionStatement"
-        },
-        "license": {
-          "$ref": "#/$defs/License"
-        }
-      },
       "unevaluatedProperties": false
     },
     "AdminPolicyAdministrative": {
@@ -230,18 +233,6 @@
       ],
       "unevaluatedProperties": false
     },
-    "AppliesTo": {
-      "description": "Property model for indicating the parts, aspects, or versions of the resource to which a descriptive element is applicable.",
-      "type": "object",
-      "properties": {
-        "appliesTo": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/DescriptiveBasicValue"
-          }
-        }
-      }
-    },
     "Barcode": {
       "description": "A barcode",
       "oneOf": [
@@ -261,6 +252,28 @@
           "$ref": "#/$defs/CaliforniaHistoricalSocietyBarcode"
         }
       ]
+    },
+    "AppliesTo": {
+      "description": "Value model for appliesTo property.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DescriptiveBasicValue"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "identifier": {
+              "description": "Identifiers and URIs associated with the descriptive element.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/DescriptiveIdentifier"
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "BusinessBarcode": {
       "description": "The barcode associated with a business library DRO, prefixed with 2050",
@@ -672,23 +685,26 @@
     },
     "DROAccess": {
       "type": "object",
-      "properties": {
-        "copyright": {
-          "$ref": "#/$defs/Copyright"
-        },
-        "embargo": {
-          "$ref": "#/$defs/Embargo"
-        },
-        "useAndReproductionStatement": {
-          "$ref": "#/$defs/UseAndReproductionStatement"
-        },
-        "license": {
-          "$ref": "#/$defs/License"
-        }
-      },
       "allOf": [
         {
           "$ref": "#/$defs/Access"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "copyright": {
+              "$ref": "#/$defs/Copyright"
+            },
+            "embargo": {
+              "$ref": "#/$defs/Embargo"
+            },
+            "useAndReproductionStatement": {
+              "$ref": "#/$defs/UseAndReproductionStatement"
+            },
+            "license": {
+              "$ref": "#/$defs/License"
+            }
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -1073,7 +1089,7 @@
       "unevaluatedProperties": false
     },
     "DescriptiveBasicValue": {
-      "description": "Basic value model for descriptive elements. Can only have one of value, parallelValue, groupedValue, or structuredValue.",
+      "description": "Basic value model for descriptive elements. Can only have one of value, parallelValue, groupedValue, or structuredValue. Does not have identifier or appliesTo properties.",
       "type": "object",
       "allOf": [
         {
@@ -1117,13 +1133,6 @@
             },
             "encoding": {
               "$ref": "#/$defs/Standard"
-            },
-            "identifier": {
-              "description": "Identifiers and URIs associated with the descriptive element.",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/DescriptiveIdentifier"
-              }
             },
             "source": {
               "$ref": "#/$defs/Source"
@@ -1203,7 +1212,7 @@
               "required": ["groupedValue"],
               "properties": {
                 "groupedValue": {
-                  "minItems": 2
+                  "minItems": 1
                 }
               }
             }
@@ -1349,59 +1358,42 @@
         }
       }
     },
-    "DescriptiveValue": {
-      "description": "Default value model for descriptive elements.",
+    "DescriptiveIdentifier": {
+      "description": "Default value model for identifiers.",
       "type": "object",
-      "properties": {
-        "appliesTo": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/DescriptiveBasicValue"
-          }
-        }
-      },
       "allOf": [
         {
-          "$ref": "#/$defs/DescriptiveStructuredValue"
-        },
-        {
-          "$ref": "#/$defs/DescriptiveParallelValue"
-        },
-        {
-          "$ref": "#/$defs/DescriptiveGroupedValue"
+          "$ref": "#/$defs/DescriptiveBasicValue"
         },
         {
           "type": "object",
           "properties": {
-            "value": {
-              "description": "String or integer value of the descriptive element.",
-              "oneOf": [
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "type": {
-              "description": "Type of value provided by the descriptive element. See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.",
-              "type": "string"
-            },
-            "status": {
-              "description": "Status of the descriptive element value relative to other instances of the element.",
-              "type": "string"
-            },
-            "code": {
-              "description": "Code value of the descriptive element.",
-              "type": "string"
-            },
-            "uri": {
-              "description": "URI value of the descriptive element.",
-              "type": "string"
-            },
-            "standard": {
-              "$ref": "#/$defs/Standard"
-            },
-            "encoding": {
-              "$ref": "#/$defs/Standard"
+            "appliesTo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/AppliesTo"
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "DescriptiveValue": {
+      "description": "Default value model for descriptive elements.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DescriptiveBasicValue"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "appliesTo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/AppliesTo"
+              }
             },
             "identifier": {
               "description": "Identifiers and URIs associated with the descriptive element.",
@@ -1409,121 +1401,6 @@
               "items": {
                 "$ref": "#/$defs/DescriptiveIdentifier"
               }
-            },
-            "source": {
-              "$ref": "#/$defs/Source"
-            },
-            "displayLabel": {
-              "description": "The preferred display label to use for the descriptive element in access systems.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "qualifier": {
-              "description": "A term providing information about the circumstances of the statement (e.g., approximate dates).",
-              "type": "string"
-            },
-            "note": {
-              "description": "Other information related to the descriptive element.",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/DescriptiveValue"
-              }
-            },
-            "valueLanguage": {
-              "$ref": "#/$defs/DescriptiveValueLanguage"
-            },
-            "valueAt": {
-              "description": "URL or other pointer to the location of the value of the descriptive element.",
-              "type": "string"
-            }
-          }
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "DescriptiveIdentifier": {
-      "description": "Value model for descriptive identifiers. Same as DescriptiveValue but omits the identifier property to prevent infinite recursion.",
-      "type": "object",
-      "properties": {
-        "appliesTo": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/DescriptiveBasicValue"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/$defs/DescriptiveStructuredValue"
-        },
-        {
-          "$ref": "#/$defs/DescriptiveParallelValue"
-        },
-        {
-          "$ref": "#/$defs/DescriptiveGroupedValue"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "value": {
-              "description": "String or integer value of the descriptive element.",
-              "oneOf": [
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "type": {
-              "description": "Type of value provided by the descriptive element. See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.",
-              "type": "string"
-            },
-            "status": {
-              "description": "Status of the descriptive element value relative to other instances of the element.",
-              "type": "string"
-            },
-            "code": {
-              "description": "Code value of the descriptive element.",
-              "type": "string"
-            },
-            "uri": {
-              "description": "URI value of the descriptive element.",
-              "type": "string"
-            },
-            "standard": {
-              "$ref": "#/$defs/Standard"
-            },
-            "encoding": {
-              "$ref": "#/$defs/Standard"
-            },
-            "source": {
-              "$ref": "#/$defs/Source"
-            },
-            "displayLabel": {
-              "description": "The preferred display label to use for the descriptive element in access systems.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "qualifier": {
-              "description": "A term providing information about the circumstances of the statement (e.g., approximate dates).",
-              "type": "string"
-            },
-            "note": {
-              "description": "Other information related to the descriptive element.",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/DescriptiveValue"
-              }
-            },
-            "valueLanguage": {
-              "$ref": "#/$defs/DescriptiveValueLanguage"
-            },
-            "valueAt": {
-              "description": "URL or other pointer to the location of the value of the descriptive element.",
-              "type": "string"
             }
           }
         }
@@ -2012,7 +1889,7 @@
         "appliesTo": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/DescriptiveBasicValue"
+            "$ref": "#/$defs/AppliesTo"
           }
         },
         "code": {


### PR DESCRIPTION
## Why was this change made? 🤔
* We were adding `anyOf` requirements to `DescriptiveBasicValues` that we intended to be applied more broadly to `DescriptiveValues`.
* Per @arcadiafalcone, we are not yet ready to require `groupedValue` to have multiple children.
* Classes hadn't been regenerated after recent schema changes.


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-18.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
