### PR TITLE
Make validation error messages more user-friendly

### DIFF
--- a/lib/cocina/models/validators/description_date_time_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_date_time_visitor_validator.rb
@@ -35,7 +35,7 @@ module Cocina
           code = hash.dig(:encoding, :code)
           if code
             encoding_paths[path.dup] = code if VALIDATABLE_TYPES.include?(code)
-            invalid_encoding_codes << "#{path_to_s(path)}.encoding.code (#{code})" unless VALID_ENCODING_CODES.include?(code)
+            invalid_encoding_codes << { path: path_to_s(path), code: code } unless VALID_ENCODING_CODES.include?(code)
           end
 
           value = hash[:value]
@@ -97,7 +97,10 @@ module Cocina
         def invalid_encoding_codes_error
           return if invalid_encoding_codes.empty?
 
-          "Unrecognized date encoding codes in description: #{invalid_encoding_codes.join(', ')}"
+          invalid_encoding_codes.map do |entry|
+            "The date encoding code \"#{entry[:code]}\" is not recognized at #{entry[:path]}.encoding.code. " \
+              "Use one of: #{VALID_ENCODING_CODES.join(', ')}."
+          end.join(' ')
         end
 
         def invalid_dates_error

--- a/lib/cocina/models/validators/description_date_time_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_date_time_visitor_validator.rb
@@ -66,17 +66,7 @@ module Cocina
         end
 
         def validate!
-          errors = []
-
-          errors << "Unrecognized date encoding codes in description: #{invalid_encoding_codes.join(', ')}" if invalid_encoding_codes.any?
-
-          unless invalid_groups.empty?
-            invalid_dates = invalid_groups.filter_map do |path, values|
-              [*values, encoding_paths[path]] unless values.empty?
-            end
-            errors << "Invalid date(s) in description: #{invalid_dates}" if invalid_dates.any?
-          end
-
+          errors = [invalid_encoding_codes_error, invalid_dates_error].compact
           raise ValidationError, errors.join('; ') if errors.any?
         end
 
@@ -102,6 +92,33 @@ module Cocina
           encoding_paths
             .select { |prefix, _| path.first(prefix.length) == prefix }
             .max_by { |prefix, _| prefix.length }
+        end
+
+        def invalid_encoding_codes_error
+          return if invalid_encoding_codes.empty?
+
+          "Unrecognized date encoding codes in description: #{invalid_encoding_codes.join(', ')}"
+        end
+
+        def invalid_dates_error
+          invalid_messages = invalid_date_messages
+          return if invalid_messages.empty?
+
+          invalid_messages.join(' ')
+        end
+
+        def invalid_date_messages
+          invalid_groups.filter_map do |path, values|
+            invalid_date_message(path, values)
+          end
+        end
+
+        def invalid_date_message(path, values)
+          return if values.empty?
+
+          quoted_values = values.map { |value| %("#{value}") }.join(', ')
+          verb = values.length == 1 ? 'is' : 'are'
+          "The date(s) #{quoted_values} #{verb} invalid for the stated encoding of #{encoding_paths[path]}."
         end
 
         def valid_value?(value, code)

--- a/lib/cocina/models/validators/description_language_code_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_language_code_visitor_validator.rb
@@ -12,7 +12,8 @@ module Cocina
         def validate!
           return if error_paths.empty?
 
-          raise ValidationError, "Unrecognized language codes in description: #{error_paths.join(', ')}"
+          raise ValidationError,
+                error_paths.map { |entry| invalid_language_code_message(entry) }.join(' ')
         end
 
         def visit_hash(hash:, path:)
@@ -21,7 +22,7 @@ module Cocina
           code = hash[:code]
           return unless code
 
-          error_paths << "#{path_to_s(path)}.code (#{code})" unless valid_codes.include?(code)
+          error_paths << { path: path_to_s(path), code: code } unless valid_codes.include?(code)
         end
 
         private
@@ -32,6 +33,11 @@ module Cocina
 
         def language_path?(path)
           path.length >= 2 && path[-1].is_a?(Integer) && path[-2].to_s == 'language'
