### PR TITLE
ensure we do not check in cocina dump file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # rspec failure tracking
 .rspec_status
 
+*.jsonl.zst
 *.jq.txt
 *.jsonl.xz
 *.csv


### PR DESCRIPTION
## Why was this change made? 🤔

Add new file format for cocina dump to gitignore