### PR TITLE
Adds marc date validator.

### DIFF
--- a/lib/cocina/models/validators/description_date_time_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_date_time_visitor_validator.rb
@@ -7,7 +7,7 @@ module Cocina
     module Validators
       # Validates that dates of known types are type-valid using the visitor pattern.
       class DescriptionDateTimeVisitorValidator < BaseDescriptionVisitorValidator
-        VALIDATABLE_TYPES = %w[edtf iso8601 w3cdtf].freeze
+        VALIDATABLE_TYPES = %w[edtf iso8601 marc w3cdtf].freeze
         VALID_ENCODING_CODES = %w[edtf iso8601 marc temper w3cdtf].freeze
 
         def visit_hash(hash:, path:) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
@@ -134,6 +134,10 @@ module Cocina
 
         def valid_w3cdtf?(value)
           W3cdtfValidator.validate(value)
+        end
+
+        def valid_marc?(value)
+          MarcDateValidator.validate(value)
         end
       end
     end

--- a/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     end
   end
 
-  context 'when no dates of validatable type present' do
+  context 'when marc date with valid value present' do
     let(:props) do
       {
         event: [
@@ -72,6 +72,8 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
       ['w3cdtf', '1997-07-16T19:20+01:00', true],
       ['w3cdtf', '1997-07-16T19:20:30+01:00', true],
       ['w3cdtf', '1997-07-16T19:20:30.45+01:00', true],
+      # MARC cases covered by the MarcDateValidator tests
+      ['marc', '1963', true],
       # Type-specific cases
       ['edtf', '-3999', true],
       ['iso8601', '-3999', false],


### PR DESCRIPTION
closes #841

## Why was this change made? 🤔
Per ticket.


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-18.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
