### PR TITLE
Refactor NonAlternativeTitleValidator for clarity

### DIFF
--- a/lib/cocina/models/validators/non_alternative_title_validator.rb
+++ b/lib/cocina/models/validators/non_alternative_title_validator.rb
@@ -3,10 +3,10 @@
 module Cocina
   module Models
     module Validators
-      # Validates that at least one title with no type or a type other than "alternative" is present.
+      # Validates that not all titles have type 'alternative'
       class NonAlternativeTitleValidator
-        def self.validate(clazz, attributes)
-          new(clazz, attributes).validate
+        def self.validate(...)
+          new(...).validate
         end
 
         def initialize(clazz, attributes)
@@ -17,10 +17,9 @@ module Cocina
         def validate
           return unless meets_preconditions?
 
-          return if titles.empty? || titles.any? { |title| title[:type].nil? || title[:type] != 'alternative' }
+          return unless titles.all? { |title| title[:type] == 'alternative' }
 
-          raise ValidationError,
-                "At least one title must have no type or a type other than 'alternative'."
+          raise ValidationError, "At least one title must have no type or a type other than 'alternative'."
         end
 
         private
@@ -28,20 +27,12 @@ module Cocina
         attr_reader :clazz, :attributes
 
         def meets_preconditions?
-          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz)
+          [Cocina::Models::Description, Cocina::Models::RequestDescription].include?(clazz) &&
+            titles.present?
         end
 
         def titles
-          @titles ||= Array(description_attributes[:title])
-        end
-
-        def description_attributes
-          @description_attributes ||= if [Cocina::Models::Description,
-                                          Cocina::Models::RequestDescription].include?(clazz)
-                                        attributes
-                                      else
-                                        attributes[:description] || {}
-                                      end
+          @titles ||= Array(attributes[:title])
         end
       end
     end

--- a/spec/cocina/models/validators/non_alternative_title_validator_spec.rb
+++ b/spec/cocina/models/validators/non_alternative_title_validator_spec.rb
@@ -4,30 +4,27 @@ require 'spec_helper'
 
 RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
   let(:clazz) { Cocina::Models::Description }
-
-  let(:props) { {} }
+  let(:attributes) { { title: [{ value: 'Gaudy night' }] } }
 
   describe '#validate' do
-    let(:validate) { described_class.validate(clazz, props) }
+    let(:validate) { described_class.validate(clazz, attributes) }
 
     context 'when no description' do
+      let(:attributes) { {} }
+
       it 'does not raise' do
         expect { validate }.not_to raise_error
       end
     end
 
     context 'when title has no type' do
-      let(:props) do
-        { title: [{ value: 'Gaudy night' }] }
-      end
-
       it 'does not raise' do
         expect { validate }.not_to raise_error
       end
     end
 
     context 'when title has a non-alternative type' do
-      let(:props) do
+      let(:attributes) do
         { title: [{ value: 'Gaudy night', type: 'main title' }] }
       end
 
@@ -37,7 +34,7 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
     end
 
     context 'when one of multiple titles is non-alternative' do
-      let(:props) do
+      let(:attributes) do
         {
           title: [
             { value: 'Five red herrings' },
@@ -52,7 +49,7 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
     end
 
     context 'when the only title is alternative' do
-      let(:props) do
+      let(:attributes) do
         { title: [{ value: 'Suspicious characters', type: 'alternative' }] }
       end
 
@@ -65,7 +62,7 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
     end
 
     context 'when relatedResource has only an alternative title' do
-      let(:props) do
+      let(:attributes) do
         {
           title: [{ value: 'Gaudy night' }],
           relatedResource: [
@@ -80,7 +77,7 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
     end
 
     context 'when relatedResource has no title' do
-      let(:props) do
+      let(:attributes) do
         {
           title: [{ value: 'Gaudy night' }],
           relatedResource: [
@@ -95,7 +92,7 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
     end
 
     context 'when relatedResource has a valid title' do
-      let(:props) do
+      let(:attributes) do
         {
           title: [{ value: 'Gaudy night' }],
           relatedResource: [
@@ -111,32 +108,26 @@ RSpec.describe Cocina::Models::Validators::NonAlternativeTitleValidator do
   end
 
   describe '#meets_preconditions?' do
-    let(:validator) { described_class.new(clazz, props) }
+    subject(:meets_preconditions) { validator.send(:meets_preconditions?) }
 
-    let(:meets_preconditions) { validator.send(:meets_preconditions?) }
+    let(:validator) { described_class.new(clazz, attributes) }
 
     context 'when RequestDescription' do
       let(:clazz) { Cocina::Models::RequestDescription }
 
-      it 'meets preconditions' do
-        expect(meets_preconditions).to be true
-      end
+      it { is_expected.to be true }
     end
 
     context 'when Description' do
       let(:clazz) { Cocina::Models::Description }
 
-      it 'meets preconditions' do
-        expect(meets_preconditions).to be true
-      end
+      it { is_expected.to be true }
     end
 
     context 'when DRO' do
       let(:clazz) { Cocina::Models::DRO }
 
-      it 'does not meet preconditions' do
-        expect(meets_preconditions).to be false
-      end
+      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

- Simplify logic to check all titles for `alternative` type, raising error only if all are `alternative`
- Remove unnecessary `#description_attributes` indirection for title extraction, using `attributes[:title]` directly for clarity and maintainability
- Update `#meets_preconditions?` to require presence of titles, preventing validation on empty input
- Refactor specs to use consistent `attributes` naming and streamline test cases for readability and maintainability
- Ensure validator only applies to `Description` and `RequestDescription`, clarifying intent

# How was this change tested?

CI