+        end
+
+        def invalid_language_code_message(entry)
+          "The language code \"#{entry[:code]}\" is not recognized at #{entry[:path]}.code. " \
+            'Use a valid code from searchworks_languages or one of: mul, und, zxx.'
         end
 
         # rubocop:disable Style/ClassVars

--- a/lib/cocina/models/validators/description_location_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_location_visitor_validator.rb
@@ -9,10 +9,8 @@ module Cocina
       # validates location.code against marc_country_codes.yml when source.code is marccountry.
       class DescriptionLocationVisitorValidator < BaseDescriptionVisitorValidator
         def validate!
-          errors = []
-          errors << "Unrecognized location source codes in description: #{error_paths.join(', ')}" if error_paths.any?
-          errors << "Invalid MARC country codes in description: #{marc_country_error_paths.join(', ')}" if marc_country_error_paths.any?
-          raise ValidationError, errors.join('; ') if errors.any?
+          errors = [invalid_source_codes_error, invalid_marc_country_codes_error].compact
+          raise ValidationError, errors.join(' ') if errors.any?
         end
 
         def visit_hash(hash:, path:)
@@ -21,12 +19,12 @@ module Cocina
           source_code = hash.dig(:source, :code)
           return unless source_code
 
-          error_paths << "#{path_to_s(path)}.source.code (#{source_code})" unless valid_codes.include?(source_code.downcase)
+          error_paths << { path: path_to_s(path), code: source_code } unless valid_codes.include?(source_code.downcase)
 
           return unless source_code.downcase == 'marccountry'
 
           code = hash[:code]
-          marc_country_error_paths << "#{path_to_s(path)}.code (#{code})" if code && !valid_marc_country_codes.include?(code.downcase)
+          marc_country_error_paths << { path: path_to_s(path), code: code } if code && !valid_marc_country_codes.include?(code.downcase)
         end
 
         private
@@ -37,6 +35,23 @@ module Cocina
 
         def marc_country_error_paths
           @marc_country_error_paths ||= []
+        end
+
+        def invalid_source_codes_error
+          return if error_paths.empty?
+
+          error_paths.map do |entry|
+            "The location source code \"#{entry[:code]}\" is not recognized at #{entry[:path]}.source.code."
+          end.join(' ')
+        end
+
+        def invalid_marc_country_codes_error
+          return if marc_country_error_paths.empty?
+
+          marc_country_error_paths.map do |entry|
+            "The location code \"#{entry[:code]}\" is invalid at #{entry[:path]}.code when source code is marccountry. " \
+              'Use a valid MARC country code.'
+          end.join(' ')
         end
 
         def location_path?(path)

--- a/lib/cocina/models/validators/description_subject_temporal_encoding_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_subject_temporal_encoding_visitor_validator.rb
@@ -9,7 +9,7 @@ module Cocina
         def validate!
           return if error_paths.empty?
 
-          raise ValidationError, "Unrecognized subject temporal encoding codes in description: #{error_paths.join(', ')}"
+          raise ValidationError, error_paths.map { |entry| invalid_temporal_encoding_message(entry) }.join(' ')
         end
 
         def visit_hash(hash:, path:)
@@ -19,7 +19,7 @@ module Cocina
           encoding_code = hash.dig(:encoding, :code)
           return unless encoding_code
 
-          error_paths << "#{path_to_s(path)}.encoding.code (#{encoding_code})" unless valid_codes.include?(encoding_code.downcase)
+          error_paths << { path: path_to_s(path), code: encoding_code } unless valid_codes.include?(encoding_code.downcase)
         end
 
         private
@@ -30,6 +30,11 @@ module Cocina
 
         def in_subject_path?(path)
           path.any? { |part| part.to_s == 'subject' }
+        end
+
+        def invalid_temporal_encoding_message(entry)
+          "The temporal subject encoding code \"#{entry[:code]}\" is not recognized at #{entry[:path]}.encoding.code. " \
+            'Use a valid temporal encoding code.'
         end
 
         # rubocop:disable Style/ClassVars

