### PR TITLE
Adds alternative title validation.

### DIFF
--- a/lib/cocina/models/validators/non_alternative_title_validator.rb
+++ b/lib/cocina/models/validators/non_alternative_title_validator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Models
+    module Validators
+      # Validates that at least one title with no type or a type other than "alternative" is present.
+      class NonAlternativeTitleValidator
+        def self.validate(clazz, attributes)
+          new(clazz, attributes).validate
+        end
+
+        def initialize(clazz, attributes)
+          @clazz = clazz
+          @attributes = attributes
+        end
+
+        def validate
+          return unless meets_preconditions?
+
+          return if titles.empty? || titles.any? { |title| title[:type].nil? || title[:type] != 'alternative' }
+
+          raise ValidationError,
+                "At least one title must have no type or a type other than 'alternative'."
+        end
+
+        private
+
+        attr_reader :clazz, :attributes
+
+        def meets_preconditions?
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
+        end
+
+        def titles
+          @titles ||= Array(description_attributes[:title])
+        end
+
+        def description_attributes
+          @description_attributes ||= if [Cocina::Models::Description,
+                                          Cocina::Models::RequestDescription].include?(clazz)
+                                        attributes
+                                      else
+                                        attributes[:description] || {}
+                                      end
+        end
+      end
+    end
+  end
+end

--- a/lib/cocina/models/validators/validator.rb
+++ b/lib/cocina/models/validators/validator.rb
@@ -12,7 +12,8 @@ module Cocina
           PurlValidator,
           CatalogLinksValidator,
           AssociatedNameValidator,
-          MarcRelatorRoleValidator
+          MarcRelatorRoleValidator,
+          NonAlternativeTitleValidator
         ].freeze
 
         def self.validate(clazz, attributes, validators: VALIDATORS)

--- a/spec/cocina/models/validators/non_alternative_title_validator_spec.rb
+++ b/spec/cocina/models/validators/non_alternative_title_validator_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
+  let(:clazz) { Cocina::Models::Description }
+
+  let(:props) { {} }
+
+  describe '#validate' do
+    let(:validate) { described_class.validate(clazz, props) }
+
+    context 'when no description' do
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when title has no type' do
+      let(:props) do
+        { title: [{ value: 'Gaudy night' }] }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when title has a non-alternative type' do
+      let(:props) do
+        { title: [{ value: 'Gaudy night', type: 'main title' }] }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when one of multiple titles is non-alternative' do
+      let(:props) do
+        {
+          title: [
+            { value: 'Five red herrings' },
+            { value: 'Suspicious characters', type: 'alternative' }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when the only title is alternative' do
+      let(:props) do
+        { title: [{ value: 'Suspicious characters', type: 'alternative' }] }
+      end
+
+      it 'raises' do
+        expect do
+          validate
+        end.to raise_error(Cocina::Models::ValidationError,
+                           "At least one title must have no type or a type other than 'alternative'.")
+      end
+    end
+
+    context 'when relatedResource has only an alternative title' do
+      let(:props) do
+        {
+          title: [{ value: 'Gaudy night' }],
+          relatedResource: [
+            { title: [{ value: 'Suspicious characters', type: 'alternative' }] }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when relatedResource has no title' do
+      let(:props) do
+        {
+          title: [{ value: 'Gaudy night' }],
+          relatedResource: [
+            { contributor: [{ name: [{ value: 'Sayers, Dorothy L.' }] }] }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when relatedResource has a valid title' do
+      let(:props) do
+        {
+          title: [{ value: 'Gaudy night' }],
+          relatedResource: [
+            { title: [{ value: 'Gaudy night', type: 'supplied' }] }
+          ]
+        }
+      end
+
+      it 'does not raise' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#meets_preconditions?' do
+    let(:validator) { described_class.new(clazz, props) }
+
+    let(:meets_preconditions) { validator.send(:meets_preconditions?) }
+
+    context 'when RequestDescription' do
+      let(:clazz) { Cocina::Models::RequestDescription }
+
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
+    end
+
+    context 'when Description' do
+      let(:clazz) { Cocina::Models::Description }
+
+      it 'meets preconditions' do
+        expect(meets_preconditions).to be true
+      end
+    end
+
+    context 'when DRO' do
+      let(:clazz) { Cocina::Models::DRO }
+
+      it 'does not meet preconditions' do
+        expect(meets_preconditions).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #1160

## Why was this change made? 🤔
Per ticket


## How was this change tested? 🤨
Unit, `bin/validate-data`

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
