### PR TITLE
Improve readability of error messages from JSON schema validation

### DIFF
--- a/lib/cocina/models/validators/json_schema_validator.rb
+++ b/lib/cocina/models/validators/json_schema_validator.rb
@@ -67,7 +67,7 @@ module Cocina
           evaluation = self.class.validator_for(method_name).evaluate(attributes.as_json)
           return if evaluation.valid?
 
-          raise ValidationError, "When validating #{method_name}: " + filtered_error_messages(evaluation).join(', ')
+          raise ValidationError, "When validating #{method_name}: " + filtered_error_messages(evaluation).join('; ')
         end
 
         private
@@ -90,7 +90,7 @@ module Cocina
           denoised.flat_map { |d| format_detail(d) }.uniq
         end
 
-        # Removes two categories of cascade noise produced by `unevaluatedProperties: false`:
+        #  Removes three categories of cascade noise from errors:
         #
         #   1. falseSchema errors — every `unevaluatedProperties: false` on a sub-path emits
         #      a "False schema does not allow …" entry for each matched value.  These are
@@ -100,8 +100,28 @@ module Cocina
         #      is a known model attribute — these arise because allOf/$ref composition means
         #      the validator can't prove top-level properties were "evaluated", even though
         #      they are valid model fields.
+        #
+        #   3. anyOf branch noise — when each branch requires a different property, all failing
+        #      branches emit a separate "required" error at the same path. Collapse into one
+        #      "needs to include at least one of: …" message.
         def denoise(details)
-          details.reject { |d| false_schema_noise?(d) || root_unevaluated_noise?(d) }
+          filtered = details.reject { |detail| false_schema_noise?(detail) || root_unevaluated_noise?(detail) }
+          collapse_anyof_required(filtered)
+        end
+
+        def collapse_anyof_required(details)
+          # instanceLocation is the input data that failed. Group errors for each failing data location.
+          details.group_by { |detail| detail[:instanceLocation] }.flat_map do |loc, group|
+            # splits errors into "required" anyOf errors and others (minItems, unevaluatedProperties)
+            required, others = group.partition { |detail| detail[:errors].keys == ['required'] }
+            next group if required.size <= 1
+
+            # Extract property name from "required" messages such as, '"url" is a required property'
+            props = required.filter_map { |detail| detail[:errors]['required'][/"([^"]+)"/, 1] }.uniq
+            # Put the data path at the start of the message; blank instanceLocation so format_detail won't also append it
+            msg = "#{loc} needs to include at least one of the following: #{props.join(', ')}"
+            others + [required.first.merge(instanceLocation: '', errors: { 'required' => msg })]
+          end
         end
 
         def false_schema_noise?(detail)
@@ -120,11 +140,31 @@ module Cocina
           unexpected.all? { |prop| known_root_properties.include?(prop) }
         end
 
+        # Formats error details hash into more user-friendly messages
+        # A detail can carry multiple errors (one per JSON Schema keyword), so this returns an array.
+        # minItems errors get a dedicated formatter; everything else uses the generic one.
         def format_detail(detail)
           loc = detail[:instanceLocation]
-          detail[:errors].map do |_keyword, message|
-            loc.empty? ? message : "#{message} at #{loc}"
+          detail[:errors].map do |keyword, message|
+            keyword == 'minItems' ? format_min_items(message, loc) : format_generic(message, loc)
           end
+        end
+
+        # Rewrites messages regarding minItems validation
+        # "[] has less than 1 item at /event/0/date " is rewritten to "/event/0/date is empty but should have at least 1 item"
+        # Arrays with items but fewer than the minimum will be rewritten to "/event/0/date should have at least 2 items"
+        def format_min_items(message, loc)
+          # extract minimum number of items from message
+          min = message[/less than (\d+)/, 1] || '1'
+          # pluralize "item" when appropriate
+          items = min == '1' ? 'item' : 'items'
+          # determine if the message is about an empty array or an non-empty array without enough items
+          prefix = message.start_with?('[]') ? "#{loc} is empty but" : loc.to_s
+          "#{prefix} should have at least #{min} #{items}"
+        end
+
+        def format_generic(message, loc)
+          loc.empty? ? message : "#{message} at #{loc}"
         end
       end
     end

--- a/spec/cocina/models/validators/json_schema_validator_spec.rb
+++ b/spec/cocina/models/validators/json_schema_validator_spec.rb
@@ -127,6 +127,53 @@ RSpec.describe Cocina::Models::Validators::JsonSchemaValidator do
         }
       end
     end
