### PR TITLE
collect all validation errors at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,16 @@ If there is a possibility that a model, mapping, or validation change will confl
 
 ### How validation errors are reported
 
-`bin/validate-data` reports **only the first error raised for each object**, then moves on to the next druid. The error counts and `validate-data-errors.csv` should therefore be read as a first pass only: an object listed with one error may have several, and an object's error may change (rather than disappear) after remediation. This is a property of how validation short-circuits at the first exception.
+`bin/validate-data` reports **every validation error it can find for each object**, not just the first one raised. `validate-data-errors.csv` therefore has one row per error, and an object with several problems appears on several rows. The summary counts "Lines with errors" (objects) and "Total errors reported" separately.
 
-The practical consequences for a remediation cycle:
+This takes some work, because `Cocina::Models.build` deliberately stops at the first exception, in three separate places: `Validators::Validator` stops at the first validator that raises; the composite description and structural validators walk the object once to feed all of their sub-validators but then stop at the first sub-validator that raises; and validation happens in two passes (the object, then its nested `Description`), so a top-level failure aborts construction before the description is validated at all.
 
-* Fixing every error in the report does not guarantee the next run will be clean. Expect to iterate: remediate, re-run, repeat until no errors are reported.
-* A schema error and a semantic error (e.g. a purl mismatch) will not appear together for the same object. Schema errors are the exception to the "one error" rule — the JSON schema validator aggregates schema violations into a single message, so those are reported in full.
+`ValidationErrorCollector` (in `bin/`, alongside the script) works around all three from the outside by invoking one validator at a time — with a single validator there is nothing left for a raise to mask. It uses only the public `validators:` keyword the gem already accepts.
+
+Notes on reading the output:
+
+* Objects are validated normally first, and only objects that fail are re-run through the collector. Valid objects cost nothing extra, so this does not meaningfully change how long a full run takes unless there are many invalid objects.
+* If an object fails **JSON schema** validation, that error is reported on its own and the remaining validators are skipped for that object. The schema is authoritative for the shape of the object; once it fails, the other validators are working with data they can't interpret and anything they report is noise or a restatement. Note that the schema validator already aggregates all schema violations into a single message, so nothing is lost. Fixing a schema error may reveal further errors on the next run.
 * `bin/validate-data` has no option to run against a subset of druids, so re-checking remediated objects means another full (~2 hour) run against a fresh export. To re-check just the remediated druids, use `bin/validate-cocina` in DSA with its `-f` option and the `validate-data-errors.csv` produced here (see below).
 
 Alternatively, you can use [validate-cocina](https://github.com/sul-dlss/dor-services-app/blob/main/bin/validate-cocina) for testing. This must be run on the `sdr-infra` VM since it requires deploying a branch of cocina-models.  It is slower than using `bin/validate-data`, but all of the data is completely up to date.

--- a/bin/validate-data
+++ b/bin/validate-data
@@ -20,6 +20,7 @@ require 'json'
 require 'ruby-progressbar'
 require 'optparse'
 require 'csv'
+require_relative 'validation_error_collector'
 
 # Parse command line options
 def parse_options # rubocop:disable Metrics/MethodLength
@@ -106,19 +107,33 @@ def worker_process(reader) # rubocop:disable Metrics/MethodLength
     batch.each do |line_num, line_content|
       json = JSON.parse(line_content)
       druid = json['externalIdentifier']
+      # Fast path: validate exactly as a client of the gem would. Valid objects -- the overwhelming
+      # majority -- cost nothing extra. Only objects that fail take the slower collecting path below.
       Cocina::Models.build(json)
     rescue JSON::ParserError => e
       errors << { line: line_num, error: "JSON Parse Error: #{e.message}" }
-    rescue Cocina::Models::ValidationError => e
-      errors << { line: line_num, druid:, error: "Validation Error: #{e.message}" }
     rescue Cocina::Models::UnknownTypeError => e
+      # Without a resolvable type there is no model class to validate against, so this is the one
+      # failure the collector can add nothing to. Report it directly.
       errors << { line: line_num, druid:, error: "Unknown Type Error: #{e.message}" }
     rescue StandardError => e
-      errors << { line: line_num, druid:, error: "Error: #{e.class} - #{e.message}" }
+      all_errors_for(json, e).each do |message|
+        errors << { line: line_num, druid:, error: message }
+      end
     end
   end
 
   errors
+end
+
+# Re-validate an object that has already failed, collecting every error rather than just the first.
+# Falls back to the originally raised error if the collector somehow turns up nothing, so that a
+# disagreement between the two paths can never make an invalid object look valid.
+def all_errors_for(json, error)
+  messages = ValidationErrorCollector.call(json)
+  messages.presence || ["#{error.class}: #{error.message}"]
+rescue StandardError => e
+  ["#{error.class}: #{error.message}", "Error while collecting all errors: #{e.class} - #{e.message}"]
 end
 
 # Spawn worker processes
@@ -235,34 +250,42 @@ def collect_results(workers, result_readers)
 end
 
 # Print validation summary
-def print_summary(total_lines, errors, elapsed_time) # rubocop:disable Metrics/MethodLength
+def print_summary(total_lines, errors, elapsed_time)
   puts '=' * 80
   puts 'VALIDATION SUMMARY'
   puts '=' * 80
+  # An object can now report more than one error, so lines and errors are counted separately.
+  error_lines = errors.map { |error| error[:line] }.uniq
   puts "Total lines processed: #{total_lines}"
-  puts "Lines with errors: #{errors.length}"
-  puts "Success rate: #{((total_lines - errors.length).to_f / total_lines * 100).round(2)}%"
+  puts "Lines with errors: #{error_lines.length}"
+  puts "Total errors reported: #{errors.length}"
+  puts "Success rate: #{((total_lines - error_lines.length).to_f / total_lines * 100).round(2)}%"
   puts "Time elapsed: #{elapsed_time.round(2)} seconds"
   puts "Throughput: #{(total_lines / elapsed_time).round(0)} lines/second"
 
   return unless errors.any?
 
-  sorted_errors = errors.sort_by { |e| e[:line] }
+  print_error_details(errors, error_lines)
+end
+
+# Print each error and write them all to CSV
+def print_error_details(errors, error_lines)
+  # Sort by message as well as line, so that the several errors an object may report are ordered
+  # deterministically (Ruby's sort_by is not stable) and two runs produce comparable output.
+  sorted_errors = errors.sort_by { |error| [error[:line], error[:error]] }
 
   puts "\n"
   puts 'Error details:'
   puts '-' * 80
-  # Sort errors by line number for better readability
   sorted_errors.each do |error|
     puts "Line #{error[:line]}: #{error[:druid]} - #{error[:error]}"
   end
   puts "\n"
-  puts "Line numbers with errors: #{sorted_errors.map { |e| e[:line] }.join(', ')}"
+  puts "Line numbers with errors: #{error_lines.sort.join(', ')}"
 
+  # One row per error, so an object with several problems appears on several rows.
   CSV.open('validate-data-errors.csv', 'w') do |csv|
-    sorted_errors.each do |error|
-      csv << [error[:druid], error[:error]]
-    end
+    sorted_errors.each { |error| csv << [error[:druid], error[:error]] }
   end
   puts 'Errors written to validate-data-errors.csv'
 end

--- a/bin/validation_error_collector.rb
+++ b/bin/validation_error_collector.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Collects every validation error for a single Cocina object, instead of stopping at the first.
+#
+# `Cocina::Models.build` deliberately short-circuits, in three separate places:
+#
+#   1. `Validators::Validator` runs its validators in sequence; the first one to raise aborts the rest.
+#   2. `CompositeDescriptionValidator` / `CompositeStructuralValidator` walk the object once to feed all of
+#      their sub-validators, then call `validate!` on each in turn. Every sub-validator has therefore
+#      already accumulated its findings, but only the first one to raise is surfaced.
+#   3. Validation happens in two passes -- once for the object itself and again for its nested
+#      `Description` -- and a failure in the first pass aborts construction before the second ever runs.
+#      That means an object failing a top-level validation never has its description validated at all.
+#
+# This class works around all three from the outside, by invoking one validator at a time: with a single
+# validator in the list there is nothing left for a raise to mask. It relies only on the public
+# `validators:` keyword that `Validators::Validator.validate` and the composite validators already accept,
+# so it requires no changes to the gem.
+#
+# This is reporting/remediation tooling for bin/validate-data, not part of the gem's public API. Because it
+# re-walks the description tree once per sub-validator it is several times slower than a plain
+# `Cocina::Models.build`, so callers should use it only for objects already known to be invalid.
+class ValidationErrorCollector
+  # The gem's validation entry point; it accepts a `validators:` list.
+  VALIDATOR = Cocina::Models::Validators::Validator
+  SCHEMA_VALIDATOR = Cocina::Models::Validators::JsonSchemaValidator
+  SEMANTIC_VALIDATORS = (VALIDATOR::VALIDATORS - [SCHEMA_VALIDATOR]).freeze
+  # Composite validators get expanded so that every sub-validator's `validate!` is reached.
+  COMPOSITE_SUB_VALIDATORS = {
+    Cocina::Models::Validators::CompositeDescriptionValidator =>
+      Cocina::Models::Validators::CompositeDescriptionValidator::VALIDATORS,
+    Cocina::Models::Validators::CompositeStructuralValidator =>
+      Cocina::Models::Validators::CompositeStructuralValidator::VALIDATORS
+  }.freeze
+
+  # @param json [Hash] a parsed Cocina JSON serialization
+  # @return [Array<String>] every validation error found; empty if the object is valid
+  def self.call(json)
+    new(json).call
+  end
+
+  def initialize(json)
+    @json = json
+    @hash = json.with_indifferent_access
+    @clazz = resolve_clazz
+  end
+
+  # @return [Array<String>] every validation error found; empty if the object is valid
+  def call
+    return [type_error] unless clazz
+
+    # The schema is authoritative for the shape of the object. When it fails, the semantic validators are
+    # running against data they cannot make sense of, so anything they report is either noise (a
+    # NoMethodError on nil) or a restatement of the schema error. The schema validator already aggregates
+    # and de-noises all schema violations into one message, so nothing is lost by stopping here.
+    schema_error = capture { SCHEMA_VALIDATOR.validate(clazz, hash) }
+    return [schema_error] if schema_error
+
+    semantic_errors + construction_errors
+  end
+
+  private
+
+  attr_reader :json, :hash, :clazz
+
+  # Runs both validation passes: the object itself, then its nested description.
+  def semantic_errors
+    errors = pass_errors(clazz, hash)
+    return errors unless hash[:description].is_a?(Hash)
+
+    errors + pass_errors(Cocina::Models::Description, hash[:description])
+  end
+
+  # @return [Array<String>] errors from running each validator against the given class in isolation
+  def pass_errors(pass_clazz, attributes)
+    SEMANTIC_VALIDATORS.flat_map do |validator|
+      sub_validators = COMPOSITE_SUB_VALIDATORS[validator]
+      if sub_validators
+        composite_errors(validator, sub_validators, pass_clazz, attributes)
+      else
+        Array(capture { VALIDATOR.validate(pass_clazz, attributes, validators: [validator]) })
+      end
+    end
+  end
+
+  # Runs a composite validator once per sub-validator, so that no sub-validator can mask another.
+  def composite_errors(composite, sub_validators, pass_clazz, attributes)
+    sub_validators.filter_map do |sub_validator|
+      capture { composite.new(pass_clazz, attributes, validators: [sub_validator]).validate }
+    end
+  end
+
+  # Type coercion errors that the JSON schema did not catch.
+  def construction_errors
+    Cocina::Models.build(json, validate: false)
+    []
+  rescue StandardError => e
+    ["#{e.class}: #{e.message}"]
+  end
+
+  # @return [String, nil] the error message, or nil if the block did not raise
+  def capture
+    yield
+    nil
+  rescue Cocina::Models::ValidationError => e
+    e.message
+  rescue StandardError => e
+    "#{e.class}: #{e.message}"
+  end
+
+  def type_error
+    return 'Cocina::Models::ValidationError: Type field not found' if hash[:type].blank?
+
+    "Cocina::Models::UnknownTypeError: Unknown type: '#{hash[:type]}'"
+  end
+
+  # Mirrors the class dispatch in `Cocina::Models.build`, whose `type_for` and `has_metadata?` are private.
+  # Kept honest by a spec that compares this against the class `Cocina::Models.build` actually returns.
+  def resolve_clazz
+    case hash[:type]
+    when *Cocina::Models::DRO::TYPES
+      with_metadata? ? Cocina::Models::DROWithMetadata : Cocina::Models::DRO
+    when *Cocina::Models::Collection::TYPES
+      with_metadata? ? Cocina::Models::CollectionWithMetadata : Cocina::Models::Collection
+    when *Cocina::Models::AdminPolicy::TYPES
+      with_metadata? ? Cocina::Models::AdminPolicyWithMetadata : Cocina::Models::AdminPolicy
+    end
+  end
+
+  def with_metadata?
+    Cocina::Models::METADATA_KEYS.any? { |key| hash.key?(key) }
+  end
+end

--- a/spec/bin/validation_error_collector_spec.rb
+++ b/spec/bin/validation_error_collector_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../bin/validation_error_collector'
+
+RSpec.describe ValidationErrorCollector do
+  subject(:errors) { described_class.call(json) }
+
+  let(:dro) { build(:dro).to_h }
+
+  context 'with a valid object' do
+    let(:json) { dro }
+
+    it 'reports no errors' do
+      expect(errors).to be_empty
+    end
+  end
+
+  context 'with several independent errors' do
+    let(:json) do
+      dro.tap do |props|
+        props[:description][:purl] = 'https://purl.stanford.edu/zz999zz9999'
+        props[:description][:contributor] = [{ name: [{ value: 'Anon' }], type: 'bogusType' }]
+        props[:description][:language] = [{ code: 'zzz', source: { code: 'iso639-2b' } }]
+        props[:description][:title] = [{ value: 'A title', type: 'alternative' }]
+      end
+    end
+
+    it 'reports all of them rather than stopping at the first' do
+      expect(errors).to include(
+        a_string_matching(/Purl mismatch/),
+        a_string_matching(/Unrecognized types in description/),
+        a_string_matching(/Unrecognized language codes in description/),
+        a_string_matching(/At least one title must have no type/)
+      )
+    end
+
+    it 'reports what Cocina::Models.build alone would not' do
+      build_error = begin
+        Cocina::Models.build(json)
+        nil
+      rescue Cocina::Models::ValidationError => e
+        e.message
+      end
+
+      expect(errors).to include(build_error)
+      expect(errors.length).to be > 1
+    end
+  end
+
+  # A top-level failure aborts construction, so Cocina::Models.build never validates the description.
+  context 'with both a top-level error and a description error' do
+    let(:json) do
+      dro.tap do |props|
+        props[:description][:purl] = 'https://purl.stanford.edu/zz999zz9999'
+        props[:description][:contributor] = [{ name: [{ value: 'Anon' }], type: 'bogusType' }]
+      end
+    end
+
+    it 'still validates the description' do
+      expect(errors).to include(a_string_matching(/Unrecognized types in description/))
+    end
+  end
+
+  # The composite validators walk the object once, then stop at the first sub-validator that raises.
+  context 'with two errors from sub-validators of the same composite validator' do
+    let(:json) do
+      dro.tap do |props|
+        props[:description][:contributor] = [{ name: [{ value: 'Anon' }], type: 'bogusType' }]
+        props[:description][:language] = [{ code: 'zzz', source: { code: 'iso639-2b' } }]
+      end
+    end
+
+    it 'reports both' do
+      expect(errors).to include(
+        a_string_matching(/Unrecognized types in description/),
+        a_string_matching(/Unrecognized language codes in description/)
+      )
+    end
+  end
+
+  context 'when the object does not conform to the schema' do
+    let(:json) { dro.merge(bogusKey: 1) }
+
+    it 'reports the schema error alone, without downstream noise' do
+      expect(errors).to eq(
+        ["When validating DRO: Unevaluated properties are not allowed ('bogusKey' was unexpected)"]
+      )
+    end
+  end
+
+  context 'when a nested value has the wrong shape' do
+    let(:json) { dro.merge(description: 'not an object') }
+
+    it 'does not report NoMethodErrors from validators run against unusable data' do
+      expect(errors).to eq(['When validating DRO: "not an object" is not of type "object" at /description'])
+    end
+  end
+
+  context 'with an unknown type' do
+    let(:json) { dro.merge(type: 'https://example.com/bogus') }
+
+    it 'reports the type as unknown' do
+      expect(errors).to eq(["Cocina::Models::UnknownTypeError: Unknown type: 'https://example.com/bogus'"])
+    end
+  end
+
+  context 'with no type' do
+    let(:json) { dro.except(:type) }
+
+    it 'reports the missing type' do
+      expect(errors).to eq(['Cocina::Models::ValidationError: Type field not found'])
+    end
+  end
+
+  # The collector duplicates the class dispatch in Cocina::Models.build, whose type_for and
+  # has_metadata? are private. This guards against the two drifting apart.
+  describe 'class resolution' do
+    {
+      dro: Cocina::Models::DRO::TYPES,
+      dro_with_metadata: Cocina::Models::DRO::TYPES,
+      collection: Cocina::Models::Collection::TYPES,
+      collection_with_metadata: Cocina::Models::Collection::TYPES,
+      admin_policy: Cocina::Models::AdminPolicy::TYPES,
+      admin_policy_with_metadata: Cocina::Models::AdminPolicy::TYPES
+    }.each do |factory, types|
+      it "resolves the same class the gem builds, for every #{factory} type" do
+        types.each do |type|
+          model = build(factory, type: type)
+
+          expect(described_class.new(model.to_h).send(:clazz)).to eq(model.class)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

See #1177 

This PR merges into the [README PR,](https://github.com/sul-dlss/cocina-models/pull/1178) since the tweaks some of the changes made to the README there.

Claude Code analyzed and suggested code (with some minor manual edits by me, and requested changes via prompts).

The `bin/validate-data` script currently stops at the first validation error that may be present in an object (after ensuring the JSON is valid) because of the way cocina-models currently handles validations.  This change is designed to pass through objects which fail validation into a separate helper method which collects the various invalid choices so they can be collected together in one pass (at the cost of efficiency).  Since this is only done for objects that are invalid, which is hopefully a relatively small number, the performance penalty should be acceptable.

## How was this change tested? 🤨

New spec
