### PR TITLE
Make label default to an empty string

### DIFF
--- a/lib/cocina/models/admin_policy.rb
+++ b/lib/cocina/models/admin_policy.rb
@@ -15,7 +15,7 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*AdminPolicy::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       attribute :version, Types::Strict::Integer
       # Administrative properties for an AdminPolicy
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })

--- a/lib/cocina/models/admin_policy_lite.rb
+++ b/lib/cocina/models/admin_policy_lite.rb
@@ -13,7 +13,7 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*AdminPolicyLite::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       attribute :version, Types::Strict::Integer
       # Administrative properties for an AdminPolicy
       # Validation of this property is relaxed. See the schema.json for full validation.

--- a/lib/cocina/models/admin_policy_with_metadata.rb
+++ b/lib/cocina/models/admin_policy_with_metadata.rb
@@ -16,7 +16,7 @@ module Cocina
       attribute :type, Types::Strict::String.enum(*AdminPolicyWithMetadata::TYPES)
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       attribute :version, Types::Strict::Integer
       # Administrative properties for an AdminPolicy
       attribute(:administrative, AdminPolicyAdministrative.default { AdminPolicyAdministrative.new })

--- a/lib/cocina/models/collection.rb
+++ b/lib/cocina/models/collection.rb
@@ -23,7 +23,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a Collection.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the Collection within SDR.
       attribute :version, Types::Strict::Integer
       # Access metadata for collections

--- a/lib/cocina/models/collection_lite.rb
+++ b/lib/cocina/models/collection_lite.rb
@@ -21,7 +21,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a Collection.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the Collection within SDR.
       attribute :version, Types::Strict::Integer
       # Access metadata for collections

--- a/lib/cocina/models/collection_with_metadata.rb
+++ b/lib/cocina/models/collection_with_metadata.rb
@@ -22,7 +22,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a Collection.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the Collection within SDR.
       attribute :version, Types::Strict::Integer
       # Access metadata for collections

--- a/lib/cocina/models/dro.rb
+++ b/lib/cocina/models/dro.rb
@@ -33,7 +33,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a DRO.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the DRO within SDR.
       attribute :version, Types::Strict::Integer
       attribute(:access, DROAccess.default { DROAccess.new })

--- a/lib/cocina/models/dro_lite.rb
+++ b/lib/cocina/models/dro_lite.rb
@@ -31,7 +31,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a DRO.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the DRO within SDR.
       attribute :version, Types::Strict::Integer
       # Validation of this property is relaxed. See the schema.json for full validation.

--- a/lib/cocina/models/dro_with_metadata.rb
+++ b/lib/cocina/models/dro_with_metadata.rb
@@ -32,7 +32,7 @@ module Cocina
       # example: druid:bc123df4567
       attribute :externalIdentifier, Druid
       # Primary processing label (can be same as title) for a DRO.
-      attribute :label, Types::Strict::String
+      attribute? :label, Types::Strict::String.default('')
       # Version for the DRO within SDR.
       attribute :version, Types::Strict::Integer
       attribute(:access, DROAccess.default { DROAccess.new })

--- a/schema.json
+++ b/schema.json
@@ -2656,7 +2656,8 @@
           ]
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "type": "integer",
@@ -2716,7 +2717,8 @@
           ]
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "type": "integer",
@@ -2776,7 +2778,8 @@
           ]
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "type": "integer",

--- a/schema.json
+++ b/schema.json
@@ -107,7 +107,8 @@
           "$ref": "#/$defs/Druid"
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "type": "integer"
@@ -123,7 +124,6 @@
         "cocinaVersion",
         "administrative",
         "externalIdentifier",
-        "label",
         "type",
         "version"
       ]
@@ -361,7 +361,8 @@
         },
         "label": {
           "description": "Primary processing label (can be same as title) for a Collection.",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "description": "Version for the Collection within SDR.",
@@ -384,7 +385,6 @@
         "cocinaVersion",
         "description",
         "externalIdentifier",
-        "label",
         "type",
         "version",
         "access",
@@ -634,7 +634,8 @@
         "externalIdentifier": { "$ref": "#/$defs/Druid" },
         "label": {
           "description": "Primary processing label (can be same as title) for a DRO.",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "version": {
           "description": "Version for the DRO within SDR.",
@@ -653,7 +654,6 @@
         "administrative",
         "description",
         "externalIdentifier",
-        "label",
         "type",
         "version",
         "identification",

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -561,6 +561,32 @@ RSpec.describe Cocina::Models do
         end
       end
     end
+
+    context 'when label is not provided' do
+      context 'with a DRO type' do
+        let(:data) { build(:dro).to_h.except(:label) }
+
+        it 'defaults label to empty string' do
+          expect(model_build.label).to eq('')
+        end
+      end
+
+      context 'with a Collection type' do
+        let(:data) { build(:collection).to_h.except(:label) }
+
+        it 'defaults label to empty string' do
+          expect(model_build.label).to eq('')
+        end
+      end
+
+      context 'with an AdminPolicy type' do
+        let(:data) { build(:admin_policy).to_h.except(:label) }
+
+        it 'defaults label to empty string' do
+          expect(model_build.label).to eq('')
+        end
+      end
+    end
   end
 
   describe '.build_request' do


### PR DESCRIPTION
## Why was this change made? 🤔
Preparation for future work to remove label usage in consuming apps and then remove from cocina-models altogether. We want to be able to remove `label` from code that creates RequestDROs or RequestCollections, before we remove it from the schema, to avoid disruption with apps that may read it for a CSV. We already have a lot of objects with `label` as an empty string anyway. 

## How was this change tested? 🤨
CI