--- a/lib/cocina/models/validators/description_values_visitor_validator.rb
+++ b/lib/cocina/models/validators/description_values_visitor_validator.rb
@@ -15,16 +15,16 @@ module Cocina
         def validate!
           unless error_paths_multiple.empty?
             raise ValidationError,
-                  "Multiple value, groupedValue, structuredValue, and parallelValue in description: #{error_paths_multiple.join(', ')}"
+                  error_paths_multiple.map { |path| multiple_values_message(path) }.join(' ')
           end
           unless error_paths_blank.empty?
             raise ValidationError,
-                  "Blank value in description: #{error_paths_blank.join(', ')}"
+                  error_paths_blank.map { |path| blank_value_message(path) }.join(' ')
           end
           return if error_paths_missing_title_type.empty?
 
           raise ValidationError,
-                "Missing type for value in description: #{error_paths_missing_title_type.join(', ')}"
+                error_paths_missing_title_type.map { |path| missing_title_type_message(path) }.join(' ')
         end
 
         private
@@ -67,6 +67,18 @@ module Cocina
           # title is within relatedResource, e.g ["relatedResource", 0, "title", 0, "structuredValue", 0])
           structured_value_path = path[4] == 'structuredValue' || (path[4] == 'parallelValue' && path[6] == 'structuredValue')
           path.first == 'relatedResource' && path[2] == 'title' && structured_value_path
+        end
+
+        def multiple_values_message(path)
+          "Only one of value, groupedValue, structuredValue, or parallelValue may be present at #{path}."
+        end
+
+        def blank_value_message(path)
+          "The value at #{path} is blank. Provide non-blank text or remove the value."
+        end
+
+        def missing_title_type_message(path)
+          "A title structured value at #{path} has a value but no type. Add a type."
         end
 
         def structured_value_title?(path)

--- a/lib/cocina/models/validators/marc_relator_role_validator.rb
+++ b/lib/cocina/models/validators/marc_relator_role_validator.rb
@@ -25,7 +25,7 @@ module Cocina
           return unless meets_preconditions?
 
           resources.each { |resource| validate_resource(resource) }
-          raise ValidationError, "Invalid MARC relator codes in description: #{@errors.join(', ')}" if @errors.any?
+          raise ValidationError, @errors.join(' ') if @errors.any?
         end
 
         private
@@ -63,7 +63,10 @@ module Cocina
           code = role[:code]
           return if code.nil?
 
-          @errors << "#{path} (#{code})" unless valid_codes.include?(code)
+          return if valid_codes.include?(code)
+
+          @errors << "The MARC relator code \"#{code}\" is invalid for contributor role #{path}. " \
+                     'Use a valid MARC relator code.'
         end
 
         def marc_relator_source?(role)

--- a/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
@@ -296,7 +296,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
       end
 
       it 'raises with an informative message' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError, /Unrecognized date encoding codes/)
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          /The date encoding code "unknown" is not recognized .* Use one of: edtf, iso8601, marc, temper, w3cdtf\./
+        )
       end
     end
 
@@ -319,7 +322,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
       end
 
       it 'raises' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError, /Unrecognized date encoding codes/)
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          /The date encoding code "bad" is not recognized .* Use one of: edtf, iso8601, marc, temper, w3cdtf\./
+        )
       end
     end
 

--- a/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_date_time_visitor_validator_spec.rb
@@ -42,6 +42,32 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     end
   end
 
