### PR TITLE
Adds title source code validator.

### DIFF
--- a/lib/cocina/models/validators/composite_description_validator.rb
+++ b/lib/cocina/models/validators/composite_description_validator.rb
@@ -14,7 +14,8 @@ module Cocina
           DescriptionDateTimeVisitorValidator,
           DescriptionEventDateVisitorValidator,
           DescriptionSubjectTemporalEncodingVisitorValidator,
-          DescriptionLocationSourceCodeVisitorValidator
+          DescriptionLocationSourceCodeVisitorValidator,
+          DescriptionTitleSourceCodeVisitorValidator
         ].freeze
 
         def self.validate(clazz, attributes)

--- a/lib/cocina/models/validators/description_title_source_code_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_title_source_code_visitor_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates title.source.code values against name_title_source_codes.yml.
+      class DescriptionTitleSourceCodeVisitorValidator < BaseDescriptionVisitorValidator
+        def validate!
+          return if error_paths.empty?
+
+          raise ValidationError, "Unrecognized title source codes in description: #{error_paths.join(', ')}"
+        end
+
+        def visit_hash(hash:, path:)
+          return unless title_path?(path)
+
+          source_code = hash.dig(:source, :code)
+          return unless source_code
+          return if valid_codes.include?(source_code.downcase)
+
+          error_paths << "#{path_to_s(path)}.source.code (#{source_code})"
+        end
+
+        private
+
+        def error_paths
+          @error_paths ||= []
+        end
+
+        def title_path?(path)
+          # Match entries in a title array (e.g., [:title, 0] or [:relatedResource, 0, :title, 0]).
+          path.length >= 2 && path[-1].is_a?(Integer) && path[-2].to_s == 'title'
+        end
+
+        # rubocop:disable Style/ClassVars
+        def valid_codes
+          @@valid_codes ||= YAML.load_file(::File.expand_path('../../../../name_title_source_codes.yml', __dir__)).to_set(&:downcase)
+        end
+        # rubocop:enable Style/ClassVars
+      end
+    end
+  end
+end

--- a/name_title_source_codes.yml
+++ b/name_title_source_codes.yml
@@ -1,0 +1,46 @@
+---
+# Name and title authority source codes from https://www.loc.gov/standards/sourcelist/name-title.html
+# Plus additional codes used in MODS records
+- abne
+- anb
+- banqa
+- bibalex
+- bibbi
+- bnfnaf
+- cantic
+- ccucaut
+- cerlt
+- ckhw
+- conorcg
+- conorsi
+- conorsr
+- czenas
+- dib
+- fautor
+- finaf
+- gkd
+- gnd
+- hapi
+- hkcan
+- iconauth
+- idref
+- lacnaf
+- mitos
+- naf
+- nalnaf
+- nli
+- nlmnaf
+- nta
+- ntc
+- ntd
+- nznb
+- sanb
+- snac
+- sucnsaf
+- teka
+- twnaf
+- ulan
+- unbisn
+- vera
+- viaf
+- dnlm

--- a/spec/cocina/models/validators/description_title_source_code_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_title_source_code_visitor_validator_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::DescriptionTitleSourceCodeVisitorValidator do
+  let(:clazz) { Cocina::Models::Description }
+  let(:validate) { Cocina::Models::Validators::CompositeDescriptionValidator.new(clazz, props, validators: [described_class]).validate }
+
+  let(:base_props) do
+    {
+      title: [{ value: 'Test Title' }],
+      purl: 'https://purl.stanford.edu/bc123df4567'
+    }.with_indifferent_access
+  end
+
+  describe 'when title has no source' do
+    let(:props) { base_props.merge(title: [{ value: 'A Title' }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when title has source without code' do
+    let(:props) { base_props.merge(title: [{ value: 'A Title', source: { uri: 'https://example.com' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when title has a valid source code (naf)' do
+    let(:props) { base_props.merge(title: [{ value: 'Smith, John', source: { code: 'naf' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when title has a valid source code (viaf)' do
+    let(:props) { base_props.merge(title: [{ value: 'Smith, John', source: { code: 'viaf' } }]) }
+
+    it 'does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when title has a valid source code with different case' do
+    let(:props) { base_props.merge(title: [{ value: 'Smith, John', source: { code: 'NAF' } }]) }
+
+    it 'is case-insensitive and does not raise' do
+      expect { validate }.not_to raise_error
+    end
+  end
+
+  describe 'when title has an invalid source code' do
+    let(:props) { base_props.merge(title: [{ value: 'Test', source: { code: 'bogussource' } }]) }
+
+    it 'raises ValidationError with path and code' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized title source codes in description: title1.source.code (bogussource)'
+      )
+    end
+  end
+
+  describe 'when title nested in relatedResource has an invalid source code' do
+    let(:props) do
+      base_props.merge(
+        relatedResource: [
+          {
+            title: [
+              { value: 'Test', source: { code: 'invalidsource' } }
+            ]
+          }
+        ]
+      )
+    end
+
+    it 'raises ValidationError with nested path' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized title source codes in description: relatedResource1.title1.source.code (invalidsource)'
+      )
+    end
+  end
+
+  describe 'when using RequestDescription class' do
+    let(:clazz) { Cocina::Models::RequestDescription }
+    let(:props) { base_props.merge(title: [{ value: 'Test', source: { code: 'invalid' } }]) }
+
+    it 'raises ValidationError' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        'Unrecognized title source codes in description: title1.source.code (invalid)'
+      )
+    end
+  end
+end


### PR DESCRIPTION
closes #1116

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
`bin/validate-data cocina-head-versions-prod-2026-06-22.jsonl.xz`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