+
+    context 'when anyOf branches each require a different property' do
+      context 'when all branches fail with required errors' do
+        # Simulates DescriptiveAccessMetadata: anyOf with 6 branches, each requiring one property.
+        # All branches fail when access: {} or access: { note: [] } is given.
+        let(:details) do
+          %w[url physicalLocation digitalLocation accessContact digitalRepository note].map do |prop|
+            { valid: false, instanceLocation: '/access', errors: { 'required' => "\"#{prop}\" is a required property" } }
+          end
+        end
+
+        it 'collapses to a single "needs to include at least one of" message' do
+          expect { validate }.to raise_error(Cocina::Models::ValidationError) { |error|
+            expect(error.message).to include('/access needs to include at least one of the following: url, physicalLocation, digitalLocation, accessContact, digitalRepository, note')
+            expect(error.message).not_to include('"url" is a required property')
+          }
+        end
+      end
+
+      context 'when one branch fails with minItems instead of required' do
+        let(:required_details) do
+          %w[url physicalLocation digitalLocation accessContact digitalRepository].map do |prop|
+            { valid: false, instanceLocation: '/access', errors: { 'required' => "\"#{prop}\" is a required property" } }
+          end
+        end
+        let(:min_items_detail) { { valid: false, instanceLocation: '/access/note', errors: { 'minItems' => '[] has less than 1 item' } } }
+        let(:details) { required_details + [min_items_detail] }
+
+        it 'collapses required errors and preserves the minItems error' do
+          expect { validate }.to raise_error(Cocina::Models::ValidationError) { |error|
+            expect(error.message).to include('/access needs to include at least one of the following: url, physicalLocation, digitalLocation, accessContact, digitalRepository')
+            expect(error.message).to include('/access/note is empty but should have at least 1 item')
+          }
+        end
+      end
+
+      context 'when only one branch fails with a required error' do
+        let(:details) { [{ valid: false, instanceLocation: '/access', errors: { 'required' => '"url" is a required property' } }] }
+
+        it 'does not collapse a single required error' do
+          expect { validate }.to raise_error(Cocina::Models::ValidationError) { |error|
+            expect(error.message).to include('"url" is a required property at /access')
+            expect(error.message).not_to include('needs to include at least one of the following')
+          }
+        end
+      end
+    end
   end
 
   # AdminPolicy.externalIdentifier must be a valid druid

--- a/spec/cocina/models_spec.rb
+++ b/spec/cocina/models_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{"title" is a required property at /description/relatedResource})
+                                                  %r{/description/relatedResource/0 needs to include at least one of the following: title, contributor, event, note, identifier, valueAt, purl, access})
           end
         end
 
@@ -246,7 +246,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/title})
+                                                  %r{/description/relatedResource/0/title is empty but should have at least 1 item; /description/relatedResource/0 needs to include at least one of the following: contributor, event, note, identifier, valueAt, purl, access})
           end
         end
 
@@ -255,7 +255,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/contributor})
+                                                  %r{/description/relatedResource/0 needs to include at least one of the following: title, event, note, identifier, valueAt, purl, access; /description/relatedResource/0/contributor is empty but should have at least 1 item})
           end
         end
 
@@ -264,7 +264,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/event})
+                                                  %r{/description/relatedResource/0/event is empty but should have at least 1 item})
           end
         end
 
@@ -273,7 +273,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{"url" is a required property at /description/relatedResource/0/access})
+                                                  %r{/description/relatedResource/0/access needs to include at least one of the following: url, physicalLocation, digitalLocation, accessContact, digitalRepository, note; /description/relatedResource/0 needs to include at least one of the following: title, contributor, event, note, identifier, valueAt, purl})
           end
         end
 
@@ -282,7 +282,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/note})
+                                                  %r{/description/relatedResource/0 needs to include at least one of the following: title, contributor, event, identifier, valueAt, purl, access; /description/relatedResource/0/note is empty but should have at least 1 item})
           end
         end
 
@@ -291,7 +291,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/identifier})
+                                                  %r{/description/relatedResource/0 needs to include at least one of the following: title, contributor, event, note, valueAt, purl, access; /description/relatedResource/0/identifier is empty but should have at least 1 item})
           end
         end
 
@@ -318,7 +318,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/access/url})
+                                                  %r{/description/relatedResource/0/access/url is empty but should have at least 1 item})
           end
         end
 
@@ -327,7 +327,7 @@ RSpec.describe Cocina::Models do
 
           it 'rejects the relatedResource entry' do
             expect { model_build }.to raise_error(Cocina::Models::ValidationError,
-                                                  %r{has less than 1 item at /description/relatedResource/0/access/physicalLocation})
+                                                  %r{/description/relatedResource/0/access/physicalLocation is empty but should have at least 1 item})
           end
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔
Refs sul-dlss/argo#1145 and (partially) https://github.com/sul-dlss/cocina-models/issues/1164.

Reformats validation error messages produced by `jsonschema_rs` into incrementally more readable and less redundant text. Continues in the same vein as existing de-noising functions. I used Claude to work through how to parse the jsonschema error message text, but added comments to help make what is happening more transparent. 

This would change:
```[] has less than 1 item at /event/0/date, "contributor" is a required property at /event/0, "location" is a required property at /event/0, "identifier" is a required property at /event/0, "note" is a required property at /event/0, "structuredValue" is a required property at /event/0, "parallelEvent" is a required property at /event/0 ```
to:
```/event/0/date is empty but should have at least 1 item; /event/0 needs to include at least one of the following: contributor, location, identifier, note, structuredValue, parallelEvent```


## How was this change tested? 🤨
CI. 