+  context 'when date is invalid for stated encoding' do
+    let(:props) do
+      {
+        event: [
+          {
+            date: [
+              {
+                value: 'c1900',
+                encoding: {
+                  code: 'w3cdtf'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'raises with a user-friendly message' do
+      expect { validate }.to raise_error(
+        Cocina::Models::ValidationError,
+        /The date\(s\) "c1900" is invalid for the stated encoding of w3cdtf\./
+      )
+    end
+  end
+
   context 'when dates of validatable type present' do
     [
       # Common cases
@@ -191,7 +217,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     it 'raises' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        /\["1996b", "1998a", "iso8601"\]/
+        /The date\(s\) "1996b", "1998a" are invalid for the stated encoding of iso8601\./
       )
     end
   end
@@ -234,7 +260,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     it 'raises' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        /\["1850z", "iso8601"\], \["1875y", "iso8601"\]/
+        /The date\(s\) "1850z" is invalid for the stated encoding of iso8601\..*The date\(s\) "1875y" is invalid for the stated encoding of iso8601\./
       )
     end
   end
@@ -345,7 +371,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionDateTimeVisitorValidator d
     it 'raises' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        /\["1803-05g", "iso8601"\], \["foo", "iso8601"\]/
+        /The date\(s\) "1803-05g" is invalid for the stated encoding of iso8601\..*The date\(s\) "foo" is invalid for the stated encoding of iso8601\./
       )
     end
   end

--- a/spec/cocina/models/validators/description_language_code_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_language_code_visitor_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLanguageCodeVisitorValidat
     it 'raises ValidationError' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized language codes in description: language1.code (ENG)'
+        'The language code "ENG" is not recognized at language1.code. Use a valid code from searchworks_languages or one of: mul, und, zxx.'
       )
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLanguageCodeVisitorValidat
     it 'raises ValidationError with path and code' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized language codes in description: language1.code (bogus)'
+        'The language code "bogus" is not recognized at language1.code. Use a valid code from searchworks_languages or one of: mul, und, zxx.'
       )
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLanguageCodeVisitorValidat
     it 'raises ValidationError listing all invalid codes' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized language codes in description: language2.code (bogus), language3.code (fake)'
+        'The language code "bogus" is not recognized at language2.code. Use a valid code from searchworks_languages or one of: mul, und, zxx. The language code "fake" is not recognized at language3.code. Use a valid code from searchworks_languages or one of: mul, und, zxx.'
       )
     end
   end

--- a/spec/cocina/models/validators/description_location_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_location_visitor_validator_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLocationVisitorValidator d
     it 'raises ValidationError with path and code' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized location source codes in description: location1.source.code (bogussource)'
+        'The location source code "bogussource" is not recognized at location1.source.code.'
       )
     end
   end
@@ -88,7 +88,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLocationVisitorValidator d
     it 'raises ValidationError with nested path' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized location source codes in description: relatedResource1.location1.source.code (invalidsource)'
+        'The location source code "invalidsource" is not recognized at relatedResource1.location1.source.code.'
       )
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLocationVisitorValidator d
     it 'raises ValidationError' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized location source codes in description: location1.source.code (invalid)'
+        'The location source code "invalid" is not recognized at location1.source.code.'
       )
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLocationVisitorValidator d
     it 'raises ValidationError with path and code' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Invalid MARC country codes in description: location1.code (zzz)'
+        'The location code "zzz" is invalid at location1.code when source code is marccountry. Use a valid MARC country code.'
       )
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionLocationVisitorValidator d
     it 'raises ValidationError with nested path' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Invalid MARC country codes in description: relatedResource1.location1.code (zz)'
+        'The location code "zz" is invalid at relatedResource1.location1.code when source code is marccountry. Use a valid MARC country code.'
       )
     end
   end

--- a/spec/cocina/models/validators/description_subject_temporal_encoding_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_subject_temporal_encoding_visitor_validator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionSubjectTemporalEncodingVis
     it 'raises ValidationError with path and code' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized subject temporal encoding codes in description: subject1.encoding.code (bogusenc)'
+        'The temporal subject encoding code "bogusenc" is not recognized at subject1.encoding.code. Use a valid temporal encoding code.'
       )
     end
   end
@@ -111,7 +111,7 @@ RSpec.describe Cocina::Models::Validators::DescriptionSubjectTemporalEncodingVis
     it 'raises ValidationError with nested path' do
       expect { validate }.to raise_error(
         Cocina::Models::ValidationError,
-        'Unrecognized subject temporal encoding codes in description: subject1.structuredValue1.encoding.code (bogusenc)'
+        'The temporal subject encoding code "bogusenc" is not recognized at subject1.structuredValue1.encoding.code. Use a valid temporal encoding code.'
       )
     end
   end

--- a/spec/cocina/models/validators/description_values_visitor_validator_spec.rb
+++ b/spec/cocina/models/validators/description_values_visitor_validator_spec.rb
@@ -178,7 +178,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Multiple value, groupedValue, structuredValue, and parallelValue in description: title1, relatedResource1.title1')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'Only one of value, groupedValue, structuredValue, or parallelValue may be present at title1. Only one of value, groupedValue, structuredValue, or parallelValue may be present at relatedResource1.title1.'
+        )
       end
     end
 
@@ -188,7 +191,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Blank value in description: title1')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'The value at title1 is blank. Provide non-blank text or remove the value.'
+        )
       end
     end
 
@@ -198,7 +204,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.structuredValue1')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'A title structured value at title1.structuredValue1 has a value but no type. Add a type.'
+        )
       end
     end
 
@@ -208,7 +217,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.structuredValue2')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'A title structured value at title1.structuredValue2 has a value but no type. Add a type.'
+        )
       end
     end
 
@@ -218,7 +230,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: relatedResource1.title1.structuredValue1')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'A title structured value at relatedResource1.title1.structuredValue1 has a value but no type. Add a type.'
+        )
       end
     end
 
@@ -228,7 +243,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: relatedResource1.title1.parallelValue1.structuredValue2')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'A title structured value at relatedResource1.title1.parallelValue1.structuredValue2 has a value but no type. Add a type.'
+        )
       end
     end
 
@@ -238,7 +256,10 @@ RSpec.describe Cocina::Models::Validators::DescriptionValuesVisitorValidator do
       it 'is not valid' do
         expect do
           validate
-        end.to raise_error(Cocina::Models::ValidationError, 'Missing type for value in description: title1.parallelValue1.structuredValue2')
+        end.to raise_error(
+          Cocina::Models::ValidationError,
+          'A title structured value at title1.parallelValue1.structuredValue2 has a value but no type. Add a type.'
+        )
       end
     end
   end

--- a/spec/cocina/models/validators/marc_relator_role_validator_spec.rb
+++ b/spec/cocina/models/validators/marc_relator_role_validator_spec.rb
@@ -120,8 +120,10 @@ RSpec.describe Cocina::Models::Validators::MarcRelatorRoleValidator do
       end
 
       it 'raises a ValidationError' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError,
-                                           /contributor1\.role1 \(xyz\)/)
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          'The MARC relator code "xyz" is invalid for contributor role contributor1.role1. Use a valid MARC relator code.'
+        )
       end
     end
 
@@ -181,8 +183,10 @@ RSpec.describe Cocina::Models::Validators::MarcRelatorRoleValidator do
       end
 
       it 'raises a ValidationError naming the specific path' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError,
-                                           /contributor2\.role1 \(xyz\)/)
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          'The MARC relator code "xyz" is invalid for contributor role contributor2.role1. Use a valid MARC relator code.'
+        )
       end
     end
 
@@ -205,8 +209,10 @@ RSpec.describe Cocina::Models::Validators::MarcRelatorRoleValidator do
       end
 
       it 'raises a ValidationError' do
-        expect { validate }.to raise_error(Cocina::Models::ValidationError,
-                                           /contributor1\.role1 \(xyz\)/)
+        expect { validate }.to raise_error(
+          Cocina::Models::ValidationError,
+          'The MARC relator code "xyz" is invalid for contributor role contributor1.role1. Use a valid MARC relator code.'
+        )
       end
     end
 


### PR DESCRIPTION
# Why was this change made?

Fixes #1164

(With assistance from @eca-agent & the 5.3 Codex model)

- **Improve date encoding validation error messages**
- **Clarify invalid date encoding code guidance.**
- **Clarify location validation error guidance.**
- **Clarify language code validation error guidance.**
- **Clarify temporal subject encoding validation errors.**
- **Clarify MARC relator validation error guidance.**
- **Clarify description values validation error guidance.**

# How was this change tested?

CI
